### PR TITLE
[feat] 토큰 처리 중앙화 및 레거시 키 마이그레이션, 401 상태코드 처리 통합

### DIFF
--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 
 import MyPageScreen from "./index";
+import { clearAuthToken } from "@/services/auth/service";
 
 export default function MyPage() {
   const router = useRouter();
@@ -21,7 +22,10 @@ export default function MyPage() {
       onPurchaseHistoryClick={() => router.push("/mypage/purchase-history")}
       onSalesHistoryClick={() => router.push("/mypage/sales-history")}
       onBiddingClick={() => router.push("/mypage/my-bids")}
-      onLogout={() => router.push("/")}
+      onLogout={() => {
+        clearAuthToken();
+        router.push("/login");
+      }}
     />
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -80,9 +80,13 @@ import OutbidNotificationScreen from "./auctions/[auctionId]/outbid";
 import MyBidsScreen from "./(main)/mypage/my-bids";
 import SalesManagementScreen from "./(main)/mypage/sales-management";
 import { getErrorMessage } from "@/services/apiError";
-import { clearAuthToken } from "@/services/auth/service";
 import { fetchMyProfileForm, saveMyLocation } from "@/services/mypage/service";
 import { updateMyProfileDraft } from "@/services/mypage/profileDraft";
+import {
+  clearAuthToken,
+  fetchCurrentMember,
+  getAuthToken,
+} from "@/services/auth/service";
 
 export default function App() {
   const [currentScreen, setCurrentScreen] = useState<Screen>("login");
@@ -99,7 +103,8 @@ export default function App() {
   const [isEditingProfile, setIsEditingProfile] = useState(false);
   const [userLocation, setUserLocation] = useState("");
   const [isEditingLocation, setIsEditingLocation] = useState(false);
-  const [locationReturnScreen, setLocationReturnScreen] = useState<Screen | null>(null);
+  const [locationReturnScreen, setLocationReturnScreen] =
+    useState<Screen | null>(null);
   const [profileRefreshKey, setProfileRefreshKey] = useState(0);
   const [toast, setToast] = useState<{ message: string; visible: boolean }>({
     message: "",
@@ -128,6 +133,34 @@ export default function App() {
     setSelectedProductId(id);
     setCurrentScreen("product_detail");
   };
+
+  useEffect(() => {
+    const accessToken = getAuthToken();
+
+    if (!accessToken) {
+      setCurrentScreen("login");
+      return;
+    }
+
+    let ignore = false;
+
+    fetchCurrentMember()
+      .then(() => {
+        if (!ignore) {
+          setCurrentScreen("main");
+        }
+      })
+      .catch(() => {
+        if (!ignore) {
+          setCurrentTab("home");
+          setCurrentScreen("login");
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
 
   return (
     <div className="min-h-screen bg-white flex justify-center px-4 font-sans text-[#141414]">
@@ -187,7 +220,9 @@ export default function App() {
                     navigateTo("phone_auth");
                   }
                 } catch (error) {
-                  showToast(getErrorMessage(error, "지역 저장에 실패했습니다."));
+                  showToast(
+                    getErrorMessage(error, "지역 저장에 실패했습니다."),
+                  );
                 }
               }}
               onFindLocation={() => {
@@ -226,7 +261,9 @@ export default function App() {
                     navigateTo("phone_auth");
                   }
                 } catch (error) {
-                  showToast(getErrorMessage(error, "지역 저장에 실패했습니다."));
+                  showToast(
+                    getErrorMessage(error, "지역 저장에 실패했습니다."),
+                  );
                 }
               }}
             />
@@ -301,7 +338,9 @@ export default function App() {
                   updateMyProfileDraft({ location: userLocation });
                   navigateTo("edit_profile");
                 } catch (error) {
-                  showToast(getErrorMessage(error, "지역 저장에 실패했습니다."));
+                  showToast(
+                    getErrorMessage(error, "지역 저장에 실패했습니다."),
+                  );
                 }
               }}
               onFindLocation={() => {

--- a/src/services/apiError.ts
+++ b/src/services/apiError.ts
@@ -1,4 +1,17 @@
-﻿export async function getApiErrorMessage(response: Response, fallbackMessage: string) {
+﻿export class ApiRequestError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ApiRequestError";
+    this.status = status;
+  }
+}
+
+export async function getApiErrorMessage(
+  response: Response,
+  fallbackMessage: string,
+) {
   try {
     const data = await response.json();
 

--- a/src/services/auth/api.ts
+++ b/src/services/auth/api.ts
@@ -1,4 +1,4 @@
-﻿import { getApiErrorMessage } from "@/services/apiError";
+﻿import { ApiRequestError, getApiErrorMessage } from "@/services/apiError";
 import type {
   CurrentMemberResponse,
   LoginIdCheckResponse,
@@ -19,7 +19,10 @@ export async function postLogin(payload: LoginRequest): Promise<LoginResponse> {
   });
 
   if (!response.ok) {
-    throw new Error(await getApiErrorMessage(response, "로그인에 실패했습니다."));
+    throw new ApiRequestError(
+      await getApiErrorMessage(response, "로그인에 실패했습니다."),
+      response.status,
+    );
   }
 
   return response.json();
@@ -34,7 +37,10 @@ export async function getCurrentMember(
   });
 
   if (!response.ok) {
-    throw new Error(await getApiErrorMessage(response, "내 정보 조회에 실패했습니다."));
+    throw new ApiRequestError(
+      await getApiErrorMessage(response, "내 정보 조회에 실패했습니다."),
+      response.status,
+    );
   }
 
   return response.json();
@@ -52,7 +58,10 @@ export async function postSignUp(
   });
 
   if (!response.ok) {
-    throw new Error(await getApiErrorMessage(response, "회원가입에 실패했습니다."));
+    throw new ApiRequestError(
+      await getApiErrorMessage(response, "회원가입에 실패했습니다."),
+      response.status,
+    );
   }
 
   return response.json();
@@ -67,7 +76,10 @@ export async function checkLoginId(
   });
 
   if (!response.ok) {
-    throw new Error(await getApiErrorMessage(response, "아이디 중복 확인에 실패했습니다."));
+    throw new ApiRequestError(
+      await getApiErrorMessage(response, "아이디 중복 확인에 실패했습니다."),
+      response.status,
+    );
   }
 
   return response.json();
@@ -82,10 +94,11 @@ export async function checkNickname(
   });
 
   if (!response.ok) {
-    throw new Error(await getApiErrorMessage(response, "닉네임 중복 확인에 실패했습니다."));
+    throw new ApiRequestError(
+      await getApiErrorMessage(response, "닉네임 중복 확인에 실패했습니다."),
+      response.status,
+    );
   }
 
   return response.json();
 }
-
-

--- a/src/services/auth/service.ts
+++ b/src/services/auth/service.ts
@@ -1,4 +1,5 @@
-﻿import * as authApi from "@/services/auth/api";
+import { ApiRequestError } from "@/services/apiError";
+import * as authApi from "@/services/auth/api";
 import type {
   AuthResult,
   CurrentMemberResponse,
@@ -12,11 +13,74 @@ import type {
   SignUpResponse,
 } from "@/services/auth/types";
 
-const AUTH_TOKEN_STORAGE_KEY = "dealit_access_token";
-const AUTH_TOKEN_TYPE_STORAGE_KEY = "dealit_token_type";
+const ACCESS_TOKEN_STORAGE_KEY = "accessToken";
+const TOKEN_TYPE_STORAGE_KEY = "tokenType";
+const LEGACY_ACCESS_TOKEN_STORAGE_KEY = "dealit_access_token";
+const LEGACY_TOKEN_TYPE_STORAGE_KEY = "dealit_token_type";
+const DEFAULT_TOKEN_TYPE = "Bearer";
 
 function canUseStorage() {
   return typeof window !== "undefined" && Boolean(window.localStorage);
+}
+
+function normalizeTokenType(tokenType: string | null | undefined) {
+  const normalizedTokenType = tokenType?.trim();
+
+  if (normalizedTokenType === "Bearer") {
+    return normalizedTokenType;
+  }
+
+  return DEFAULT_TOKEN_TYPE;
+}
+
+function migrateLegacyTokenStorage(legacyAccessToken: string) {
+  const nextTokenType = normalizeTokenType(
+    localStorage.getItem(LEGACY_TOKEN_TYPE_STORAGE_KEY),
+  );
+
+  localStorage.setItem(ACCESS_TOKEN_STORAGE_KEY, legacyAccessToken);
+  localStorage.setItem(TOKEN_TYPE_STORAGE_KEY, nextTokenType);
+  localStorage.removeItem(LEGACY_ACCESS_TOKEN_STORAGE_KEY);
+  localStorage.removeItem(LEGACY_TOKEN_TYPE_STORAGE_KEY);
+}
+
+function getStoredTokenType() {
+  if (!canUseStorage()) {
+    return DEFAULT_TOKEN_TYPE;
+  }
+
+  const currentTokenType = localStorage.getItem(TOKEN_TYPE_STORAGE_KEY);
+
+  if (currentTokenType) {
+    return normalizeTokenType(currentTokenType);
+  }
+
+  const legacyTokenType = localStorage.getItem(LEGACY_TOKEN_TYPE_STORAGE_KEY);
+
+  if (!legacyTokenType) {
+    return DEFAULT_TOKEN_TYPE;
+  }
+
+  const nextTokenType = normalizeTokenType(legacyTokenType);
+  localStorage.setItem(TOKEN_TYPE_STORAGE_KEY, nextTokenType);
+  localStorage.removeItem(LEGACY_TOKEN_TYPE_STORAGE_KEY);
+
+  return nextTokenType;
+}
+
+function redirectToLogin() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (window.location.pathname !== "/login") {
+    window.location.href = "/login";
+  }
+}
+
+export function handleUnauthorizedAccess() {
+  clearAuthToken();
+  redirectToLogin();
 }
 
 export function saveAuthToken(loginResponse: LoginResponse) {
@@ -24,8 +88,13 @@ export function saveAuthToken(loginResponse: LoginResponse) {
     return;
   }
 
-  localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, loginResponse.accessToken);
-  localStorage.setItem(AUTH_TOKEN_TYPE_STORAGE_KEY, loginResponse.tokenType || "Bearer");
+  localStorage.setItem(ACCESS_TOKEN_STORAGE_KEY, loginResponse.accessToken);
+  localStorage.setItem(
+    TOKEN_TYPE_STORAGE_KEY,
+    normalizeTokenType(loginResponse.tokenType),
+  );
+  localStorage.removeItem(LEGACY_ACCESS_TOKEN_STORAGE_KEY);
+  localStorage.removeItem(LEGACY_TOKEN_TYPE_STORAGE_KEY);
 }
 
 export function clearAuthToken() {
@@ -33,8 +102,10 @@ export function clearAuthToken() {
     return;
   }
 
-  localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
-  localStorage.removeItem(AUTH_TOKEN_TYPE_STORAGE_KEY);
+  localStorage.removeItem(ACCESS_TOKEN_STORAGE_KEY);
+  localStorage.removeItem(TOKEN_TYPE_STORAGE_KEY);
+  localStorage.removeItem(LEGACY_ACCESS_TOKEN_STORAGE_KEY);
+  localStorage.removeItem(LEGACY_TOKEN_TYPE_STORAGE_KEY);
 }
 
 export function getAuthToken() {
@@ -42,7 +113,23 @@ export function getAuthToken() {
     return null;
   }
 
-  return localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+  const currentAccessToken = localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY);
+
+  if (currentAccessToken) {
+    return currentAccessToken;
+  }
+
+  const legacyAccessToken = localStorage.getItem(
+    LEGACY_ACCESS_TOKEN_STORAGE_KEY,
+  );
+
+  if (!legacyAccessToken) {
+    return null;
+  }
+
+  migrateLegacyTokenStorage(legacyAccessToken);
+
+  return legacyAccessToken;
 }
 
 export function getAuthorizationHeaders(): Record<string, string> {
@@ -52,12 +139,8 @@ export function getAuthorizationHeaders(): Record<string, string> {
     return {};
   }
 
-  const tokenType = canUseStorage()
-    ? localStorage.getItem(AUTH_TOKEN_TYPE_STORAGE_KEY) || "Bearer"
-    : "Bearer";
-
   return {
-    Authorization: `${tokenType} ${accessToken}`,
+    Authorization: `${getStoredTokenType()} ${accessToken}`,
   };
 }
 
@@ -131,7 +214,15 @@ export async function login(
 }
 
 export async function fetchCurrentMember(): Promise<CurrentMemberResponse> {
-  return authApi.getCurrentMember(getAuthorizationHeaders());
+  try {
+    return await authApi.getCurrentMember(getAuthorizationHeaders());
+  } catch (error) {
+    if (error instanceof ApiRequestError && error.status === 401) {
+      handleUnauthorizedAccess();
+    }
+
+    throw error;
+  }
 }
 
 export async function signUp(

--- a/src/services/mypage/api.ts
+++ b/src/services/mypage/api.ts
@@ -1,5 +1,8 @@
-import { getApiErrorMessage } from "@/services/apiError";
-import { getAuthorizationHeaders } from "@/services/auth/service";
+import { ApiRequestError, getApiErrorMessage } from "@/services/apiError";
+import {
+  getAuthorizationHeaders,
+  handleUnauthorizedAccess,
+} from "@/services/auth/service";
 import type {
   MyProfileResponse,
   UpdateMyLocationRequest,
@@ -8,6 +11,20 @@ import type {
   UploadProfileImageResponse,
 } from "@/services/mypage/types";
 
+async function throwProtectedApiError(
+  response: Response,
+  fallbackMessage: string,
+) {
+  if (response.status === 401) {
+    handleUnauthorizedAccess();
+  }
+
+  throw new ApiRequestError(
+    await getApiErrorMessage(response, fallbackMessage),
+    response.status,
+  );
+}
+
 export async function getMyProfile(): Promise<MyProfileResponse> {
   const response = await fetch("/api/v1/users/me/mypage", {
     method: "GET",
@@ -15,7 +32,7 @@ export async function getMyProfile(): Promise<MyProfileResponse> {
   });
 
   if (!response.ok) {
-    throw new Error(await getApiErrorMessage(response, "마이페이지 조회에 실패했습니다."));
+    await throwProtectedApiError(response, "마이페이지 조회에 실패했습니다.");
   }
 
   return response.json();
@@ -34,7 +51,7 @@ export async function updateMyProfile(
   });
 
   if (!response.ok) {
-    throw new Error(await getApiErrorMessage(response, "프로필 저장에 실패했습니다."));
+    await throwProtectedApiError(response, "프로필 저장에 실패했습니다.");
   }
 
   return response.json();
@@ -53,7 +70,7 @@ export async function updateMyLocation(
   });
 
   if (!response.ok) {
-    throw new Error(await getApiErrorMessage(response, "지역 저장에 실패했습니다."));
+    await throwProtectedApiError(response, "지역 저장에 실패했습니다.");
   }
 
   return response.json();
@@ -72,7 +89,10 @@ export async function uploadProfileImage(
   });
 
   if (!response.ok) {
-    throw new Error(await getApiErrorMessage(response, "프로필 이미지 업로드에 실패했습니다."));
+    await throwProtectedApiError(
+      response,
+      "프로필 이미지 업로드에 실패했습니다.",
+    );
   }
 
   return response.json();


### PR DESCRIPTION


### 🚀 Summary

- JWT Access Token 기반 1차 인증 연동을 프론트엔드에 적용했습니다.  
- 토큰 저장/조회/삭제 로직을 `auth/service.ts`에 정리하고, 보호 API 요청에서 `Authorization` 헤더를 공통으로 붙이며, 401 응답 시 로그아웃/리다이렉트가 일관되게 동작하도록 개선했습니다.  
- 또한 기존 저장 키(`dealit_*`)에서 신규 키(`accessToken`, `tokenType`)로의 점진적 마이그레이션을 추가해 배포 시 기존 로그인 세션 단절을 최소화했습니다.
---

### ✨ Description
- ApiRequestError 추가로 API 실패 시 HTTP status를 함께 전달하도록 개선
- auth API 레이어에서 비정상 응답(non-2xx) 시 ApiRequestError를 throw하도록 통일
- auth service 토큰 처리 로직 정리
 - 저장 키를 accessToken/tokenType으로 통일
 - tokenType 화이트리스트(Bearer) + fallback 적용
 - 레거시 키(dealit_*) fallback 조회 및 즉시 마이그레이션 추가
 - 로그아웃/비인가 처리 시 신/구 키 모두 삭제
- mypage 보호 API의 401 처리 로직을 status 기반으로 통합
- 앱 시작 시(/) accessToken + /auth/me 기반 세션 복원(useEffect) 추가
- 마이페이지 로그아웃 시 토큰 삭제 후 /login 이동하도록 수정
#### 1) 인증/토큰 처리
- 로그인 성공 시 `accessToken`, `tokenType` 저장.
- `tokenType`은 화이트리스트 방식으로 `Bearer`만 허용, 그 외 값은 `Bearer` fallback 처리.
- 신규 키 우선 조회 후, 없으면 구 키(`dealit_access_token`, `dealit_token_type`) fallback 조회 및 즉시 신규 키로 이관.
- 로그아웃/비인가 처리 시 신규+구 키 모두 삭제.

#### 2) 보호 API 처리
- 보호 API에서 공통으로 Authorization 헤더(`Authorization: Bearer <token>`)가 붙도록 처리.
- 보호 API 응답이 401이면 공통 처리 함수로 토큰 정리 후 `/login`으로 이동.
- `ApiRequestError`를 도입해 상태코드 기반 에러 분기가 가능하도록 개선.

#### 3) 앱 진입/세션 복원
- 앱 시작 시 저장된 토큰 존재 여부 확인 후 `/api/v1/auth/me` 호출로 로그인 상태 복원.
- 유효 토큰이면 메인 화면 유지, 실패 시 로그인 화면 이동.

#### 4) 점검 결과
- [x] localStorage에 `accessToken`, `tokenType` 저장 확인
- [x] 보호 API 요청 시 Authorization 헤더 포함 확인 (DevTools Network)
- [x] 새로고침 후 세션 복원 동작 확인
- [x] 401 상황에서 토큰 삭제 + 로그인 화면 이동 확인
- [x] 로그아웃 시 토큰 삭제 + 로그인 화면 이동 확인

1. 로그인시 access Token과 토큰 타입을 확인할 수 있습니다 f12 -> Application -> Local Storage
<img width="1167" height="163" alt="인증토큰디테일" src="https://github.com/user-attachments/assets/201e3ae1-cf78-4c4a-b89f-52b8423bee46" />

2. 인증 확인 헤더
<img width="1149" height="94" alt="인증확인헤더" src="https://github.com/user-attachments/assets/2a8d0e53-4eca-4942-9236-c0dd1fc67248" />

3. 강제로 401 에러를 유발하기 위해 access Token을 훼손
<img width="1358" height="436" alt="에러유발" src="https://github.com/user-attachments/assets/7a5d7e8e-1387-424a-a112-6d83ad1a5f66" />

4. 401 에러 발생 후 화면 나가짐 + 토큰 사라짐(확인됨)
<img width="1155" height="890" alt="에러발생나가짐" src="https://github.com/user-attachments/assets/ff15affb-e529-4c27-a7e7-450e0b19fdae" />

<img width="568" height="145" alt="에러검증" src="https://github.com/user-attachments/assets/4b2fa009-6331-4122-b1dd-46702925ca8c" />

#### 참고 변경 파일
- `src/services/auth/service.ts` (토큰 저장/조회/이관/헤더/401 처리)
- `src/services/auth/api.ts` (`ApiRequestError` 기반 에러 처리)
- `src/services/mypage/api.ts` (보호 API 401 공통 처리)
- `src/services/apiError.ts` (`ApiRequestError` 추가)
- `src/app/page.tsx` (초기 세션 복원)
- `src/app/(main)/mypage/page.tsx` (로그아웃 처리)
---

### 🎲 Issue Number

close #{28}
