### PR TITLE
feat: auth 및 mypage 프로필 서비스 구조 구성 및 백엔드 연동

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,5 @@ GEMINI_API_KEY="MY_GEMINI_API_KEY"
 # AI Studio automatically injects this at runtime with the Cloud Run service URL.
 # Used for self-referential links, OAuth callbacks, and API endpoints.
 APP_URL="MY_APP_URL"
+# Backend API base URL used by Next.js rewrites.
+NEXT_PUBLIC_API_BASE_URL="http://localhost:8080"

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,20 @@
 /** @type {import('next').NextConfig} */
+const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8080";
+
 const nextConfig = {
   reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${apiBaseUrl}/api/:path*`,
+      },
+      {
+        source: "/profile/images/:path*",
+        destination: `${apiBaseUrl}/profile/images/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/(auth)/login/index.tsx
+++ b/src/app/(auth)/login/index.tsx
@@ -1,42 +1,51 @@
 "use client";
-import React, { useState, useEffect } from 'react';
-import { 
-  ChevronLeft, 
-  Check, 
-  ChevronRight, 
-  User, 
-  Camera, 
-  Search, 
-  Home, 
-  PlusCircle, 
-  MessageCircle, 
-  Heart, 
-  Bell, 
-  Filter, 
-  Settings,
-  MoreVertical, 
-  Send, 
-  Star,
-  Clock,
-  ArrowUpRight,
-  X,
-  Trash2,
-  Eye,
-  Image as ImageIcon,
-  ArrowLeft,
-  TrendingUp,
-  Sparkles,
-  Menu,
-  ShoppingBag,
-  Store,
-  Receipt
-} from 'lucide-react';
-import { motion, AnimatePresence } from 'motion/react';
 
-import { Screen, Tab } from '../../../types/index';
-import { ExploreIcon } from '../../../components/common/ExploreIcon';
+import { useState } from "react";
+import { motion } from "motion/react";
 
-export default function LoginScreen({ showToast, onNavigateSignup, onNavigateFindId, onNavigateFindPassword, onLogin }: { showToast: (msg: string) => void; onNavigateSignup: () => void; onNavigateFindId: () => void; onNavigateFindPassword: () => void; onLogin: () => void; key?: string }) {
+import { getErrorMessage } from "@/services/apiError";
+import {
+  createDefaultLoginForm,
+  isLoginFormValid,
+  login,
+} from "@/services/auth/service";
+
+export default function LoginScreen({
+  showToast,
+  onNavigateSignup,
+  onNavigateFindId,
+  onNavigateFindPassword,
+  onLogin,
+}: {
+  showToast: (msg: string) => void;
+  onNavigateSignup: () => void;
+  onNavigateFindId: () => void;
+  onNavigateFindPassword: () => void;
+  onLogin: () => void;
+  key?: string;
+}) {
+  const [formData, setFormData] = useState(createDefaultLoginForm);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isFormValid = isLoginFormValid(formData);
+
+  const handleLogin = async () => {
+    if (!isFormValid || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const result = await login(formData);
+      showToast(result.message);
+      onLogin();
+    } catch (error) {
+      showToast(getErrorMessage(error, "로그인에 실패했습니다. 아이디와 비밀번호를 확인해주세요."));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
     <motion.div
       initial={{ opacity: 0, x: -20 }}
@@ -45,9 +54,9 @@ export default function LoginScreen({ showToast, onNavigateSignup, onNavigateFin
       className="flex-1 flex flex-col px-8 pt-32 pb-10"
     >
       <div className="flex justify-center mb-20">
-        <img 
-          src="https://i.ibb.co/FLydFL1L/2026-03-22-201249.png" 
-          alt="Deal it Logo" 
+        <img
+          src="https://i.ibb.co/FLydFL1L/2026-03-22-201249.png"
+          alt="Deal it Logo"
           className="h-24 object-contain"
           referrerPolicy="no-referrer"
         />
@@ -56,28 +65,47 @@ export default function LoginScreen({ showToast, onNavigateSignup, onNavigateFin
       <div className="flex-1 flex flex-col justify-center space-y-4">
         <input
           type="text"
+          value={formData.loginId}
+          onChange={(event) =>
+            setFormData({ ...formData, loginId: event.target.value })
+          }
           placeholder="아이디"
           className="w-full h-14 bg-gray-100 rounded-xl px-5 outline-none focus:ring-2 focus:ring-[#98E446] transition-all"
         />
         <input
           type="password"
+          value={formData.password}
+          onChange={(event) =>
+            setFormData({ ...formData, password: event.target.value })
+          }
           placeholder="비밀번호"
           className="w-full h-14 bg-gray-100 rounded-xl px-5 outline-none focus:ring-2 focus:ring-[#98E446] transition-all"
         />
-        
-        <button 
-          onClick={onLogin}
-          className="w-full h-14 bg-[#98E446] hover:bg-[#87d335] text-black font-bold rounded-xl mt-2 transition-colors"
+
+        <button
+          onClick={handleLogin}
+          disabled={!isFormValid || isSubmitting}
+          className={`w-full h-14 font-bold rounded-xl mt-2 transition-colors ${
+            isFormValid && !isSubmitting
+              ? "bg-[#98E446] hover:bg-[#87d335] text-black"
+              : "bg-gray-200 text-gray-400 cursor-not-allowed"
+          }`}
         >
-          로그인
+          {isSubmitting ? "로그인 중" : "로그인"}
         </button>
 
         <div className="flex justify-center items-center space-x-4 text-sm text-gray-500 mt-2">
-          <button onClick={onNavigateFindId} className="hover:text-black">아이디 찾기</button>
+          <button onClick={onNavigateFindId} className="hover:text-black">
+            아이디 찾기
+          </button>
           <span className="w-px h-3 bg-gray-300"></span>
-          <button onClick={onNavigateFindPassword} className="hover:text-black">비밀번호 찾기</button>
+          <button onClick={onNavigateFindPassword} className="hover:text-black">
+            비밀번호 찾기
+          </button>
           <span className="w-px h-3 bg-gray-300"></span>
-          <button onClick={onNavigateSignup} className="hover:text-black">회원가입</button>
+          <button onClick={onNavigateSignup} className="hover:text-black">
+            회원가입
+          </button>
         </div>
       </div>
 
@@ -88,13 +116,22 @@ export default function LoginScreen({ showToast, onNavigateSignup, onNavigateFin
           <div className="flex-1 h-px bg-gray-200"></div>
         </div>
 
-        <button onClick={() => showToast('카카오 로그인')} className="w-full h-14 bg-[#FEE500] hover:bg-[#fada0a] text-black font-bold rounded-xl flex items-center justify-center transition-colors">
+        <button
+          onClick={() => showToast("카카오 로그인")}
+          className="w-full h-14 bg-[#FEE500] hover:bg-[#fada0a] text-black font-bold rounded-xl flex items-center justify-center transition-colors"
+        >
           카카오 로그인
         </button>
-        <button onClick={() => showToast('네이버 로그인')} className="w-full h-14 bg-[#03C75A] hover:bg-[#02b351] text-white font-bold rounded-xl flex items-center justify-center transition-colors">
+        <button
+          onClick={() => showToast("네이버 로그인")}
+          className="w-full h-14 bg-[#03C75A] hover:bg-[#02b351] text-white font-bold rounded-xl flex items-center justify-center transition-colors"
+        >
           네이버 로그인
         </button>
-        <button onClick={() => showToast('구글 로그인')} className="w-full h-14 bg-white border border-gray-200 hover:bg-gray-50 text-black font-medium rounded-xl flex items-center justify-center transition-colors">
+        <button
+          onClick={() => showToast("구글 로그인")}
+          className="w-full h-14 bg-white border border-gray-200 hover:bg-gray-50 text-black font-medium rounded-xl flex items-center justify-center transition-colors"
+        >
           구글로 시작하기
         </button>
       </div>

--- a/src/app/(auth)/profile-setup/index.tsx
+++ b/src/app/(auth)/profile-setup/index.tsx
@@ -1,117 +1,260 @@
 "use client";
-import React, { useState, useEffect } from 'react';
-import { 
-  ChevronLeft, 
-  Check, 
-  ChevronRight, 
-  User, 
-  Camera, 
-  Search, 
-  Home, 
-  PlusCircle, 
-  MessageCircle, 
-  Heart, 
-  Bell, 
-  Filter, 
-  Settings,
-  MoreVertical, 
-  Send, 
-  Star,
-  Clock,
-  ArrowUpRight,
-  X,
-  Trash2,
-  Eye,
-  Image as ImageIcon,
-  ArrowLeft,
-  TrendingUp,
-  Sparkles,
-  Menu,
-  ShoppingBag,
-  Store,
-  Receipt
-} from 'lucide-react';
-import { motion, AnimatePresence } from 'motion/react';
 
-import { Screen, Tab } from '../../../types/index';
-import { ExploreIcon } from '../../../components/common/ExploreIcon';
+import { ChangeEvent, useEffect, useRef, useState } from "react";
+import { Camera, ChevronLeft } from "lucide-react";
+import { motion } from "motion/react";
 
-export default function ProfileSetupScreen({ showToast, onBack, onComplete }: { showToast: (msg: string) => void; onBack: () => void; onComplete: () => void; key?: string }) {
-  const [nickname, setNickname] = useState('비드마스터');
-  const [bio, setBio] = useState('안녕하세요! 비드마스터입니다. 좋은 거래 부탁드려요.');
+import { getErrorMessage } from "@/services/apiError";
+import ResultModal from "@/components/common/modal/ResultModal";
+import { checkNicknameAvailability } from "@/services/auth/service";
+import { saveMyProfile, uploadMyProfileImage } from "@/services/mypage/service";
+
+type CheckStatus = "idle" | "available" | "duplicate";
+
+export default function ProfileSetupScreen({
+  showToast,
+  onBack,
+  onComplete,
+}: {
+  showToast: (msg: string) => void;
+  onBack: () => void;
+  onComplete: () => void;
+  key?: string;
+}) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const imagePreviewUrlRef = useRef<string | null>(null);
+  const [nickname, setNickname] = useState("비드마스터");
+  const [bio, setBio] = useState("안녕하세요! 비드마스터입니다. 좋은 거래 부탁드려요.");
+  const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
+  const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null);
+  const [nicknameCheckStatus, setNicknameCheckStatus] =
+    useState<CheckStatus>("idle");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
+  const [resultModal, setResultModal] = useState({
+    isOpen: false,
+    title: "",
+    message: "",
+  });
 
   const isFormValid = nickname.trim().length >= 2;
+  const canSubmit = isFormValid && nicknameCheckStatus === "available";
+
+  const openResultModal = (title: string, message: string) => {
+    setResultModal({ isOpen: true, title, message });
+  };
+
+  useEffect(() => {
+    return () => {
+      if (imagePreviewUrlRef.current) {
+        URL.revokeObjectURL(imagePreviewUrlRef.current);
+      }
+    };
+  }, []);
+
+  const updateImagePreviewUrl = (nextPreviewUrl: string | null) => {
+    if (imagePreviewUrlRef.current) {
+      URL.revokeObjectURL(imagePreviewUrlRef.current);
+    }
+
+    imagePreviewUrlRef.current = nextPreviewUrl;
+    setImagePreviewUrl(nextPreviewUrl);
+  };
+
+  const handleNicknameCheck = async () => {
+    if (!nickname.trim()) {
+      openResultModal("닉네임 확인", "닉네임을 입력해주세요.");
+      return;
+    }
+
+    try {
+      const result = await checkNicknameAvailability(nickname);
+      setNicknameCheckStatus(result.available ? "available" : "duplicate");
+      openResultModal(
+        "닉네임 중복 확인",
+        result.available
+          ? "사용 가능한 닉네임입니다."
+          : "중복된 닉네임입니다.",
+      );
+    } catch (error) {
+      setNicknameCheckStatus("idle");
+      openResultModal("닉네임 중복 확인", getErrorMessage(error, "닉네임 중복 확인에 실패했습니다."));
+    }
+  };
+
+  const handleImageButtonClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleImageChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    setIsUploadingImage(true);
+    updateImagePreviewUrl(URL.createObjectURL(file));
+
+    try {
+      const uploadedImage = await uploadMyProfileImage(file);
+      setProfileImageUrl(uploadedImage.profileImageUrl);
+    } catch (error) {
+      updateImagePreviewUrl(null);
+      openResultModal("이미지 업로드 실패", getErrorMessage(error, "프로필 이미지 업로드에 실패했습니다."));
+    } finally {
+      setIsUploadingImage(false);
+      event.target.value = "";
+    }
+  };
+
+  const handleComplete = async () => {
+    if (!canSubmit || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await saveMyProfile({
+        nickname,
+        bio,
+        profileImageUrl,
+        location: "",
+      });
+      showToast("프로필 설정이 저장되었습니다.");
+      onComplete();
+    } catch (error) {
+      openResultModal("프로필 저장 실패", getErrorMessage(error, "프로필 설정 저장에 실패했습니다."));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
-    <motion.div
-      initial={{ opacity: 0, x: 20 }}
-      animate={{ opacity: 1, x: 0 }}
-      exit={{ opacity: 0, x: -20 }}
-      className="flex-1 flex flex-col"
-    >
-      <div className="h-16 flex items-center px-4 border-b border-gray-100">
-        <button onClick={onBack} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
-          <ChevronLeft size={24} />
-        </button>
-        <h1 className="flex-1 text-center font-bold text-lg mr-10">프로필 설정</h1>
-      </div>
+    <>
+      <motion.div
+        initial={{ opacity: 0, x: 20 }}
+        animate={{ opacity: 1, x: 0 }}
+        exit={{ opacity: 0, x: -20 }}
+        className="flex-1 flex flex-col"
+      >
+        <div className="h-16 flex items-center px-4 border-b border-gray-100">
+          <button onClick={onBack} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+            <ChevronLeft size={24} />
+          </button>
+          <h1 className="flex-1 text-center font-bold text-lg mr-10">프로필 설정</h1>
+        </div>
 
-      <div className="flex-1 px-8 py-10 space-y-10">
-        <div className="flex flex-col items-center space-y-4">
-          <div className="relative">
-            <div className="w-32 h-32 bg-gray-100 rounded-full flex items-center justify-center overflow-hidden border border-gray-200">
-              <img src="https://picsum.photos/seed/me/200/200" alt="Profile" className="w-full h-full object-cover" />
-            </div>
-            <button className="absolute bottom-0 right-0 w-10 h-10 bg-[#98E446] rounded-full flex items-center justify-center border-4 border-white shadow-sm">
-              <Camera size={20} className="text-black" />
+        <div className="flex-1 px-8 py-10 space-y-10">
+          <div className="flex flex-col items-center space-y-4">
+            <button
+              type="button"
+              onClick={handleImageButtonClick}
+              disabled={isUploadingImage}
+              className="relative group disabled:cursor-wait"
+              aria-label="프로필 사진 수정"
+            >
+              <div className="w-32 h-32 bg-gray-100 rounded-full flex items-center justify-center overflow-hidden border border-gray-200 group-hover:opacity-90 transition-opacity">
+                {imagePreviewUrl || profileImageUrl ? (
+                  <img
+                    src={imagePreviewUrl || profileImageUrl || ""}
+                    alt="Profile"
+                    className="w-full h-full object-cover"
+                    onError={() => {
+                      if (imagePreviewUrl) {
+                        updateImagePreviewUrl(null);
+                        return;
+                      }
+
+                      setProfileImageUrl(null);
+                    }}
+                  />
+                ) : (
+                  <Camera size={36} className="text-gray-300" />
+                )}
+              </div>
+              <span className="absolute bottom-0 right-0 w-10 h-10 bg-[#98E446] rounded-full flex items-center justify-center border-4 border-white shadow-sm">
+                <Camera size={20} className="text-black" />
+              </span>
             </button>
+            <button
+              type="button"
+              onClick={handleImageButtonClick}
+              disabled={isUploadingImage}
+              className="text-sm font-medium text-gray-400 hover:text-gray-600 transition-colors disabled:cursor-wait"
+            >
+              {isUploadingImage ? "업로드 중" : "프로필 사진 수정"}
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              onChange={handleImageChange}
+              className="sr-only"
+            />
           </div>
-          <span className="text-sm font-medium text-gray-400">프로필 사진 수정</span>
-        </div>
 
-        <div className="space-y-6">
-          <div className="space-y-2">
-            <label className="text-sm font-bold">닉네임</label>
-            <div className="flex space-x-2 w-full">
-              <input
-                type="text"
-                value={nickname}
-                onChange={(e) => setNickname(e.target.value)}
-                placeholder="닉네임 입력 (2-10자)"
-                className="flex-1 min-w-0 h-12 bg-gray-100 rounded-lg px-4 outline-none focus:ring-2 focus:ring-[#98E446]"
-              />
-              <button onClick={() => showToast('중복 확인')} className="whitespace-nowrap px-4 h-12 border border-gray-200 rounded-lg text-sm font-medium hover:bg-gray-50 shrink-0">
-                중복확인
-              </button>
+          <div className="space-y-6">
+            <div className="space-y-2">
+              <label className="text-sm font-bold">닉네임</label>
+              <div className="flex space-x-2 w-full">
+                <input
+                  type="text"
+                  value={nickname}
+                  onChange={(event) => {
+                    setNickname(event.target.value);
+                    setNicknameCheckStatus("idle");
+                  }}
+                  placeholder="닉네임 입력 (2-10자)"
+                  className="flex-1 min-w-0 h-12 bg-gray-100 rounded-lg px-4 outline-none focus:ring-2 focus:ring-[#98E446]"
+                />
+                <button onClick={handleNicknameCheck} className="whitespace-nowrap px-4 h-12 border border-gray-200 rounded-lg text-sm font-medium hover:bg-gray-50 shrink-0">
+                  중복확인
+                </button>
+              </div>
+              {nicknameCheckStatus === "available" && (
+                <p className="text-[10px] text-green-600">사용 가능한 닉네임입니다.</p>
+              )}
+              {nicknameCheckStatus === "duplicate" && (
+                <p className="text-[10px] text-red-500">중복된 닉네임입니다.</p>
+              )}
+              <p className="text-xs text-gray-400">다른 사람에게 보여질 이름이에요</p>
             </div>
-            <p className="text-xs text-gray-400">다른 사람에게 보여질 이름이에요</p>
-          </div>
 
-          <div className="space-y-2">
-            <label className="text-sm font-bold">소개</label>
-            <textarea
-              value={bio}
-              onChange={(e) => setBio(e.target.value)}
-              placeholder="자기소개를 입력해주세요 (선택)"
-              className="w-full h-32 bg-gray-100 rounded-lg p-4 outline-none focus:ring-2 focus:ring-[#98E446] resize-none"
-            ></textarea>
+            <div className="space-y-2">
+              <label className="text-sm font-bold">소개</label>
+              <textarea
+                value={bio}
+                onChange={(event) => setBio(event.target.value)}
+                placeholder="자기소개를 입력해주세요 (선택)"
+                className="w-full h-32 bg-gray-100 rounded-lg p-4 outline-none focus:ring-2 focus:ring-[#98E446] resize-none"
+              ></textarea>
+            </div>
           </div>
         </div>
-      </div>
 
-      <div className="p-6">
-        <button 
-          onClick={onComplete}
-          disabled={!isFormValid}
-          className={`w-full h-14 font-bold rounded-xl transition-colors ${
-            isFormValid 
-              ? 'bg-[#98E446] hover:bg-[#87d335] text-black' 
-              : 'bg-gray-200 text-gray-400 cursor-not-allowed'
-          }`}
-        >
-          완료
-        </button>
-      </div>
-    </motion.div>
+        <div className="p-6">
+          <button
+            onClick={handleComplete}
+            disabled={!canSubmit || isSubmitting || isUploadingImage}
+            className={`w-full h-14 font-bold rounded-xl transition-colors ${
+              canSubmit && !isSubmitting && !isUploadingImage
+                ? "bg-[#98E446] hover:bg-[#87d335] text-black"
+                : "bg-gray-200 text-gray-400 cursor-not-allowed"
+            }`}
+          >
+            {isSubmitting ? "저장 중" : "완료"}
+          </button>
+        </div>
+      </motion.div>
+
+      <ResultModal
+        isOpen={resultModal.isOpen}
+        title={resultModal.title}
+        message={resultModal.message}
+        onClose={() => setResultModal({ ...resultModal, isOpen: false })}
+      />
+    </>
   );
 }

--- a/src/app/(auth)/region-setup/index.tsx
+++ b/src/app/(auth)/region-setup/index.tsx
@@ -36,7 +36,20 @@ import { motion, AnimatePresence } from 'motion/react';
 import { Screen, Tab } from '../../../types/index';
 import { ExploreIcon } from '../../../components/common/ExploreIcon';
 
-export default function RegionSetupScreen({ onBack, onNext, onFindLocation, currentLocation }: { onBack: () => void; onNext: () => void; onFindLocation: () => void; currentLocation?: string; key?: string }) {
+export default function RegionSetupScreen({
+  onBack,
+  onNext,
+  onFindLocation,
+  currentLocation,
+  onLocationChange,
+}: {
+  onBack: () => void;
+  onNext: () => void;
+  onFindLocation: () => void;
+  currentLocation?: string;
+  onLocationChange?: (location: string) => void;
+  key?: string;
+}) {
   return (
     <motion.div
       initial={{ opacity: 0, x: 20 }}
@@ -83,6 +96,8 @@ export default function RegionSetupScreen({ onBack, onNext, onFindLocation, curr
         <div className="w-full relative">
           <input
             type="text"
+            value={currentLocation || ""}
+            onChange={(event) => onLocationChange?.(event.target.value)}
             placeholder="동네 이름으로 탐색 (ex. 역삼동)"
             className="w-full h-12 bg-gray-100 rounded-lg px-4 outline-none focus:ring-2 focus:ring-[#98E446]"
           />
@@ -99,7 +114,7 @@ export default function RegionSetupScreen({ onBack, onNext, onFindLocation, curr
               : 'bg-gray-200 text-gray-400 cursor-not-allowed'
           }`}
         >
-          {currentLocation ? '수정 완료' : '다음'}
+          {currentLocation ? '확인' : '다음'}
         </button>
       </div>
     </motion.div>

--- a/src/app/(auth)/region-setup/page.tsx
+++ b/src/app/(auth)/region-setup/page.tsx
@@ -1,18 +1,21 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 import RegionSetupScreen from "./index";
 
 export default function RegionSetupPage() {
   const router = useRouter();
+  const [location, setLocation] = useState("");
 
   return (
     <RegionSetupScreen
       onBack={() => router.back()}
       onNext={() => router.push("/category-selection")}
       onFindLocation={() => router.push("/find-location")}
-      currentLocation="서울특별시 강남구 역삼동"
+      currentLocation={location}
+      onLocationChange={setLocation}
     />
   );
 }

--- a/src/app/(auth)/signup/index.tsx
+++ b/src/app/(auth)/signup/index.tsx
@@ -1,7 +1,21 @@
 "use client";
-import React, { useState } from 'react';
-import { ChevronLeft } from 'lucide-react';
-import { motion } from 'motion/react';
+
+import { useState } from "react";
+import { ChevronLeft } from "lucide-react";
+import { motion } from "motion/react";
+
+import { getErrorMessage } from "@/services/apiError";
+import ResultModal from "@/components/common/modal/ResultModal";
+import {
+  checkLoginIdAvailability,
+  createDefaultSignUpForm,
+  isEmailValid,
+  isPasswordValid,
+  isSignUpFormValid,
+  signUp,
+} from "@/services/auth/service";
+
+type CheckStatus = "idle" | "available" | "duplicate";
 
 export default function SignupScreen({
   showToast,
@@ -13,112 +27,177 @@ export default function SignupScreen({
   onNext: () => void;
   key?: string;
 }) {
-  const [formData, setFormData] = useState({
-    userId: '',
-    password: '',
-    confirmPassword: '',
-    email: '',
+  const [formData, setFormData] = useState(createDefaultSignUpForm);
+  const [loginIdCheckStatus, setLoginIdCheckStatus] =
+    useState<CheckStatus>("idle");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [resultModal, setResultModal] = useState({
+    isOpen: false,
+    title: "",
+    message: "",
   });
 
-  const isEmailValid = (email: string) => {
-    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+  const isFormValid = isSignUpFormValid(formData);
+  const canSubmit = isFormValid && loginIdCheckStatus === "available";
+
+  const openResultModal = (title: string, message: string) => {
+    setResultModal({ isOpen: true, title, message });
   };
 
-  const isPasswordValid = (password: string) => {
-    return password.length >= 8;
+  const handleLoginIdCheck = async () => {
+    if (!formData.loginId.trim()) {
+      openResultModal("아이디 확인", "아이디를 입력해주세요.");
+      return;
+    }
+
+    try {
+      const result = await checkLoginIdAvailability(formData.loginId);
+      setLoginIdCheckStatus(result.available ? "available" : "duplicate");
+      openResultModal(
+        "아이디 중복 확인",
+        result.available
+          ? "사용 가능한 아이디입니다."
+          : "중복된 아이디입니다.",
+      );
+    } catch (error) {
+      setLoginIdCheckStatus("idle");
+      openResultModal("아이디 중복 확인", getErrorMessage(error, "아이디 중복 확인에 실패했습니다."));
+    }
   };
 
-  const isFormValid =
-    formData.userId.trim() !== '' &&
-    isPasswordValid(formData.password) &&
-    formData.password === formData.confirmPassword &&
-    isEmailValid(formData.email);
+  const handleNext = async () => {
+    if (!canSubmit || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const result = await signUp(formData);
+      showToast(result.message);
+      onNext();
+    } catch (error) {
+      openResultModal("회원가입 실패", getErrorMessage(error, "회원가입에 실패했습니다. 입력값을 다시 확인해주세요."));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
-    <motion.div
-      initial={{ opacity: 0, x: 20 }}
-      animate={{ opacity: 1, x: 0 }}
-      exit={{ opacity: 0, x: -20 }}
-      className="flex-1 flex flex-col"
-    >
-      <div className="h-16 flex items-center px-4 border-b border-gray-100">
-        <button onClick={onBack} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
-          <ChevronLeft size={24} />
-        </button>
-        <h1 className="flex-1 text-center font-bold text-lg mr-10">회원가입</h1>
-      </div>
+    <>
+      <motion.div
+        initial={{ opacity: 0, x: 20 }}
+        animate={{ opacity: 1, x: 0 }}
+        exit={{ opacity: 0, x: -20 }}
+        className="flex-1 flex flex-col"
+      >
+        <div className="h-16 flex items-center px-4 border-b border-gray-100">
+          <button onClick={onBack} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+            <ChevronLeft size={24} />
+          </button>
+          <h1 className="flex-1 text-center font-bold text-lg mr-10">회원가입</h1>
+        </div>
 
-      <div className="flex-1 overflow-y-auto no-scrollbar px-8 py-6 space-y-6">
-        <div className="space-y-2">
-          <label className="text-sm font-bold">아이디</label>
-          <div className="flex space-x-2 w-full">
+        <div className="flex-1 overflow-y-auto no-scrollbar px-8 py-6 space-y-6">
+          <div className="space-y-2">
+            <label className="text-sm font-bold">아이디</label>
+            <div className="flex space-x-2 w-full">
+              <input
+                type="text"
+                value={formData.loginId}
+                onChange={(event) => {
+                  setFormData({ ...formData, loginId: event.target.value });
+                  setLoginIdCheckStatus("idle");
+                }}
+                placeholder="아이디 입력"
+                className="flex-1 min-w-0 h-12 bg-gray-100 rounded-lg px-4 outline-none focus:ring-2 focus:ring-[#98E446]"
+              />
+              <button
+                onClick={handleLoginIdCheck}
+                className="whitespace-nowrap px-4 h-12 border border-gray-200 rounded-lg text-sm font-medium hover:bg-gray-50 shrink-0"
+              >
+                중복확인
+              </button>
+            </div>
+            {loginIdCheckStatus === "available" && (
+              <p className="text-[10px] text-green-600">사용 가능한 아이디입니다.</p>
+            )}
+            {loginIdCheckStatus === "duplicate" && (
+              <p className="text-[10px] text-red-500">중복된 아이디입니다.</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-bold">비밀번호</label>
             <input
-              type="text"
-              value={formData.userId}
-              onChange={(e) => setFormData({ ...formData, userId: e.target.value })}
-              placeholder="아이디 입력"
-              className="flex-1 min-w-0 h-12 bg-gray-100 rounded-lg px-4 outline-none focus:ring-2 focus:ring-[#98E446]"
+              type="password"
+              value={formData.password}
+              onChange={(event) =>
+                setFormData({ ...formData, password: event.target.value })
+              }
+              placeholder="8자 이상 입력"
+              className="w-full h-12 bg-gray-100 rounded-lg px-4 outline-none focus:ring-2 focus:ring-[#98E446]"
             />
-            <button
-              onClick={() => showToast('중복 확인')}
-              className="whitespace-nowrap px-4 h-12 border border-gray-200 rounded-lg text-sm font-medium hover:bg-gray-50 shrink-0"
-            >
-              중복확인
-            </button>
+            <p className="text-[10px] text-gray-400">영문, 숫자, 특수문자 조합</p>
+            {formData.password && !isPasswordValid(formData.password) && (
+              <p className="text-[10px] text-red-500">비밀번호는 8자 이상 30자 이하여야 합니다.</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-bold">비밀번호 확인</label>
+            <input
+              type="password"
+              value={formData.confirmPassword}
+              onChange={(event) =>
+                setFormData({ ...formData, confirmPassword: event.target.value })
+              }
+              placeholder="비밀번호 재입력"
+              className="w-full h-12 bg-gray-100 rounded-lg px-4 outline-none focus:ring-2 focus:ring-[#98E446]"
+            />
+            {formData.confirmPassword && formData.password !== formData.confirmPassword && (
+              <p className="text-[10px] text-red-500">비밀번호가 일치하지 않습니다.</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-bold">이메일</label>
+            <input
+              type="email"
+              value={formData.email}
+              onChange={(event) =>
+                setFormData({ ...formData, email: event.target.value })
+              }
+              placeholder="example@email.com"
+              className="w-full h-12 bg-gray-100 rounded-lg px-4 outline-none focus:ring-2 focus:ring-[#98E446]"
+            />
+            {formData.email && !isEmailValid(formData.email) && (
+              <p className="text-[10px] text-red-500">올바른 이메일 형식으로 입력해주세요.</p>
+            )}
           </div>
         </div>
 
-        <div className="space-y-2">
-          <label className="text-sm font-bold">비밀번호</label>
-          <input
-            type="password"
-            value={formData.password}
-            onChange={(e) => setFormData({ ...formData, password: e.target.value })}
-            placeholder="8자 이상 입력"
-            className="w-full h-12 bg-gray-100 rounded-lg px-4 outline-none focus:ring-2 focus:ring-[#98E446]"
-          />
-          <p className="text-[10px] text-gray-400">영문, 숫자, 특수문자 조합</p>
+        <div className="p-6">
+          <button
+            onClick={handleNext}
+            disabled={!canSubmit || isSubmitting}
+            className={`w-full h-14 font-bold rounded-xl transition-colors ${
+              canSubmit && !isSubmitting
+                ? "bg-[#98E446] hover:bg-[#87d335] text-black"
+                : "bg-gray-200 text-gray-400 cursor-not-allowed"
+            }`}
+          >
+            {isSubmitting ? "처리 중" : "다음"}
+          </button>
         </div>
+      </motion.div>
 
-        <div className="space-y-2">
-          <label className="text-sm font-bold">비밀번호 확인</label>
-          <input
-            type="password"
-            value={formData.confirmPassword}
-            onChange={(e) => setFormData({ ...formData, confirmPassword: e.target.value })}
-            placeholder="비밀번호 재입력"
-            className="w-full h-12 bg-gray-100 rounded-lg px-4 outline-none focus:ring-2 focus:ring-[#98E446]"
-          />
-          {formData.confirmPassword && formData.password !== formData.confirmPassword && (
-            <p className="text-[10px] text-red-500">비밀번호가 일치하지 않습니다.</p>
-          )}
-        </div>
-
-        <div className="space-y-2">
-          <label className="text-sm font-bold">이메일</label>
-          <input
-            type="email"
-            value={formData.email}
-            onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-            placeholder="example@email.com"
-            className="w-full h-12 bg-gray-100 rounded-lg px-4 outline-none focus:ring-2 focus:ring-[#98E446]"
-          />
-        </div>
-      </div>
-
-      <div className="p-6">
-        <button
-          onClick={onNext}
-          disabled={!isFormValid}
-          className={`w-full h-14 font-bold rounded-xl transition-colors ${
-            isFormValid
-              ? 'bg-[#98E446] hover:bg-[#87d335] text-black'
-              : 'bg-gray-200 text-gray-400 cursor-not-allowed'
-          }`}
-        >
-          다음
-        </button>
-      </div>
-    </motion.div>
+      <ResultModal
+        isOpen={resultModal.isOpen}
+        title={resultModal.title}
+        message={resultModal.message}
+        onClose={() => setResultModal({ ...resultModal, isOpen: false })}
+      />
+    </>
   );
 }

--- a/src/app/(main)/index.tsx
+++ b/src/app/(main)/index.tsx
@@ -65,7 +65,8 @@ export default function MainLayout({
   onThemeChange,
   themeColor,
   userLocation,
-  onLogout
+  onLogout,
+  profileRefreshKey = 0,
 }: { 
   activeTab: Tab; 
   onTabChange: (tab: Tab) => void;
@@ -90,6 +91,7 @@ export default function MainLayout({
   themeColor: string;
   userLocation: string;
   onLogout: () => void;
+  profileRefreshKey?: number;
   key?: string;
 }) {
   const [lastTab, setLastTab] = useState<Tab>(activeTab === 'register' ? 'home' : activeTab);
@@ -164,6 +166,7 @@ export default function MainLayout({
             onBiddingClick={onBiddingClick}
             userLocation={userLocation}
             onLogout={onLogout}
+            refreshKey={profileRefreshKey}
           />
         )}
       </div>

--- a/src/app/(main)/mypage/edit-profile/index.tsx
+++ b/src/app/(main)/mypage/edit-profile/index.tsx
@@ -4,12 +4,20 @@ import { ChangeEvent, useEffect, useRef, useState } from "react";
 import { Camera, ChevronLeft, Home } from "lucide-react";
 import { motion } from "motion/react";
 
+import ResultModal from "@/components/common/modal/ResultModal";
+import { checkNicknameAvailability } from "@/services/auth/service";
 import {
   createDefaultProfileForm,
   fetchMyProfileForm,
   saveMyProfile,
   uploadMyProfileImage,
 } from "@/services/mypage/service";
+import { getErrorMessage } from "@/services/apiError";
+import {
+  clearMyProfileDraft,
+  getMyProfileDraft,
+  setMyProfileDraft,
+} from "@/services/mypage/profileDraft";
 import type { MyProfileFormValues } from "@/services/mypage/types";
 
 const TEXT = {
@@ -27,7 +35,13 @@ const TEXT = {
   bioPlaceholder: "\uc790\uae30\uc18c\uac1c\ub97c \uc785\ub825\ud574 \uc8fc\uc138\uc694. (\uc120\ud0dd)",
   saving: "\uc800\uc7a5 \uc911",
   complete: "\uc644\ub8cc",
+  duplicateCheck: "\uc911\ubcf5\ud655\uc778",
+  nicknameAvailable: "\uc0ac\uc6a9 \uac00\ub2a5\ud55c \ub2c9\ub124\uc784\uc785\ub2c8\ub2e4.",
+  nicknameDuplicate: "\uc911\ubcf5\ub41c \ub2c9\ub124\uc784\uc785\ub2c8\ub2e4.",
+  nicknameCheckTitle: "\ub2c9\ub124\uc784 \uc911\ubcf5 \ud655\uc778",
 };
+
+type CheckStatus = "idle" | "available" | "duplicate";
 
 interface ProfileEditScreenProps {
   onBack: () => void;
@@ -41,17 +55,47 @@ export default function ProfileEditScreen({
   onLocationEdit,
 }: ProfileEditScreenProps) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const imagePreviewUrlRef = useRef<string | null>(null);
   const [form, setForm] = useState<MyProfileFormValues>(
     createDefaultProfileForm(),
   );
+  const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null);
+  const [initialNickname, setInitialNickname] = useState("");
+  const [nicknameCheckStatus, setNicknameCheckStatus] =
+    useState<CheckStatus>("idle");
   const [isSaving, setIsSaving] = useState(false);
+  const [resultModal, setResultModal] = useState({
+    isOpen: false,
+    title: "",
+    message: "",
+  });
 
   useEffect(() => {
+    const draft = getMyProfileDraft();
+
+    if (draft) {
+      setForm(draft);
+    }
+
     let ignore = false;
 
     fetchMyProfileForm().then((nextForm) => {
-      if (!ignore) {
+      if (ignore) {
+        return;
+      }
+
+      setInitialNickname(nextForm.nickname);
+
+      if (!draft) {
         setForm(nextForm);
+        setMyProfileDraft(nextForm);
+      }
+    }).catch((error) => {
+      if (!ignore) {
+        openResultModal(
+          "프로필 조회 실패",
+          getErrorMessage(error, "프로필 정보를 불러오지 못했습니다."),
+        );
       }
     });
 
@@ -60,13 +104,77 @@ export default function ProfileEditScreen({
     };
   }, []);
 
+  useEffect(() => {
+    return () => {
+      if (imagePreviewUrlRef.current) {
+        URL.revokeObjectURL(imagePreviewUrlRef.current);
+      }
+    };
+  }, []);
+
   const isFormValid = form.nickname.trim().length >= 2;
+  const isNicknameUnchanged =
+    form.nickname.trim() !== "" &&
+    form.nickname.trim() === initialNickname.trim();
+  const canSave =
+    isFormValid && (isNicknameUnchanged || nicknameCheckStatus === "available");
+
+  const openResultModal = (title: string, message: string) => {
+    setResultModal({ isOpen: true, title, message });
+  };
 
   const updateForm = (nextForm: Partial<MyProfileFormValues>) => {
-    setForm((prevForm) => ({
-      ...prevForm,
-      ...nextForm,
-    }));
+    setForm((prevForm) => {
+      const mergedForm = {
+        ...prevForm,
+        ...nextForm,
+      };
+
+      setMyProfileDraft(mergedForm);
+      return mergedForm;
+    });
+  };
+
+  const updateImagePreviewUrl = (nextPreviewUrl: string | null) => {
+    if (imagePreviewUrlRef.current) {
+      URL.revokeObjectURL(imagePreviewUrlRef.current);
+    }
+
+    imagePreviewUrlRef.current = nextPreviewUrl;
+    setImagePreviewUrl(nextPreviewUrl);
+  };
+
+  const handleNicknameChange = (nickname: string) => {
+    updateForm({ nickname });
+    setNicknameCheckStatus("idle");
+  };
+
+  const handleNicknameCheck = async () => {
+    if (!form.nickname.trim()) {
+      openResultModal(TEXT.nicknameCheckTitle, "닉네임을 입력해주세요.");
+      return;
+    }
+
+    if (isNicknameUnchanged) {
+      setNicknameCheckStatus("available");
+      openResultModal(TEXT.nicknameCheckTitle, "현재 사용 중인 닉네임입니다.");
+      return;
+    }
+
+    try {
+      const result = await checkNicknameAvailability(form.nickname);
+      setNicknameCheckStatus(result.available ? "available" : "duplicate");
+      openResultModal(
+        TEXT.nicknameCheckTitle,
+        result.available ? TEXT.nicknameAvailable : TEXT.nicknameDuplicate,
+      );
+    } catch (error) {
+      setNicknameCheckStatus("idle");
+      openResultModal(
+        TEXT.nicknameCheckTitle,
+        getErrorMessage(error, "닉네임 중복 확인에 실패했습니다."),
+      );
+    }
   };
 
   const handleImageButtonClick = () => {
@@ -80,24 +188,41 @@ export default function ProfileEditScreen({
       return;
     }
 
-    const uploadedImage = await uploadMyProfileImage(file);
-    updateForm({ profileImageUrl: uploadedImage.profileImageUrl });
-    event.target.value = "";
+    const nextPreviewUrl = URL.createObjectURL(file);
+    updateImagePreviewUrl(nextPreviewUrl);
+
+    try {
+      const uploadedImage = await uploadMyProfileImage(file);
+      updateForm({ profileImageUrl: uploadedImage.profileImageUrl });
+    } catch (error) {
+      updateImagePreviewUrl(null);
+      window.alert(getErrorMessage(error, "프로필 이미지 업로드에 실패했습니다."));
+    } finally {
+      event.target.value = "";
+    }
   };
 
   const handleSave = async () => {
-    if (!isFormValid || isSaving) {
+    if (!canSave || isSaving) {
       return;
     }
 
     setIsSaving(true);
-    await saveMyProfile(form);
-    setIsSaving(false);
-    onComplete();
+
+    try {
+      await saveMyProfile(form);
+      clearMyProfileDraft();
+      onComplete();
+    } catch (error) {
+      window.alert(getErrorMessage(error, "프로필 저장에 실패했습니다."));
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   return (
-    <motion.div
+    <>
+      <motion.div
       initial={{ opacity: 0, x: 20 }}
       animate={{ opacity: 1, x: 0 }}
       exit={{ opacity: 0, x: -20 }}
@@ -125,11 +250,19 @@ export default function ProfileEditScreen({
             aria-label={TEXT.editPhoto}
           >
             <div className="w-32 h-32 bg-gray-100 rounded-full flex items-center justify-center overflow-hidden border border-gray-200 group-hover:opacity-90 transition-opacity">
-              {form.profileImageUrl ? (
+              {imagePreviewUrl || form.profileImageUrl ? (
                 <img
-                  src={form.profileImageUrl}
+                  src={imagePreviewUrl || form.profileImageUrl || ""}
                   alt={TEXT.profileAlt}
                   className="w-full h-full object-cover"
+                  onError={() => {
+                    if (imagePreviewUrl) {
+                      updateImagePreviewUrl(null);
+                      return;
+                    }
+
+                    updateForm({ profileImageUrl: null });
+                  }}
                 />
               ) : (
                 <Camera size={36} className="text-gray-300" />
@@ -160,14 +293,33 @@ export default function ProfileEditScreen({
             <label className="text-sm font-bold" htmlFor="nickname">
               {TEXT.nickname}
             </label>
-            <input
-              id="nickname"
-              type="text"
-              value={form.nickname}
-              onChange={(event) => updateForm({ nickname: event.target.value })}
-              placeholder={TEXT.nicknamePlaceholder}
-              className="w-full h-12 bg-gray-100 rounded-lg px-4 outline-none focus:ring-2 focus:ring-[#98E446]"
-            />
+            <div className="flex space-x-2 w-full">
+              <input
+                id="nickname"
+                type="text"
+                value={form.nickname}
+                onChange={(event) => handleNicknameChange(event.target.value)}
+                placeholder={TEXT.nicknamePlaceholder}
+                className="flex-1 min-w-0 h-12 bg-gray-100 rounded-lg px-4 outline-none focus:ring-2 focus:ring-[#98E446]"
+              />
+              <button
+                type="button"
+                onClick={handleNicknameCheck}
+                className="whitespace-nowrap px-4 h-12 border border-gray-200 rounded-lg text-sm font-medium hover:bg-gray-50 shrink-0"
+              >
+                {TEXT.duplicateCheck}
+              </button>
+            </div>
+            {nicknameCheckStatus === "available" && !isNicknameUnchanged && (
+              <p className="text-[10px] text-green-600">
+                {TEXT.nicknameAvailable}
+              </p>
+            )}
+            {nicknameCheckStatus === "duplicate" && (
+              <p className="text-[10px] text-red-500">
+                {TEXT.nicknameDuplicate}
+              </p>
+            )}
             <p className="text-xs text-gray-400">{TEXT.nicknameHelper}</p>
           </div>
 
@@ -207,9 +359,9 @@ export default function ProfileEditScreen({
       <div className="p-6">
         <button
           onClick={handleSave}
-          disabled={!isFormValid || isSaving}
+          disabled={!canSave || isSaving}
           className={`w-full h-14 font-bold rounded-xl transition-colors ${
-            isFormValid && !isSaving
+            canSave && !isSaving
               ? "bg-[#98E446] hover:bg-[#87d335] text-black"
               : "bg-gray-200 text-gray-400 cursor-not-allowed"
           }`}
@@ -218,5 +370,13 @@ export default function ProfileEditScreen({
         </button>
       </div>
     </motion.div>
+
+      <ResultModal
+        isOpen={resultModal.isOpen}
+        title={resultModal.title}
+        message={resultModal.message}
+        onClose={() => setResultModal({ ...resultModal, isOpen: false })}
+      />
+    </>
   );
 }

--- a/src/app/(main)/mypage/edit-profile/location/find/page.tsx
+++ b/src/app/(main)/mypage/edit-profile/location/find/page.tsx
@@ -2,15 +2,22 @@
 
 import { useRouter } from "next/navigation";
 
+import { getErrorMessage } from "@/services/apiError";
 import FindLocationScreen from "@/app/(auth)/find-location";
 import { saveMyLocation } from "@/services/mypage/service";
+import { updateMyProfileDraft } from "@/services/mypage/profileDraft";
 
 export default function ProfileLocationFindPage() {
   const router = useRouter();
 
   const handleComplete = async (location: string) => {
-    await saveMyLocation(location);
-    router.push("/mypage/edit-profile/location");
+    try {
+      updateMyProfileDraft({ location });
+      await saveMyLocation(location);
+      router.push("/mypage/edit-profile/location");
+    } catch (error) {
+      window.alert(getErrorMessage(error, "지역 저장에 실패했습니다."));
+    }
   };
 
   return (

--- a/src/app/(main)/mypage/edit-profile/location/page.tsx
+++ b/src/app/(main)/mypage/edit-profile/location/page.tsx
@@ -3,21 +3,32 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
+import { getErrorMessage } from "@/services/apiError";
 import RegionSetupScreen from "@/app/(auth)/region-setup";
 import { fetchMyProfileForm, saveMyLocation } from "@/services/mypage/service";
-
-const DEFAULT_LOCATION = "\uc11c\uc6b8\ud2b9\ubcc4\uc2dc \uac15\ub0a8\uad6c";
+import { getMyProfileDraft, updateMyProfileDraft } from "@/services/mypage/profileDraft";
 
 export default function ProfileLocationEditPage() {
   const router = useRouter();
-  const [location, setLocation] = useState(DEFAULT_LOCATION);
+  const [location, setLocation] = useState("");
 
   useEffect(() => {
+    const draft = getMyProfileDraft();
+
+    if (draft?.location) {
+      setLocation(draft.location);
+      return;
+    }
+
     let ignore = false;
 
     fetchMyProfileForm().then((form) => {
       if (!ignore && form.location) {
         setLocation(form.location);
+      }
+    }).catch((error) => {
+      if (!ignore) {
+        window.alert(getErrorMessage(error, "프로필 정보를 불러오지 못했습니다."));
       }
     });
 
@@ -27,8 +38,13 @@ export default function ProfileLocationEditPage() {
   }, []);
 
   const handleComplete = async () => {
-    await saveMyLocation(location);
-    router.push("/mypage/edit-profile");
+    try {
+      updateMyProfileDraft({ location });
+      await saveMyLocation(location);
+      router.push("/mypage/edit-profile");
+    } catch (error) {
+      window.alert(getErrorMessage(error, "지역 저장에 실패했습니다."));
+    }
   };
 
   return (
@@ -37,6 +53,7 @@ export default function ProfileLocationEditPage() {
       onNext={handleComplete}
       onFindLocation={() => router.push("/mypage/edit-profile/location/find")}
       currentLocation={location}
+      onLocationChange={setLocation}
     />
   );
 }

--- a/src/app/(main)/mypage/index.tsx
+++ b/src/app/(main)/mypage/index.tsx
@@ -11,9 +11,11 @@ import {
   ShoppingBag,
   Star,
   Store,
+  User,
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 
+import { getErrorMessage } from "@/services/apiError";
 import { fetchMyPageProfile } from "@/services/mypage/service";
 import type { MyPageProfileViewModel } from "@/services/mypage/types";
 
@@ -32,6 +34,7 @@ interface MyPageScreenProps {
   onBiddingClick: () => void;
   onLogout: () => void;
   userLocation?: string;
+  refreshKey?: number;
 }
 
 export default function MyPageScreen({
@@ -47,23 +50,35 @@ export default function MyPageScreen({
   onSalesHistoryClick,
   onBiddingClick,
   onLogout,
+  refreshKey = 0,
 }: MyPageScreenProps) {
   const [profile, setProfile] = useState<MyPageProfileViewModel | null>(null);
+  const [profileErrorMessage, setProfileErrorMessage] = useState("");
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
 
   useEffect(() => {
     let ignore = false;
 
-    fetchMyPageProfile().then((nextProfile) => {
-      if (!ignore) {
-        setProfile(nextProfile);
-      }
-    });
+    fetchMyPageProfile()
+      .then((nextProfile) => {
+        if (!ignore) {
+          setProfile(nextProfile);
+          setProfileErrorMessage("");
+        }
+      })
+      .catch((error) => {
+        if (!ignore) {
+          setProfile(null);
+          setProfileErrorMessage(
+            getErrorMessage(error, "마이페이지 정보를 불러오지 못했습니다."),
+          );
+        }
+      });
 
     return () => {
       ignore = true;
     };
-  }, []);
+  }, [refreshKey]);
 
   const menus = [
     { icon: <ShoppingBag size={20} />, label: "구매 내역", onClick: onPurchaseHistoryClick },
@@ -89,16 +104,31 @@ export default function MyPageScreen({
       </div>
 
       <div className="flex-1 overflow-y-auto no-scrollbar px-6 py-4 space-y-8">
+        {profileErrorMessage && (
+          <div className="rounded-lg bg-red-50 px-4 py-3 text-xs text-red-500">
+            {profileErrorMessage}
+          </div>
+        )}
+
         <div className="flex items-center space-x-4">
           <div className="w-20 h-20 rounded-full overflow-hidden bg-gray-100 border border-gray-200">
-            {profile ? (
+            {profile?.profileImageUrl ? (
               <img
                 src={profile.profileImageUrl}
                 alt={`${profile.nickname} 프로필`}
                 className="w-full h-full object-cover"
+                onError={() =>
+                  setProfile((prevProfile) =>
+                    prevProfile
+                      ? { ...prevProfile, profileImageUrl: "" }
+                      : prevProfile,
+                  )
+                }
               />
             ) : (
-              <div className="w-full h-full animate-pulse bg-gray-200" />
+              <div className="w-full h-full flex items-center justify-center text-gray-300">
+                <User size={32} />
+              </div>
             )}
           </div>
           <div className="space-y-1">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -79,7 +79,10 @@ import WinningBidCompletionScreen from "./auctions/[auctionId]/winning-complete"
 import OutbidNotificationScreen from "./auctions/[auctionId]/outbid";
 import MyBidsScreen from "./(main)/mypage/my-bids";
 import SalesManagementScreen from "./(main)/mypage/sales-management";
+import { getErrorMessage } from "@/services/apiError";
+import { clearAuthToken } from "@/services/auth/service";
 import { fetchMyProfileForm, saveMyLocation } from "@/services/mypage/service";
+import { updateMyProfileDraft } from "@/services/mypage/profileDraft";
 
 export default function App() {
   const [currentScreen, setCurrentScreen] = useState<Screen>("login");
@@ -94,9 +97,10 @@ export default function App() {
   >("all");
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [isEditingProfile, setIsEditingProfile] = useState(false);
-  const [userLocation, setUserLocation] = useState("서울특별시 강남구 역삼동");
+  const [userLocation, setUserLocation] = useState("");
   const [isEditingLocation, setIsEditingLocation] = useState(false);
   const [locationReturnScreen, setLocationReturnScreen] = useState<Screen | null>(null);
+  const [profileRefreshKey, setProfileRefreshKey] = useState(0);
   const [toast, setToast] = useState<{ message: string; visible: boolean }>({
     message: "",
     visible: false,
@@ -172,12 +176,18 @@ export default function App() {
                   navigateTo("signup");
                 }
               }}
-              onNext={() => {
-                if (isEditingLocation) {
-                  navigateTo("main");
-                  setIsEditingLocation(false);
-                } else {
-                  navigateTo("phone_auth");
+              onNext={async () => {
+                try {
+                  await saveMyLocation(userLocation);
+
+                  if (isEditingLocation) {
+                    navigateTo("main");
+                    setIsEditingLocation(false);
+                  } else {
+                    navigateTo("phone_auth");
+                  }
+                } catch (error) {
+                  showToast(getErrorMessage(error, "지역 저장에 실패했습니다."));
                 }
               }}
               onFindLocation={() => {
@@ -185,6 +195,7 @@ export default function App() {
                 navigateTo("find_location");
               }}
               currentLocation={userLocation}
+              onLocationChange={setUserLocation}
             />
           )}
           {currentScreen === "find_location" && (
@@ -198,17 +209,24 @@ export default function App() {
                   navigateTo("region_setup");
                 }
               }}
-              onComplete={(newLocation) => {
+              onComplete={async (newLocation) => {
                 setUserLocation(newLocation);
-                if (locationReturnScreen) {
-                  saveMyLocation(newLocation);
-                  navigateTo(locationReturnScreen);
-                  setLocationReturnScreen(null);
-                } else if (isEditingLocation) {
-                  navigateTo("main");
-                  setIsEditingLocation(false);
-                } else {
-                  navigateTo("phone_auth");
+
+                try {
+                  await saveMyLocation(newLocation);
+
+                  if (locationReturnScreen) {
+                    updateMyProfileDraft({ location: newLocation });
+                    navigateTo(locationReturnScreen);
+                    setLocationReturnScreen(null);
+                  } else if (isEditingLocation) {
+                    navigateTo("main");
+                    setIsEditingLocation(false);
+                  } else {
+                    navigateTo("phone_auth");
+                  }
+                } catch (error) {
+                  showToast(getErrorMessage(error, "지역 저장에 실패했습니다."));
                 }
               }}
             />
@@ -266,6 +284,8 @@ export default function App() {
                 setIsEditingProfile(false);
               }}
               onComplete={() => {
+                setProfileRefreshKey((prevKey) => prevKey + 1);
+                setCurrentTab("mypage");
                 navigateTo("main");
                 setIsEditingProfile(false);
               }}
@@ -275,15 +295,21 @@ export default function App() {
             <RegionSetupScreen
               key="edit_profile_region"
               onBack={() => navigateTo("edit_profile")}
-              onNext={() => {
-                saveMyLocation(userLocation);
-                navigateTo("edit_profile");
+              onNext={async () => {
+                try {
+                  await saveMyLocation(userLocation);
+                  updateMyProfileDraft({ location: userLocation });
+                  navigateTo("edit_profile");
+                } catch (error) {
+                  showToast(getErrorMessage(error, "지역 저장에 실패했습니다."));
+                }
               }}
               onFindLocation={() => {
                 setLocationReturnScreen("edit_profile_region");
                 navigateTo("find_location");
               }}
               currentLocation={userLocation}
+              onLocationChange={setUserLocation}
             />
           )}
           {currentScreen === "category_selection" && (
@@ -347,7 +373,9 @@ export default function App() {
               onThemeChange={setThemeMode}
               themeColor={themeColor}
               userLocation={userLocation}
+              profileRefreshKey={profileRefreshKey}
               onLogout={() => {
+                clearAuthToken();
                 setCurrentTab("home");
                 navigateTo("login");
               }}

--- a/src/components/common/modal/ResultModal.tsx
+++ b/src/components/common/modal/ResultModal.tsx
@@ -1,0 +1,55 @@
+﻿"use client";
+
+import { motion } from "motion/react";
+
+interface ResultModalProps {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  onClose: () => void;
+  confirmText?: string;
+  themeColor?: string;
+}
+
+export default function ResultModal({
+  isOpen,
+  title,
+  message,
+  onClose,
+  confirmText = "확인",
+  themeColor = "#98E446",
+}: ResultModalProps) {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-6">
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        onClick={onClose}
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+      />
+      <motion.div
+        initial={{ opacity: 0, scale: 0.9, y: 20 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.9, y: 20 }}
+        className="relative w-full max-w-[320px] bg-white rounded-3xl shadow-2xl overflow-hidden p-6 space-y-6"
+      >
+        <div className="space-y-2 text-center">
+          <h3 className="text-lg font-bold text-gray-900">{title}</h3>
+          <p className="text-sm text-gray-500 leading-relaxed">{message}</p>
+        </div>
+        <button
+          onClick={onClose}
+          className="w-full py-3.5 rounded-2xl text-black font-bold text-sm transition-opacity hover:opacity-90"
+          style={{ backgroundColor: themeColor }}
+        >
+          {confirmText}
+        </button>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/services/apiError.ts
+++ b/src/services/apiError.ts
@@ -1,0 +1,26 @@
+﻿export async function getApiErrorMessage(response: Response, fallbackMessage: string) {
+  try {
+    const data = await response.json();
+
+    if (typeof data?.message === "string" && data.message.trim()) {
+      return data.message;
+    }
+
+    if (Array.isArray(data?.errors) && data.errors.length > 0) {
+      const firstError = data.errors[0];
+      if (typeof firstError?.reason === "string" && firstError.reason.trim()) {
+        return firstError.reason;
+      }
+    }
+  } catch {
+    // Ignore body parsing failures and use the fallback below.
+  }
+
+  return `${fallbackMessage} (${response.status})`;
+}
+
+export function getErrorMessage(error: unknown, fallbackMessage: string) {
+  return error instanceof Error && error.message.trim()
+    ? error.message
+    : fallbackMessage;
+}

--- a/src/services/auth/api.ts
+++ b/src/services/auth/api.ts
@@ -1,0 +1,91 @@
+﻿import { getApiErrorMessage } from "@/services/apiError";
+import type {
+  CurrentMemberResponse,
+  LoginIdCheckResponse,
+  LoginRequest,
+  LoginResponse,
+  NicknameCheckResponse,
+  SignUpRequest,
+  SignUpResponse,
+} from "@/services/auth/types";
+
+export async function postLogin(payload: LoginRequest): Promise<LoginResponse> {
+  const response = await fetch("/api/v1/auth/login", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(await getApiErrorMessage(response, "로그인에 실패했습니다."));
+  }
+
+  return response.json();
+}
+
+export async function getCurrentMember(
+  headers: Record<string, string> = {},
+): Promise<CurrentMemberResponse> {
+  const response = await fetch("/api/v1/auth/me", {
+    method: "GET",
+    headers,
+  });
+
+  if (!response.ok) {
+    throw new Error(await getApiErrorMessage(response, "내 정보 조회에 실패했습니다."));
+  }
+
+  return response.json();
+}
+
+export async function postSignUp(
+  payload: SignUpRequest,
+): Promise<SignUpResponse> {
+  const response = await fetch("/api/v1/members/signup", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(await getApiErrorMessage(response, "회원가입에 실패했습니다."));
+  }
+
+  return response.json();
+}
+
+export async function checkLoginId(
+  loginId: string,
+): Promise<LoginIdCheckResponse> {
+  const params = new URLSearchParams({ loginId });
+  const response = await fetch(`/api/v1/members/login-id/check?${params}`, {
+    method: "GET",
+  });
+
+  if (!response.ok) {
+    throw new Error(await getApiErrorMessage(response, "아이디 중복 확인에 실패했습니다."));
+  }
+
+  return response.json();
+}
+
+export async function checkNickname(
+  nickname: string,
+): Promise<NicknameCheckResponse> {
+  const params = new URLSearchParams({ nickname });
+  const response = await fetch(`/api/v1/members/nickname/check?${params}`, {
+    method: "GET",
+  });
+
+  if (!response.ok) {
+    throw new Error(await getApiErrorMessage(response, "닉네임 중복 확인에 실패했습니다."));
+  }
+
+  return response.json();
+}
+
+

--- a/src/services/auth/service.ts
+++ b/src/services/auth/service.ts
@@ -1,0 +1,159 @@
+﻿import * as authApi from "@/services/auth/api";
+import type {
+  AuthResult,
+  CurrentMemberResponse,
+  LoginFormValues,
+  LoginIdCheckResponse,
+  LoginRequest,
+  LoginResponse,
+  NicknameCheckResponse,
+  SignUpFormValues,
+  SignUpRequest,
+  SignUpResponse,
+} from "@/services/auth/types";
+
+const AUTH_TOKEN_STORAGE_KEY = "dealit_access_token";
+const AUTH_TOKEN_TYPE_STORAGE_KEY = "dealit_token_type";
+
+function canUseStorage() {
+  return typeof window !== "undefined" && Boolean(window.localStorage);
+}
+
+export function saveAuthToken(loginResponse: LoginResponse) {
+  if (!canUseStorage()) {
+    return;
+  }
+
+  localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, loginResponse.accessToken);
+  localStorage.setItem(AUTH_TOKEN_TYPE_STORAGE_KEY, loginResponse.tokenType || "Bearer");
+}
+
+export function clearAuthToken() {
+  if (!canUseStorage()) {
+    return;
+  }
+
+  localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+  localStorage.removeItem(AUTH_TOKEN_TYPE_STORAGE_KEY);
+}
+
+export function getAuthToken() {
+  if (!canUseStorage()) {
+    return null;
+  }
+
+  return localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+}
+
+export function getAuthorizationHeaders(): Record<string, string> {
+  const accessToken = getAuthToken();
+
+  if (!accessToken) {
+    return {};
+  }
+
+  const tokenType = canUseStorage()
+    ? localStorage.getItem(AUTH_TOKEN_TYPE_STORAGE_KEY) || "Bearer"
+    : "Bearer";
+
+  return {
+    Authorization: `${tokenType} ${accessToken}`,
+  };
+}
+
+export function createDefaultLoginForm(): LoginFormValues {
+  return {
+    loginId: "",
+    password: "",
+  };
+}
+
+export function createDefaultSignUpForm(): SignUpFormValues {
+  return {
+    loginId: "",
+    password: "",
+    confirmPassword: "",
+    email: "",
+    name: "",
+  };
+}
+
+export function isEmailValid(email: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+export function isPasswordValid(password: string) {
+  return password.length >= 8 && password.length <= 30;
+}
+
+export function isLoginFormValid(form: LoginFormValues) {
+  return form.loginId.trim() !== "" && form.password.trim() !== "";
+}
+
+export function isSignUpFormValid(form: SignUpFormValues) {
+  return (
+    form.loginId.trim() !== "" &&
+    isPasswordValid(form.password) &&
+    form.password === form.confirmPassword &&
+    isEmailValid(form.email)
+  );
+}
+
+export function buildLoginRequest(form: LoginFormValues): LoginRequest {
+  return {
+    loginId: form.loginId.trim(),
+    password: form.password,
+  };
+}
+
+export function buildSignUpRequest(form: SignUpFormValues): SignUpRequest {
+  return {
+    loginId: form.loginId.trim(),
+    password: form.password,
+    email: form.email.trim(),
+    name: form.name.trim() || null,
+  };
+}
+
+async function loginAndStoreToken(form: LoginFormValues) {
+  const loginResponse = await authApi.postLogin(buildLoginRequest(form));
+  saveAuthToken(loginResponse);
+  return loginResponse;
+}
+
+export async function login(
+  form: LoginFormValues,
+): Promise<AuthResult<LoginResponse>> {
+  return {
+    data: await loginAndStoreToken(form),
+    message: "로그인되었습니다.",
+  };
+}
+
+export async function fetchCurrentMember(): Promise<CurrentMemberResponse> {
+  return authApi.getCurrentMember(getAuthorizationHeaders());
+}
+
+export async function signUp(
+  form: SignUpFormValues,
+): Promise<AuthResult<SignUpResponse>> {
+  const signUpResponse = await authApi.postSignUp(buildSignUpRequest(form));
+  await loginAndStoreToken(form);
+
+  return {
+    data: signUpResponse,
+    message: "회원가입 후 자동 로그인되었습니다.",
+  };
+}
+
+export async function checkLoginIdAvailability(
+  loginId: string,
+): Promise<LoginIdCheckResponse> {
+  return authApi.checkLoginId(loginId.trim());
+}
+
+export async function checkNicknameAvailability(
+  nickname: string,
+): Promise<NicknameCheckResponse> {
+  return authApi.checkNickname(nickname.trim());
+}

--- a/src/services/auth/types.ts
+++ b/src/services/auth/types.ts
@@ -1,0 +1,60 @@
+﻿export interface LoginRequest {
+  loginId: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  accessToken: string;
+  tokenType: string;
+  expiresIn: number;
+}
+
+export interface CurrentMemberResponse {
+  memberId: number;
+  loginId: string;
+  email: string;
+  nickname: string;
+}
+
+export interface SignUpRequest {
+  loginId: string;
+  password: string;
+  email: string;
+  name: string | null;
+}
+
+export interface SignUpResponse {
+  memberId: number;
+  loginId: string;
+  email: string;
+  nickname: string;
+  createdAt: string;
+}
+
+export interface LoginIdCheckResponse {
+  loginId: string;
+  available: boolean;
+}
+
+export interface NicknameCheckResponse {
+  nickname: string;
+  available: boolean;
+}
+
+export interface LoginFormValues {
+  loginId: string;
+  password: string;
+}
+
+export interface SignUpFormValues {
+  loginId: string;
+  password: string;
+  confirmPassword: string;
+  email: string;
+  name: string;
+}
+
+export interface AuthResult<T> {
+  data: T;
+  message: string;
+}

--- a/src/services/mypage/api.ts
+++ b/src/services/mypage/api.ts
@@ -1,3 +1,5 @@
+import { getApiErrorMessage } from "@/services/apiError";
+import { getAuthorizationHeaders } from "@/services/auth/service";
 import type {
   MyProfileResponse,
   UpdateMyLocationRequest,
@@ -7,12 +9,13 @@ import type {
 } from "@/services/mypage/types";
 
 export async function getMyProfile(): Promise<MyProfileResponse> {
-  const response = await fetch("/users/me/mypage", {
+  const response = await fetch("/api/v1/users/me/mypage", {
     method: "GET",
+    headers: getAuthorizationHeaders(),
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to get my profile: ${response.status}`);
+    throw new Error(await getApiErrorMessage(response, "마이페이지 조회에 실패했습니다."));
   }
 
   return response.json();
@@ -21,16 +24,17 @@ export async function getMyProfile(): Promise<MyProfileResponse> {
 export async function updateMyProfile(
   payload: UpdateMyProfileRequest,
 ): Promise<MyProfileResponse> {
-  const response = await fetch("/users/me/profile", {
+  const response = await fetch("/api/v1/users/me/profile", {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
+      ...getAuthorizationHeaders(),
     },
     body: JSON.stringify(payload),
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to update my profile: ${response.status}`);
+    throw new Error(await getApiErrorMessage(response, "프로필 저장에 실패했습니다."));
   }
 
   return response.json();
@@ -39,16 +43,17 @@ export async function updateMyProfile(
 export async function updateMyLocation(
   payload: UpdateMyLocationRequest,
 ): Promise<UpdateMyLocationResponse> {
-  const response = await fetch("/users/me/location", {
+  const response = await fetch("/api/v1/users/me/location", {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
+      ...getAuthorizationHeaders(),
     },
     body: JSON.stringify(payload),
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to update my location: ${response.status}`);
+    throw new Error(await getApiErrorMessage(response, "지역 저장에 실패했습니다."));
   }
 
   return response.json();
@@ -60,13 +65,14 @@ export async function uploadProfileImage(
   const formData = new FormData();
   formData.append("file", file);
 
-  const response = await fetch("/users/me/profile-image", {
+  const response = await fetch("/api/v1/users/me/profile-image", {
     method: "POST",
+    headers: getAuthorizationHeaders(),
     body: formData,
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to upload profile image: ${response.status}`);
+    throw new Error(await getApiErrorMessage(response, "프로필 이미지 업로드에 실패했습니다."));
   }
 
   return response.json();

--- a/src/services/mypage/profileDraft.ts
+++ b/src/services/mypage/profileDraft.ts
@@ -1,0 +1,26 @@
+﻿import type { MyProfileFormValues } from "@/services/mypage/types";
+
+let myProfileDraft: MyProfileFormValues | null = null;
+
+export function getMyProfileDraft() {
+  return myProfileDraft;
+}
+
+export function setMyProfileDraft(form: MyProfileFormValues) {
+  myProfileDraft = form;
+}
+
+export function updateMyProfileDraft(nextForm: Partial<MyProfileFormValues>) {
+  if (!myProfileDraft) {
+    return;
+  }
+
+  myProfileDraft = {
+    ...myProfileDraft,
+    ...nextForm,
+  };
+}
+
+export function clearMyProfileDraft() {
+  myProfileDraft = null;
+}

--- a/src/services/mypage/service.ts
+++ b/src/services/mypage/service.ts
@@ -7,22 +7,40 @@ import type {
   UpdateMyProfileRequest,
 } from "@/services/mypage/types";
 
-const DEFAULT_PROFILE_IMAGE = "https://picsum.photos/seed/me/200/200";
+const PROFILE_IMAGE_PATH_PATTERN = /^\/profile\/images\//;
 
-// TODO(mypage-api): Remove fallback after the profile API is connected.
-const fallbackProfile: MyProfileResponse = {
-  id: 1,
-  nickname: "\ube44\ub4dc\ub9c8\uc2a4\ud130",
-  email: "bidmaster@example.com",
-  bio: "\uc548\ub155\ud558\uc138\uc694. \uc88b\uc740 \uac70\ub798 \ubd80\ud0c1\ub4dc\ub824\uc694.",
-  profileImageUrl: DEFAULT_PROFILE_IMAGE,
-  location: "\uc11c\uc6b8\ud2b9\ubcc4\uc2dc \uac15\ub0a8\uad6c",
-  rating: 4.8,
-  warningCount: 0,
-  biddingCount: 3,
-  sellingCount: 1,
-  wishlistCount: 12,
-};
+function resolveProfileImageUrl(profileImageUrl: string | null) {
+  if (!profileImageUrl) {
+    return "";
+  }
+
+  if (/^(data:|blob:)/.test(profileImageUrl)) {
+    return profileImageUrl;
+  }
+
+  if (/^https?:\/\//.test(profileImageUrl)) {
+    try {
+      const url = new URL(profileImageUrl);
+
+      if (
+        PROFILE_IMAGE_PATH_PATTERN.test(url.pathname) &&
+        ["localhost", "127.0.0.1"].includes(url.hostname)
+      ) {
+        return `${url.pathname}${url.search}`;
+      }
+    } catch {
+      return profileImageUrl;
+    }
+
+    return profileImageUrl;
+  }
+
+  if (PROFILE_IMAGE_PATH_PATTERN.test(profileImageUrl)) {
+    return profileImageUrl;
+  }
+
+  return profileImageUrl;
+}
 
 export function createDefaultProfileForm(): MyProfileFormValues {
   return {
@@ -39,7 +57,7 @@ export function normalizeProfileForm(
   return {
     nickname: profile.nickname ?? "",
     bio: profile.bio ?? "",
-    profileImageUrl: profile.profileImageUrl ?? null,
+    profileImageUrl: resolveProfileImageUrl(profile.profileImageUrl) || null,
     location: profile.location ?? "",
   };
 }
@@ -50,8 +68,7 @@ export function buildUpdateMyProfileRequest(
   return {
     nickname: form.nickname.trim(),
     bio: form.bio.trim(),
-    profileImageUrl: form.profileImageUrl,
-    location: form.location.trim(),
+    profileImageUrl: null,
   };
 }
 
@@ -71,7 +88,7 @@ export function toMyPageProfileViewModel(
     nickname: profile.nickname || "\uc774\ub984 \uc5c6\uc74c",
     email: profile.email,
     bio: profile.bio ?? "",
-    profileImageUrl: profile.profileImageUrl || DEFAULT_PROFILE_IMAGE,
+    profileImageUrl: resolveProfileImageUrl(profile.profileImageUrl),
     location: profile.location || "\uc9c0\uc5ed \ubbf8\uc124\uc815",
     ratingLabel: `\ud3c9\uc810 ${profile.rating.toFixed(1)}`,
     warningLabel: `\uacbd\uace0 ${profile.warningCount}\ud68c`,
@@ -82,48 +99,29 @@ export function toMyPageProfileViewModel(
 }
 
 export async function fetchMyPageProfile() {
-  try {
-    return toMyPageProfileViewModel(await mypageApi.getMyProfile());
-  } catch {
-    return toMyPageProfileViewModel(fallbackProfile);
-  }
+  return toMyPageProfileViewModel(await mypageApi.getMyProfile());
 }
 
 export async function fetchMyProfileForm() {
-  try {
-    return normalizeProfileForm(await mypageApi.getMyProfile());
-  } catch {
-    return normalizeProfileForm(fallbackProfile);
-  }
+  return normalizeProfileForm(await mypageApi.getMyProfile());
 }
 
 export async function uploadMyProfileImage(file: File) {
-  try {
-    return await mypageApi.uploadProfileImage(file);
-  } catch {
-    return {
-      profileImageUrl: URL.createObjectURL(file),
-    };
-  }
+  const uploadedImage = await mypageApi.uploadProfileImage(file);
+
+  return {
+    ...uploadedImage,
+    profileImageUrl: resolveProfileImageUrl(uploadedImage.profileImageUrl),
+  };
 }
 
 export async function saveMyProfile(form: MyProfileFormValues) {
-  try {
-    const updatedProfile = await mypageApi.updateMyProfile(
-      buildUpdateMyProfileRequest(form),
-    );
-    return toMyPageProfileViewModel(updatedProfile);
-  } catch {
-    return toMyPageProfileViewModel(fallbackProfile);
-  }
+  const updatedProfile = await mypageApi.updateMyProfile(
+    buildUpdateMyProfileRequest(form),
+  );
+  return toMyPageProfileViewModel(updatedProfile);
 }
 
 export async function saveMyLocation(location: string) {
-  try {
-    return await mypageApi.updateMyLocation(buildUpdateMyLocationRequest(location));
-  } catch {
-    return {
-      location: fallbackProfile.location ?? "",
-    };
-  }
+  return mypageApi.updateMyLocation(buildUpdateMyLocationRequest(location));
 }

--- a/src/services/mypage/service.ts
+++ b/src/services/mypage/service.ts
@@ -68,7 +68,6 @@ export function buildUpdateMyProfileRequest(
   return {
     nickname: form.nickname.trim(),
     bio: form.bio.trim(),
-    profileImageUrl: null,
   };
 }
 

--- a/src/services/mypage/types.ts
+++ b/src/services/mypage/types.ts
@@ -15,7 +15,7 @@ export interface MyProfileResponse {
 export interface UpdateMyProfileRequest {
   nickname: string;
   bio: string;
-  profileImageUrl: string | null;
+  profileImageUrl?: string | null;
 }
 
 export interface UpdateMyLocationRequest {

--- a/src/services/mypage/types.ts
+++ b/src/services/mypage/types.ts
@@ -16,7 +16,6 @@ export interface UpdateMyProfileRequest {
   nickname: string;
   bio: string;
   profileImageUrl: string | null;
-  location: string;
 }
 
 export interface UpdateMyLocationRequest {


### PR DESCRIPTION
### 🚀 Summary
회원가입/로그인 및 마이페이지 프로필 API 연동 흐름 정리
회원가입, 로그인, 프로필 조회/수정/이미지 업로드/지역 수정 흐름을 page -> service -> api 구조로 분리
아이디/닉네임 중복확인, 프로필 이미지 수정, 지역 수정이 실제 백엔드 API 흐름을 타도록 정리
마이페이지 조회 fallback 제거 후 API 실패 시 에러 메시지를 표시하도록 변경

---

### ✨ Description

auth/types.ts  
LoginRequest - 로그인 요청 DTO  
LoginResponse - 로그인 성공 응답 타입  
SignUpRequest - 회원가입 요청 DTO  
SignUpResponse - 회원가입 성공 응답 타입  
LoginIdCheckResponse - 아이디 중복확인 응답 타입  
NicknameCheckResponse - 닉네임 중복확인 응답 타입  
LoginFormValues - 로그인 폼 모델  
SignUpFormValues - 회원가입 폼 모델

auth/api.ts  
postLogin - 로그인 요청  
postSignUp - 회원가입 요청  
getCurrentMember - 내 정보 조회  
checkLoginId - 아이디 중복확인 요청  
checkNickname - 닉네임 중복확인 요청

auth/service.ts  
login - 로그인 API 호출 및 토큰 저장  
signUp - 회원가입 API 호출 후 자동 로그인 처리  
checkLoginIdAvailability - 아이디 중복확인 service  
checkNicknameAvailability - 닉네임 중복확인 service  
getAuthorizationHeaders - 인증 요청용 Authorization header 생성  
clearAuthToken - 로그아웃 시 토큰 제거

signup/index.tsx  
아이디 중복확인 API 연결  
중복확인을 통과해야 다음 버튼 활성화  
회원가입 성공 후 자동 로그인 처리

profile-setup/index.tsx  
닉네임 중복확인 API 연결  
중복확인을 통과해야 완료 버튼 활성화  
프로필 이미지 선택 시 로컬 미리보기 표시  
프로필 이미지 업로드 API 연결

edit-profile/index.tsx  
프로필 수정 화면에 닉네임 중복확인 추가  
이미지 선택 즉시 로컬 미리보기 표시  
업로드된 프로필 이미지가 마이페이지에 반영되도록 저장 흐름 수정  
지역 수정 화면 이동 시 입력 중인 프로필 값 유지

region-setup/index.tsx  
지역 입력값 상태 연결  
기본 고정 지역값 제거  
확인 버튼 문구 정리

mypage/service.ts  
조회 fallback 제거  
프로필 이미지 URL 표시용 경로 정리  
프로필 저장 PATCH에서는 이미지 URL을 다시 보내지 않도록 수정

mypage/index.tsx  
프로필 수정 완료 후 마이페이지 정보 재조회  
프로필 이미지 로드 실패 시 기본 아이콘 표시  
조회 실패 시 에러 메시지 표시

apiError.ts  
백엔드 에러 응답의 message/errors.reason 공통 파싱

next.config.mjs  
/api 요청을 백엔드로 프록시  
/profile/images 요청을 백엔드 프로필 이미지 경로로 프록시

.env.example  
NEXT_PUBLIC_API_BASE_URL 예시 추가

프론트 진행 화면

회원가입(1)

<img width="475" height="657" alt="회원가입1" src="https://github.com/user-attachments/assets/b98d5292-7a65-4670-8b12-14345e8611e4" />

아이디 중복 확인(성공)

<img width="490" height="670" alt="회원가입2" src="https://github.com/user-attachments/assets/b6b60e3a-e2e0-420a-824b-00ac4b76c5dc" />

아이디 중복 확인(실패)

<img width="488" height="670" alt="번외1" src="https://github.com/user-attachments/assets/5b248d94-89d4-48aa-b13a-ffe2188e8067" />

회원가입(2)

<img width="469" height="662" alt="회원가입3" src="https://github.com/user-attachments/assets/b68be262-4f41-456b-b631-738a3b5607a0" />

데이터그립에서 저장된 모습 (프로필 정보는 null값)

<img width="968" height="50" alt="회원가입4" src="https://github.com/user-attachments/assets/7637410c-b70a-4994-9337-67d1e830f874" />

지역 설정

<img width="491" height="668" alt="회원가입45png" src="https://github.com/user-attachments/assets/91dda39d-8b91-4dfb-979d-b111c14b7caf" />

프로필 설정

<img width="473" height="666" alt="회원가입6" src="https://github.com/user-attachments/assets/7f7fb684-3e52-4fb1-a5b8-fe01c99aad92" />

닉네임 중복 확인

<img width="491" height="668" alt="회원가입7" src="https://github.com/user-attachments/assets/edbb5e34-902c-42d0-b3bc-d9a1ef0b3967" />

마이페이지에 저장과 동시에 보이는 모습

<img width="491" height="205" alt="회원가입8" src="https://github.com/user-attachments/assets/f6ff7d79-bd3e-4ee3-a9a5-9da94824276a" />

프로필 수정 + 중복 확인 안하면 확인 버튼 비활성화

<img width="485" height="666" alt="회원가입9" src="https://github.com/user-attachments/assets/ecbb764f-7bbd-4cf0-baee-29c3263fb88c" />

프로필 수정된 모습

<img width="478" height="211" alt="회원가입10" src="https://github.com/user-attachments/assets/cb706127-6b2a-4cdb-bd27-e3a28a40c62a" />

데이터그립에서의 수정 반영

<img width="967" height="53" alt="회원가입11" src="https://github.com/user-attachments/assets/bff0bddc-c750-42f6-abea-f850106dc136" />

마지막 끄적이는 말말말

전화번호, 이름, 인증은 아직 구현은 못했습니다. ㅠㅠ
회원가입 기능 보고 싶다면 백엔드 브랜치 feat/#19 랑 같이 해보세요. 
그리고 뭔가 지역 설정은 더 손 봐야할거 같습니다. (아직 어색함)

---

### 🎲 Issue Number

close #22
