### PR TITLE
feat. 판매 관리 기능 구조 구성 및 백엔드 API 연동 흐름 정리

### DIFF
--- a/src/app/(main)/mypage/index.tsx
+++ b/src/app/(main)/mypage/index.tsx
@@ -16,10 +16,7 @@ import {
 import { AnimatePresence, motion } from "motion/react";
 
 import { getErrorMessage } from "@/services/apiError";
-import {
-  fetchMyPageProfile,
-  fetchMySellingAuctionCount,
-} from "@/services/mypage/service";
+import { fetchMyPageProfile } from "@/services/mypage/service";
 import type { MyPageProfileViewModel } from "@/services/mypage/types";
 
 interface MyPageScreenProps {
@@ -56,9 +53,6 @@ export default function MyPageScreen({
   refreshKey = 0,
 }: MyPageScreenProps) {
   const [profile, setProfile] = useState<MyPageProfileViewModel | null>(null);
-  const [sellingAuctionCount, setSellingAuctionCount] = useState<number | null>(
-    null,
-  );
   const [profileErrorMessage, setProfileErrorMessage] = useState("");
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
 
@@ -81,25 +75,12 @@ export default function MyPageScreen({
         }
       });
 
-    fetchMySellingAuctionCount()
-      .then((nextCount) => {
-        if (!ignore) {
-          setSellingAuctionCount(nextCount);
-        }
-      })
-      .catch((error) => {
-        console.error("Failed to fetch selling auction count", error);
-        if (!ignore) {
-          setSellingAuctionCount(null);
-        }
-      });
-
     return () => {
       ignore = true;
     };
   }, [refreshKey]);
 
-  const sellingCount = sellingAuctionCount ?? profile?.sellingCount ?? 0;
+  const sellingCount = profile?.sellingCount ?? 0;
 
   const menus = [
     { icon: <ShoppingBag size={20} />, label: "구매 내역", onClick: onPurchaseHistoryClick },

--- a/src/app/(main)/mypage/sales-management/index.tsx
+++ b/src/app/(main)/mypage/sales-management/index.tsx
@@ -186,6 +186,11 @@ export default function SalesManagementScreen({
                 editingItem.product.productId,
                 draft,
               ),
+            update: (draft) =>
+              updateRegularSalesManagementProduct(
+                editingItem.product.productId,
+                draft,
+              ),
           },
           auction: {
             getCategories: getAuctionCategories,
@@ -194,6 +199,11 @@ export default function SalesManagementScreen({
             saveDraft: saveAuctionDraft,
             recommendPrice: recommendAuctionPrice,
             register: (draft) =>
+              updateAuctionSalesManagementProduct(
+                editingItem.product.auctionId ?? editingItem.product.productId,
+                draft,
+              ),
+            update: (draft) =>
               updateAuctionSalesManagementProduct(
                 editingItem.product.auctionId ?? editingItem.product.productId,
                 draft,

--- a/src/app/(main)/mypage/sales-management/index.tsx
+++ b/src/app/(main)/mypage/sales-management/index.tsx
@@ -252,7 +252,7 @@ export default function SalesManagementScreen({
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto no-scrollbar p-6 space-y-6">
+      <div className="flex-1 overflow-y-auto no-scrollbar p-6 space-y-4">
         {errorMessage && (
           <div className="rounded-lg bg-red-50 px-4 py-3 text-xs text-red-500">
             {errorMessage}
@@ -262,7 +262,9 @@ export default function SalesManagementScreen({
         {isLoading ? (
           <div className="flex flex-col items-center justify-center h-64 text-gray-400 space-y-2">
             <ShoppingBag size={48} className="opacity-20" />
-            <p className="text-sm font-medium">판매 중인 상품을 불러오는 중입니다</p>
+            <p className="text-sm font-medium">
+              판매 중인 상품을 불러오는 중입니다
+            </p>
           </div>
         ) : filteredProducts.length > 0 ? (
           filteredProducts.map((item) => (
@@ -270,50 +272,40 @@ export default function SalesManagementScreen({
               key={item.id}
               className="p-4 bg-white border border-gray-100 rounded-2xl space-y-4"
             >
-              <div className="flex items-center space-x-4">
-                <div className="w-20 h-20 rounded-xl overflow-hidden bg-gray-50 shrink-0">
+              <div className="flex items-start space-x-4">
+                <div className="w-24 h-24 rounded-lg overflow-hidden bg-gray-50 shrink-0">
                   <ProductImage imageUrl={item.imageUrl} name={item.name} />
                 </div>
-                <div className="flex-1 min-w-0 space-y-1">
-                  <div className="flex items-center space-x-2">
-                    <span className="text-[10px] font-bold px-1.5 py-0.5 bg-gray-100 rounded text-gray-500">
+                <div className="flex-1 min-w-0 pt-1 space-y-2">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[11px] font-bold px-2 py-1 bg-gray-100 rounded text-gray-500">
                       {getTypeLabel(item.type)}
                     </span>
-                    <span
-                      className="text-[10px] font-bold px-1.5 py-0.5 rounded"
-                      style={{
-                        backgroundColor: `${themeColor}22`,
-                        color: "#3C6B12",
-                      }}
-                    >
+                    <span className="text-[11px] font-bold px-2 py-1 bg-blue-50 text-blue-600 rounded">
                       {item.statusLabel}
                     </span>
                     {item.bidders !== null && (
-                      <span className="text-[10px] font-bold px-1.5 py-0.5 bg-gray-100 rounded text-gray-500">
+                      <span className="text-[11px] font-bold px-2 py-1 bg-purple-50 text-purple-600 rounded">
                         입찰 {item.bidders}명
                       </span>
                     )}
-                    {item.bidderCount !== null && item.bidderCount > 0 && (
-                      <span className="text-[10px] font-bold px-1.5 py-0.5 bg-gray-100 rounded text-gray-500">
-                        참여 {item.bidderCount}명
-                      </span>
-                    )}
                   </div>
-                  <h4 className="font-bold text-sm truncate">{item.name}</h4>
-                  <p className="font-black text-sm">{item.priceLabel}</p>
-                  <p className="text-[11px] text-gray-400 truncate">
-                    {item.location
-                      ? `${item.category} · ${item.location}`
-                      : item.category}
-                  </p>
+                  <h4 className="font-bold text-base truncate">{item.name}</h4>
+                  <p className="font-black text-lg">{item.priceLabel}</p>
+                  {item.location && (
+                    <p className="text-[11px] text-gray-400 truncate">
+                      {item.category} · {item.location}
+                    </p>
+                  )}
                 </div>
               </div>
-              <div className="flex space-x-2">
+
+              <div className="grid grid-cols-2 gap-3">
                 <button
                   type="button"
                   onClick={() => handleEditClick(item)}
                   disabled={!item.editable || editingProductId === item.id}
-                  className="flex-1 py-3 bg-gray-50 rounded-xl text-xs font-bold transition-colors disabled:text-gray-300 enabled:hover:bg-gray-100"
+                  className="h-14 bg-gray-50 rounded-xl text-sm font-bold transition-colors disabled:text-gray-300 enabled:hover:bg-gray-100"
                 >
                   {editingProductId === item.id ? "불러오는 중" : "수정"}
                 </button>
@@ -321,7 +313,7 @@ export default function SalesManagementScreen({
                   type="button"
                   onClick={() => setItemToDelete(item)}
                   disabled={!item.deletable}
-                  className="flex-1 py-3 bg-gray-50 rounded-xl text-xs font-bold text-red-500 transition-colors disabled:text-gray-300 enabled:hover:bg-gray-100"
+                  className="h-14 bg-gray-50 rounded-xl text-sm font-bold text-red-500 transition-colors disabled:text-gray-300 enabled:hover:bg-gray-100"
                 >
                   삭제
                 </button>

--- a/src/app/(main)/mypage/sales-management/index.tsx
+++ b/src/app/(main)/mypage/sales-management/index.tsx
@@ -1,72 +1,205 @@
 "use client";
-import React, { useState, useEffect } from 'react';
-import { 
-  ChevronLeft, 
-  Check, 
-  ChevronRight, 
-  User, 
-  Camera, 
-  Search, 
-  Home, 
-  PlusCircle, 
-  MessageCircle, 
-  Heart, 
-  Bell, 
-  Filter, 
-  Settings,
-  MoreVertical, 
-  Send, 
-  Star,
-  Clock,
-  ArrowUpRight,
-  X,
-  Trash2,
-  Eye,
-  Image as ImageIcon,
-  ArrowLeft,
-  TrendingUp,
-  Sparkles,
-  Menu,
-  ShoppingBag,
-  Store,
-  Receipt
-} from 'lucide-react';
-import { motion, AnimatePresence } from 'motion/react';
 
-import { Screen, Tab } from '../../../../types/index';
-import { ExploreIcon } from '../../../../components/common/ExploreIcon';
-import AuctionRegisterScreen from '../../../products/register/AuctionRegisterScreen';
-import RegularRegisterScreen from '../../../products/register/RegularRegisterScreen';
+import { useEffect, useState } from "react";
+import { ChevronLeft, ImageIcon, ShoppingBag } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
 
-export default function SalesManagementScreen({ onBack, themeColor }: { onBack: () => void; themeColor: string; key?: string }) {
-  const [products, setProducts] = useState([
-    { id: 1, name: '아이폰 14 Pro', type: 'regular', status: '판매 중', price: '850,000원', img: 'https://picsum.photos/seed/p1/200/200', description: '거의 새것입니다. 풀박스입니다.', category: '전자기기' },
-    { id: 2, name: '맥북 에어 M2', type: 'auction', status: '경매 중', price: '1,200,000원', img: 'https://picsum.photos/seed/p2/200/200', description: '배터리 사이클 10회 미만입니다.', category: '전자기기', bidders: 3 },
-    { id: 3, name: '에어팟 프로 2세대', type: 'auction', status: '경매 중', price: '200,000원', img: 'https://picsum.photos/seed/p3/200/200', description: '미개봉 새상품입니다.', category: '전자기기', bidders: 0 },
-  ]);
-  const [filter, setFilter] = useState<'all' | 'regular' | 'auction'>('all');
-  const [itemToDelete, setItemToDelete] = useState<number | null>(null);
-  const [editingItem, setEditingItem] = useState<any>(null);
+import { getErrorMessage } from "@/services/apiError";
+import {
+  deleteSalesManagementProduct,
+  fetchAuctionSalesManagementEditInitialData,
+  fetchRegularSalesManagementEditInitialData,
+  fetchSalesManagementProducts,
+  updateAuctionSalesManagementProduct,
+  updateRegularSalesManagementProduct,
+} from "@/services/sales-management/service";
+import type { SalesManagementItemViewModel } from "@/services/sales-management/types";
+import RegisterScreen from "../../../products/register/RegisterScreen";
+import {
+  deleteAuctionImage,
+  getAuctionCategories,
+  recommendAuctionPrice,
+  saveAuctionDraft,
+  uploadAuctionImage,
+} from "@/services/auction/register/service";
+import {
+  deleteRegularProductImage,
+  getRegularProductCategories,
+  recommendRegularProductPrice,
+  saveRegularProductDraft,
+  uploadRegularProductImage,
+} from "@/services/product/register/service";
 
-  const handleDeleteConfirm = () => {
-    if (itemToDelete !== null) {
-      setProducts(products.filter(p => p.id !== itemToDelete));
-      setItemToDelete(null);
+type SalesManagementFilter = "all" | "regular" | "auction";
+
+interface SalesManagementScreenProps {
+  onBack: () => void;
+  themeColor: string;
+  key?: string;
+}
+
+function getFilterLabel(filter: SalesManagementFilter) {
+  if (filter === "regular") {
+    return "일반";
+  }
+
+  if (filter === "auction") {
+    return "경매";
+  }
+
+  return "전체";
+}
+
+function getTypeLabel(type: SalesManagementItemViewModel["type"]) {
+  return type === "auction" ? "경매" : "일반";
+}
+
+function ProductImage({
+  imageUrl,
+  name,
+}: {
+  imageUrl: string | null;
+  name: string;
+}) {
+  if (imageUrl) {
+    return (
+      <img src={imageUrl} alt={name} className="w-full h-full object-cover" />
+    );
+  }
+
+  return (
+    <div className="w-full h-full flex items-center justify-center bg-gray-100 text-gray-300">
+      <ImageIcon size={24} />
+    </div>
+  );
+}
+
+export default function SalesManagementScreen({
+  onBack,
+  themeColor,
+}: SalesManagementScreenProps) {
+  const [products, setProducts] = useState<SalesManagementItemViewModel[]>([]);
+  const [filter, setFilter] = useState<SalesManagementFilter>("all");
+  const [itemToDelete, setItemToDelete] =
+    useState<SalesManagementItemViewModel | null>(null);
+  const [editingItem, setEditingItem] = useState<{
+    product: SalesManagementItemViewModel;
+    initialData: any;
+  } | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [editingProductId, setEditingProductId] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const loadProducts = async () => {
+    setIsLoading(true);
+    setErrorMessage("");
+
+    try {
+      setProducts(await fetchSalesManagementProducts());
+    } catch (error) {
+      setProducts([]);
+      setErrorMessage(
+        getErrorMessage(error, "판매 중인 상품을 불러오지 못했습니다."),
+      );
+    } finally {
+      setIsLoading(false);
     }
   };
 
-  const filteredProducts = products.filter(p => filter === 'all' || p.type === filter);
+  useEffect(() => {
+    loadProducts();
+  }, []);
+
+  const handleDeleteConfirm = async () => {
+    if (!itemToDelete || isDeleting) {
+      return;
+    }
+
+    setIsDeleting(true);
+
+    try {
+      await deleteSalesManagementProduct(itemToDelete);
+      setProducts((currentProducts) =>
+        currentProducts.filter((product) => product.id !== itemToDelete.id),
+      );
+      setItemToDelete(null);
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error, "상품 삭제에 실패했습니다."));
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleEditClick = async (product: SalesManagementItemViewModel) => {
+    if (!product.editable || editingProductId) {
+      return;
+    }
+
+    setEditingProductId(product.id);
+    setErrorMessage("");
+
+    try {
+      const initialData =
+        product.type === "auction"
+          ? await fetchAuctionSalesManagementEditInitialData(
+              product.auctionId ?? product.productId,
+            )
+          : await fetchRegularSalesManagementEditInitialData(product.productId);
+
+      setEditingItem({ product, initialData });
+    } catch (error) {
+      setErrorMessage(
+        getErrorMessage(error, "상품 수정 정보를 불러오지 못했습니다."),
+      );
+    } finally {
+      setEditingProductId(null);
+    }
+  };
+
+  const filteredProducts = products.filter(
+    (product) => filter === "all" || product.type === filter,
+  );
 
   if (editingItem) {
-    const RegisterComponent =
-      editingItem.type === 'auction' ? AuctionRegisterScreen : RegularRegisterScreen;
-
     return (
-      <RegisterComponent 
-        onBack={() => setEditingItem(null)} 
-        onComplete={() => setEditingItem(null)} 
-        themeColor={themeColor} 
-        initialData={editingItem} 
+      <RegisterScreen
+        onBack={() => setEditingItem(null)}
+        onComplete={() => {
+          setEditingItem(null);
+          void loadProducts();
+        }}
+        themeColor={themeColor}
+        mode={editingItem.product.type}
+        initialData={editingItem.initialData}
+        getCategories={getAuctionCategories}
+        servicesByType={{
+          regular: {
+            getCategories: getRegularProductCategories,
+            uploadImage: uploadRegularProductImage,
+            deleteImage: deleteRegularProductImage,
+            saveDraft: saveRegularProductDraft,
+            recommendPrice: ({ name, description }) =>
+              recommendRegularProductPrice({ name, description }),
+            register: (draft) =>
+              updateRegularSalesManagementProduct(
+                editingItem.product.productId,
+                draft,
+              ),
+          },
+          auction: {
+            getCategories: getAuctionCategories,
+            uploadImage: uploadAuctionImage,
+            deleteImage: deleteAuctionImage,
+            saveDraft: saveAuctionDraft,
+            recommendPrice: recommendAuctionPrice,
+            register: (draft) =>
+              updateAuctionSalesManagementProduct(
+                editingItem.product.auctionId ?? editingItem.product.productId,
+                draft,
+              ),
+          },
+        }}
       />
     );
   }
@@ -79,78 +212,109 @@ export default function SalesManagementScreen({ onBack, themeColor }: { onBack: 
       className="flex-1 flex flex-col relative"
     >
       <div className="h-16 flex items-center px-4 border-b border-gray-100">
-        <button onClick={onBack} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+        <button
+          onClick={onBack}
+          className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+          aria-label="뒤로가기"
+        >
           <ChevronLeft size={24} />
         </button>
-        <h1 className="flex-1 text-center font-bold text-lg mr-10">판매 관리</h1>
+        <h1 className="flex-1 text-center font-bold text-lg mr-10">
+          판매 관리
+        </h1>
       </div>
 
-      {/* Filter Toggle */}
       <div className="px-6 pt-6">
         <div className="flex bg-gray-100 p-1 rounded-xl">
-          {(['all', 'regular', 'auction'] as const).map((f) => (
+          {(["all", "regular", "auction"] as const).map((nextFilter) => (
             <button
-              key={f}
-              onClick={() => setFilter(f)}
+              key={nextFilter}
+              onClick={() => setFilter(nextFilter)}
               className={`flex-1 py-2 text-xs font-bold rounded-lg transition-all ${
-                filter === f 
-                  ? 'bg-white text-black shadow-sm' 
-                  : 'text-gray-400 hover:text-gray-600'
+                filter === nextFilter
+                  ? "bg-white text-black shadow-sm"
+                  : "text-gray-400 hover:text-gray-600"
               }`}
             >
-              {f === 'all' ? '전체' : f === 'regular' ? '일반' : '경매'}
+              {getFilterLabel(nextFilter)}
             </button>
           ))}
         </div>
       </div>
 
       <div className="flex-1 overflow-y-auto no-scrollbar p-6 space-y-6">
-        {filteredProducts.length > 0 ? (
+        {errorMessage && (
+          <div className="rounded-lg bg-red-50 px-4 py-3 text-xs text-red-500">
+            {errorMessage}
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="flex flex-col items-center justify-center h-64 text-gray-400 space-y-2">
+            <ShoppingBag size={48} className="opacity-20" />
+            <p className="text-sm font-medium">판매 중인 상품을 불러오는 중입니다</p>
+          </div>
+        ) : filteredProducts.length > 0 ? (
           filteredProducts.map((item) => (
-            <div key={item.id} className="p-4 bg-white border border-gray-100 rounded-2xl space-y-4">
+            <div
+              key={item.id}
+              className="p-4 bg-white border border-gray-100 rounded-2xl space-y-4"
+            >
               <div className="flex items-center space-x-4">
                 <div className="w-20 h-20 rounded-xl overflow-hidden bg-gray-50 shrink-0">
-                  <img src={item.img} alt={item.name} className="w-full h-full object-cover" />
+                  <ProductImage imageUrl={item.imageUrl} name={item.name} />
                 </div>
                 <div className="flex-1 min-w-0 space-y-1">
                   <div className="flex items-center space-x-2">
                     <span className="text-[10px] font-bold px-1.5 py-0.5 bg-gray-100 rounded text-gray-500">
-                      {item.type === 'regular' ? '일반' : '경매'}
+                      {getTypeLabel(item.type)}
                     </span>
-                    <span className="text-[10px] font-bold px-1.5 py-0.5 bg-blue-50 text-blue-600 rounded">
-                      {item.status}
+                    <span
+                      className="text-[10px] font-bold px-1.5 py-0.5 rounded"
+                      style={{
+                        backgroundColor: `${themeColor}22`,
+                        color: "#3C6B12",
+                      }}
+                    >
+                      {item.statusLabel}
                     </span>
-                    {item.type === 'auction' && item.bidders !== undefined && (
-                      <span className="text-[10px] font-bold px-1.5 py-0.5 bg-purple-50 text-purple-600 rounded">
+                    {item.bidders !== null && (
+                      <span className="text-[10px] font-bold px-1.5 py-0.5 bg-gray-100 rounded text-gray-500">
                         입찰 {item.bidders}명
+                      </span>
+                    )}
+                    {item.bidderCount !== null && item.bidderCount > 0 && (
+                      <span className="text-[10px] font-bold px-1.5 py-0.5 bg-gray-100 rounded text-gray-500">
+                        참여 {item.bidderCount}명
                       </span>
                     )}
                   </div>
                   <h4 className="font-bold text-sm truncate">{item.name}</h4>
-                  <p className="font-black text-sm">{item.price}</p>
+                  <p className="font-black text-sm">{item.priceLabel}</p>
+                  <p className="text-[11px] text-gray-400 truncate">
+                    {item.location
+                      ? `${item.category} · ${item.location}`
+                      : item.category}
+                  </p>
                 </div>
               </div>
               <div className="flex space-x-2">
-                {item.type === 'regular' || (item.type === 'auction' && item.bidders === 0) ? (
-                  <>
-                    <button 
-                      onClick={() => setEditingItem(item)}
-                      className="flex-1 py-3 bg-gray-50 hover:bg-gray-100 rounded-xl text-xs font-bold transition-colors"
-                    >
-                      수정
-                    </button>
-                    <button 
-                      onClick={() => setItemToDelete(item.id)}
-                      className="flex-1 py-3 bg-gray-50 hover:bg-gray-100 rounded-xl text-xs font-bold text-red-500 transition-colors"
-                    >
-                      삭제
-                    </button>
-                  </>
-                ) : (
-                  <div className="flex-1 py-3 bg-gray-50 rounded-xl text-xs font-bold text-gray-400 text-center">
-                    입찰자가 있어 수정 및 삭제가 불가능합니다
-                  </div>
-                )}
+                <button
+                  type="button"
+                  onClick={() => handleEditClick(item)}
+                  disabled={!item.editable || editingProductId === item.id}
+                  className="flex-1 py-3 bg-gray-50 rounded-xl text-xs font-bold transition-colors disabled:text-gray-300 enabled:hover:bg-gray-100"
+                >
+                  {editingProductId === item.id ? "불러오는 중" : "수정"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setItemToDelete(item)}
+                  disabled={!item.deletable}
+                  className="flex-1 py-3 bg-gray-50 rounded-xl text-xs font-bold text-red-500 transition-colors disabled:text-gray-300 enabled:hover:bg-gray-100"
+                >
+                  삭제
+                </button>
               </div>
             </div>
           ))
@@ -162,11 +326,10 @@ export default function SalesManagementScreen({ onBack, themeColor }: { onBack: 
         )}
       </div>
 
-      {/* Delete Confirmation Modal */}
       <AnimatePresence>
         {itemToDelete !== null && (
           <div className="absolute inset-0 z-50 flex items-center justify-center p-4">
-            <motion.div 
+            <motion.div
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
@@ -179,19 +342,26 @@ export default function SalesManagementScreen({ onBack, themeColor }: { onBack: 
               exit={{ opacity: 0, scale: 0.95 }}
               className="bg-white rounded-2xl p-6 w-full max-w-sm relative z-10 shadow-xl"
             >
-              <h3 className="text-lg font-bold text-center mb-6">삭제하겠습니까?</h3>
+              <h3 className="text-lg font-bold text-center mb-2">
+                삭제하시겠습니까?
+              </h3>
+              <p className="text-sm text-gray-400 text-center mb-6">
+                {itemToDelete.name}
+              </p>
               <div className="flex space-x-3">
-                <button 
+                <button
                   onClick={handleDeleteConfirm}
-                  className="flex-1 py-3 bg-red-500 text-white rounded-xl font-bold hover:bg-red-600 transition-colors"
+                  disabled={isDeleting}
+                  className="flex-1 py-3 bg-red-500 text-white rounded-xl font-bold hover:bg-red-600 transition-colors disabled:opacity-60"
                 >
-                  예
+                  {isDeleting ? "삭제 중" : "삭제"}
                 </button>
-                <button 
+                <button
                   onClick={() => setItemToDelete(null)}
-                  className="flex-1 py-3 bg-gray-100 text-gray-700 rounded-xl font-bold hover:bg-gray-200 transition-colors"
+                  disabled={isDeleting}
+                  className="flex-1 py-3 bg-gray-100 text-gray-700 rounded-xl font-bold hover:bg-gray-200 transition-colors disabled:opacity-60"
                 >
-                  아니오
+                  취소
                 </button>
               </div>
             </motion.div>

--- a/src/app/products/register/RegisterScreen.tsx
+++ b/src/app/products/register/RegisterScreen.tsx
@@ -49,6 +49,9 @@ export interface RegisterScreenServices {
   register: (draft: AuctionRegisterDraft) => Promise<unknown>;
 }
 
+const MAX_PRICE_DIGITS = 13;
+const MAX_PRICE_VALUE = 9_999_999_999_999;
+
 function normalizeInitialImages(initialData: any): ProductImagePayload[] {
   if (!initialData) {
     return [];
@@ -155,16 +158,30 @@ export default function RegisterScreen({
     number | null
   >(null);
   const [price, setPrice] = useState(
-    initialData?.price ? initialData.price.replace(/[^0-9]/g, "") : "",
+    initialData?.price ? String(initialData.price).replace(/[^0-9]/g, "") : "",
   );
   const [description, setDescription] = useState(initialData?.description || "");
   const [location, setLocation] = useState(initialData?.location || "");
   const [images, setImages] = useState<ProductImagePayload[]>(
     normalizeInitialImages(initialData),
   );
-  const [auction, setAuction] = useState<AuctionFormValues>(
-    createDefaultAuctionForm(),
-  );
+  const [auction, setAuction] = useState<AuctionFormValues>(() => ({
+    ...createDefaultAuctionForm(),
+    ...initialData?.auction,
+    startPrice:
+      initialData?.auction?.startPrice ??
+      initialData?.startPrice ??
+      initialData?.price ??
+      "",
+    bidUnit: calculateBidUnit(
+      String(
+        initialData?.auction?.startPrice ??
+          initialData?.startPrice ??
+          initialData?.price ??
+          "",
+      ),
+    ),
+  }));
   const [isUploadingImage, setIsUploadingImage] = useState(false);
   const [deletingImageIds, setDeletingImageIds] = useState<number[]>([]);
   const [isSavingDraft, setIsSavingDraft] = useState(false);
@@ -368,6 +385,11 @@ export default function RegisterScreen({
       return;
     }
 
+    if (Number(price) > MAX_PRICE_VALUE) {
+      showErrorMessage("가격은 9,999,999,999,999원 이하로 입력해 주세요.");
+      return;
+    }
+
     if (!description.trim()) {
       showErrorMessage("상품 설명을 입력해 주세요.");
       return;
@@ -480,7 +502,7 @@ export default function RegisterScreen({
       return;
     }
 
-    if (targetImage.imageId > 0) {
+    if (targetImage.imageId > 0 && !isEditMode) {
       setDeletingImageIds((currentIds) => [...currentIds, targetImage.imageId]);
 
       try {
@@ -503,7 +525,7 @@ export default function RegisterScreen({
         })),
     );
 
-    if (targetImage.imageId > 0) {
+    if (targetImage.imageId > 0 && !isEditMode) {
       setDeletingImageIds((currentIds) =>
         currentIds.filter((imageId) => imageId !== targetImage.imageId),
       );
@@ -549,7 +571,7 @@ export default function RegisterScreen({
   };
 
   const handlePriceChange = (value: string) => {
-    const numericValue = sanitizeNumericInput(value);
+    const numericValue = sanitizeNumericInput(value).slice(0, MAX_PRICE_DIGITS);
     setPrice(numericValue);
 
     if (saleType === "auction") {

--- a/src/app/products/register/RegisterScreen.tsx
+++ b/src/app/products/register/RegisterScreen.tsx
@@ -229,6 +229,14 @@ export default function RegisterScreen({
     showCategoryError &&
     (!isCategorySelectionComplete || !!categoryLoadError || isLoadingCategories);
 
+  const getEffectiveImages = () => {
+    if (images.length > 0) {
+      return images;
+    }
+
+    return isEditMode ? normalizeInitialImages(initialData) : images;
+  };
+
   const showErrorMessage = (message: string) => {
     if (typeof window !== "undefined") {
       window.alert(message);
@@ -331,7 +339,7 @@ export default function RegisterScreen({
       price,
       startPrice: price,
       description,
-      images,
+      images: getEffectiveImages(),
       categoryId,
       allowOffer: false,
       location,
@@ -405,7 +413,7 @@ export default function RegisterScreen({
       return;
     }
 
-    if (images.length === 0) {
+    if (getEffectiveImages().length === 0) {
       showErrorMessage("상품 이미지를 1장 이상 등록해 주세요.");
       return;
     }

--- a/src/services/mypage/service.ts
+++ b/src/services/mypage/service.ts
@@ -4,6 +4,7 @@ import {
 } from "@/services/location/service";
 import type { LocationFormValues } from "@/services/location/types";
 import * as mypageApi from "@/services/mypage/api";
+import { fetchSalesManagementCount } from "@/services/sales-management/service";
 import type {
   MyProfileEditViewModel,
   MyPageProfileViewModel,
@@ -111,6 +112,7 @@ export function toMyProfileEditViewModel(
 
 export function toMyPageProfileViewModel(
   profile: MyProfileResponse,
+  sellingCount = profile.sellingCount,
 ): MyPageProfileViewModel {
   return {
     id: profile.id,
@@ -123,13 +125,19 @@ export function toMyPageProfileViewModel(
     ratingLabel: `\ud3c9\uc810 ${profile.rating.toFixed(1)}`,
     warningLabel: `\uacbd\uace0 ${profile.warningCount}\ud68c`,
     biddingCount: profile.biddingCount,
-    sellingCount: profile.sellingCount,
+    sellingCount,
     wishlistCount: profile.wishlistCount,
   };
 }
 
 export async function fetchMyPageProfile() {
-  return toMyPageProfileViewModel(await mypageApi.getMyProfile());
+  const profile = await mypageApi.getMyProfile();
+
+  try {
+    return toMyPageProfileViewModel(profile, await fetchSalesManagementCount());
+  } catch {
+    return toMyPageProfileViewModel(profile);
+  }
 }
 
 export async function fetchMyProfileForm() {

--- a/src/services/product/register/service.ts
+++ b/src/services/product/register/service.ts
@@ -78,8 +78,6 @@ export function buildCreateRegularProductRequest(
     saleType: "REGULAR",
     categoryId: draft.categoryId ?? 0,
     price: Number(draft.price || 0),
-    startPrice: null,
-    auctionEndAt: null,
     allowOffer: draft.allowOffer,
     images: normalizeRegularProductImagePayload(draft.images),
     location: draft.location,

--- a/src/services/product/register/types.ts
+++ b/src/services/product/register/types.ts
@@ -46,8 +46,6 @@ export interface RegularProductCreateRequest {
   saleType: RegularProductSaleType;
   categoryId: number;
   price: number;
-  startPrice: null;
-  auctionEndAt: null;
   allowOffer: boolean;
   images: RegularProductImagePayload[];
   location: string;

--- a/src/services/sales-management/api.ts
+++ b/src/services/sales-management/api.ts
@@ -1,0 +1,173 @@
+import { ApiRequestError, getApiErrorMessage } from "@/services/apiError";
+import {
+  getAuthorizationHeaders,
+  handleUnauthorizedAccess,
+} from "@/services/auth/service";
+import type {
+  AuctionEditDetailResponse,
+  AuctionSalesManagementListResponse,
+  ProductEditDetailResponse,
+  RegularSalesManagementListResponse,
+  UpdateAuctionSalesManagementProductRequest,
+  UpdateRegularSalesManagementProductRequest,
+} from "@/services/sales-management/types";
+
+const API_BASE = "/api/v1";
+
+async function throwProtectedApiError(
+  response: Response,
+  fallbackMessage: string,
+) {
+  if (response.status === 401) {
+    handleUnauthorizedAccess();
+  }
+
+  throw new ApiRequestError(
+    await getApiErrorMessage(response, fallbackMessage),
+    response.status,
+  );
+}
+
+export async function getRegularSalesManagementProducts(): Promise<RegularSalesManagementListResponse> {
+  const params = new URLSearchParams({ page: "0", size: "20" });
+  const response = await fetch(`${API_BASE}/mypage/products/selling?${params}`, {
+    method: "GET",
+    headers: getAuthorizationHeaders(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    await throwProtectedApiError(
+      response,
+      "일반 상품 판매 중 목록을 불러오지 못했습니다.",
+    );
+  }
+
+  return response.json();
+}
+
+export async function getAuctionSalesManagementProducts(): Promise<AuctionSalesManagementListResponse> {
+  const params = new URLSearchParams({ page: "0", size: "20" });
+  const response = await fetch(`${API_BASE}/mypage/auctions/selling?${params}`, {
+    method: "GET",
+    headers: getAuthorizationHeaders(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    await throwProtectedApiError(
+      response,
+      "경매 상품 판매 중 목록을 불러오지 못했습니다.",
+    );
+  }
+
+  return response.json();
+}
+
+export async function deleteRegularSalesManagementProduct(
+  productId: number,
+): Promise<void> {
+  const response = await fetch(`${API_BASE}/products/${productId}`, {
+    method: "DELETE",
+    headers: getAuthorizationHeaders(),
+  });
+
+  if (!response.ok) {
+    await throwProtectedApiError(response, "일반 상품 삭제에 실패했습니다.");
+  }
+
+  return;
+}
+
+export async function deleteAuctionSalesManagementProduct(
+  auctionId: number,
+): Promise<void> {
+  const response = await fetch(`${API_BASE}/auctions/${auctionId}`, {
+    method: "DELETE",
+    headers: getAuthorizationHeaders(),
+  });
+
+  if (!response.ok) {
+    await throwProtectedApiError(response, "경매 상품 삭제에 실패했습니다.");
+  }
+
+  return;
+}
+
+export async function getRegularSalesManagementEditDetail(
+  productId: number,
+): Promise<ProductEditDetailResponse> {
+  const response = await fetch(`${API_BASE}/products/${productId}/edit`, {
+    method: "GET",
+    headers: getAuthorizationHeaders(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    await throwProtectedApiError(
+      response,
+      "일반 상품 수정 정보를 불러오지 못했습니다.",
+    );
+  }
+
+  return response.json();
+}
+
+export async function getAuctionSalesManagementEditDetail(
+  auctionId: number,
+): Promise<AuctionEditDetailResponse> {
+  const response = await fetch(`${API_BASE}/auctions/${auctionId}/edit`, {
+    method: "GET",
+    headers: getAuthorizationHeaders(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    await throwProtectedApiError(
+      response,
+      "경매 상품 수정 정보를 불러오지 못했습니다.",
+    );
+  }
+
+  return response.json();
+}
+
+export async function updateRegularSalesManagementProduct(
+  productId: number,
+  payload: UpdateRegularSalesManagementProductRequest,
+): Promise<ProductEditDetailResponse> {
+  const response = await fetch(`${API_BASE}/products/${productId}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      ...getAuthorizationHeaders(),
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    await throwProtectedApiError(response, "일반 상품 수정에 실패했습니다.");
+  }
+
+  return response.json();
+}
+
+export async function updateAuctionSalesManagementProduct(
+  auctionId: number,
+  payload: UpdateAuctionSalesManagementProductRequest,
+): Promise<AuctionEditDetailResponse> {
+  const response = await fetch(`${API_BASE}/auctions/${auctionId}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      ...getAuthorizationHeaders(),
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    await throwProtectedApiError(response, "경매 상품 수정에 실패했습니다.");
+  }
+
+  return response.json();
+}

--- a/src/services/sales-management/service.ts
+++ b/src/services/sales-management/service.ts
@@ -1,0 +1,269 @@
+import * as salesManagementApi from "@/services/sales-management/api";
+import type {
+  AuctionSalesManagementItemResponse,
+  RegularSalesManagementItemResponse,
+  SalesManagementListSummary,
+  SalesManagementItemViewModel,
+  UpdateAuctionSalesManagementProductRequest,
+  UpdateRegularSalesManagementProductRequest,
+} from "@/services/sales-management/types";
+import type { AuctionRegisterDraft } from "@/services/auction/register/types";
+
+const DEFAULT_CATEGORY_LABEL = "카테고리 없음";
+
+function formatPrice(price: number) {
+  return `${Number(price || 0).toLocaleString()}원`;
+}
+
+function getRegularStatusLabel(status: string) {
+  if (status === "ON_SALE") {
+    return "판매 중";
+  }
+
+  if (status === "SOLD") {
+    return "판매 완료";
+  }
+
+  if (status === "ENDED") {
+    return "판매 종료";
+  }
+
+  return "임시 저장";
+}
+
+function getAuctionStatusLabel(status: string) {
+  if (status === "AUCTION_LIVE" || status === "ON_SALE") {
+    return "경매 진행 중";
+  }
+
+  if (status === "AUCTION_SCHEDULED") {
+    return "경매 예정";
+  }
+
+  return "경매 종료";
+}
+
+function toRegularViewModel(
+  item: RegularSalesManagementItemResponse,
+): SalesManagementItemViewModel {
+  return {
+    id: `regular-${item.productId}`,
+    productId: item.productId,
+    type: "regular",
+    name: item.name,
+    description: item.description,
+    status: item.productStatus,
+    statusLabel: getRegularStatusLabel(item.productStatus),
+    price: Number(item.price || 0),
+    priceLabel: formatPrice(item.price),
+    imageUrl: item.thumbnailUrl,
+    category: item.categoryName ?? DEFAULT_CATEGORY_LABEL,
+    location: item.location,
+    bidders: null,
+    bidderCount: null,
+    editable: item.canEdit,
+    deletable: item.canDelete,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+  };
+}
+
+function toAuctionViewModel(
+  item: AuctionSalesManagementItemResponse,
+): SalesManagementItemViewModel {
+  const displayPrice = Number(item.currentPrice ?? item.startPrice ?? 0);
+
+  return {
+    id: `auction-${item.productId}`,
+    productId: item.productId,
+    auctionId: item.auctionId,
+    type: "auction",
+    name: item.name,
+    description: item.description,
+    status: item.auctionStatus,
+    statusLabel: getAuctionStatusLabel(item.auctionStatus),
+    price: displayPrice,
+    priceLabel: formatPrice(displayPrice),
+    imageUrl: item.thumbnailUrl,
+    category: item.categoryName ?? DEFAULT_CATEGORY_LABEL,
+    location: null,
+    bidders: item.bidCount,
+    bidderCount: item.bidderCount,
+    editable: item.canEdit,
+    deletable: item.canDelete,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+  };
+}
+
+function getAuctionProductIdSet(
+  auctionProducts: AuctionSalesManagementItemResponse[],
+) {
+  return new Set(auctionProducts.map((product) => product.productId));
+}
+
+function excludeAuctionProductsFromRegularList(
+  regularProducts: RegularSalesManagementItemResponse[],
+  auctionProducts: AuctionSalesManagementItemResponse[],
+) {
+  const auctionProductIds = getAuctionProductIdSet(auctionProducts);
+
+  return regularProducts.filter(
+    (product) => !auctionProductIds.has(product.productId),
+  );
+}
+
+export async function fetchSalesManagementProducts(): Promise<
+  SalesManagementItemViewModel[]
+> {
+  const [regularProducts, auctionProducts] = await Promise.all([
+    salesManagementApi.getRegularSalesManagementProducts(),
+    salesManagementApi.getAuctionSalesManagementProducts(),
+  ]);
+  const visibleRegularProducts = excludeAuctionProductsFromRegularList(
+    regularProducts.content,
+    auctionProducts.content,
+  );
+
+  return [
+    ...visibleRegularProducts.map(toRegularViewModel),
+    ...auctionProducts.content.map(toAuctionViewModel),
+  ].sort(
+    (a, b) =>
+      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+}
+
+export async function fetchSalesManagementSummary(): Promise<SalesManagementListSummary> {
+  const [regularProducts, auctionProducts] = await Promise.all([
+    salesManagementApi.getRegularSalesManagementProducts(),
+    salesManagementApi.getAuctionSalesManagementProducts(),
+  ]);
+  const auctionProductIds = getAuctionProductIdSet(auctionProducts.content);
+  const hasDuplicatedAuctionProduct = regularProducts.content.some((product) =>
+    auctionProductIds.has(product.productId),
+  );
+  const regularCount = hasDuplicatedAuctionProduct
+    ? Math.max(0, regularProducts.totalElements - auctionProducts.totalElements)
+    : regularProducts.totalElements;
+
+  return {
+    regularCount,
+    auctionCount: auctionProducts.totalElements,
+  };
+}
+
+export async function fetchSalesManagementCount() {
+  const summary = await fetchSalesManagementSummary();
+  return summary.regularCount + summary.auctionCount;
+}
+
+export async function deleteSalesManagementProduct(
+  product: SalesManagementItemViewModel,
+) {
+  if (product.type === "auction") {
+    return salesManagementApi.deleteAuctionSalesManagementProduct(
+      product.auctionId ?? product.productId,
+    );
+  }
+
+  return salesManagementApi.deleteRegularSalesManagementProduct(
+    product.productId,
+  );
+}
+
+function normalizeImages(images: AuctionRegisterDraft["images"]) {
+  return images.map((image, index) => ({
+    imageId: image.imageId,
+    imageUrl: image.imageUrl,
+    sortOrder: image.sortOrder || index + 1,
+  }));
+}
+
+export async function fetchRegularSalesManagementEditInitialData(
+  productId: number,
+) {
+  const detail = await salesManagementApi.getRegularSalesManagementEditDetail(
+    productId,
+  );
+
+  return {
+    type: "regular",
+    productId: detail.productId,
+    name: detail.name,
+    description: detail.description,
+    categoryId: detail.categoryId,
+    categoryName: detail.categoryName ?? "",
+    price: String(detail.price ?? ""),
+    location: detail.location,
+    images: detail.images,
+    allowOffer: detail.allowOffer,
+  };
+}
+
+export async function fetchAuctionSalesManagementEditInitialData(
+  auctionId: number,
+) {
+  const detail = await salesManagementApi.getAuctionSalesManagementEditDetail(
+    auctionId,
+  );
+
+  return {
+    type: "auction",
+    productId: detail.productId,
+    auctionId: detail.auctionId,
+    name: detail.name,
+    description: detail.description,
+    categoryId: detail.categoryId,
+    categoryName: detail.categoryName ?? "",
+    price: String(detail.startPrice ?? ""),
+    startPrice: String(detail.startPrice ?? ""),
+    location: detail.location,
+    images: detail.images,
+    auction: {
+      startPrice: String(detail.startPrice ?? ""),
+      bidUnit: "0",
+      durationDays: detail.auctionDurationDays || 1,
+    },
+  };
+}
+
+export async function updateRegularSalesManagementProduct(
+  productId: number,
+  draft: AuctionRegisterDraft,
+) {
+  const payload: UpdateRegularSalesManagementProductRequest = {
+    name: draft.name.trim(),
+    description: draft.description.trim(),
+    categoryId: draft.categoryId ?? 0,
+    price: Number(draft.price || 0),
+    allowOffer: draft.allowOffer,
+    location: draft.location.trim(),
+    images: normalizeImages(draft.images),
+  };
+
+  return salesManagementApi.updateRegularSalesManagementProduct(
+    productId,
+    payload,
+  );
+}
+
+export async function updateAuctionSalesManagementProduct(
+  auctionId: number,
+  draft: AuctionRegisterDraft,
+) {
+  const payload: UpdateAuctionSalesManagementProductRequest = {
+    name: draft.name.trim(),
+    description: draft.description.trim(),
+    categoryId: draft.categoryId ?? 0,
+    startPrice: Number(draft.startPrice || draft.auction.startPrice || 0),
+    auctionDurationDays: draft.auction.durationDays,
+    location: draft.location.trim(),
+    images: normalizeImages(draft.images),
+  };
+
+  return salesManagementApi.updateAuctionSalesManagementProduct(
+    auctionId,
+    payload,
+  );
+}

--- a/src/services/sales-management/types.ts
+++ b/src/services/sales-management/types.ts
@@ -1,0 +1,159 @@
+export type SalesManagementSaleType = "REGULAR" | "AUCTION";
+
+export type RegularSalesManagementStatus =
+  | "DRAFT"
+  | "ON_SALE"
+  | "SOLD"
+  | "ENDED";
+
+export type AuctionSalesManagementStatus =
+  | "AUCTION_SCHEDULED"
+  | "AUCTION_LIVE"
+  | "ON_SALE"
+  | "ENDED";
+
+export interface RegularSalesManagementItemResponse {
+  productId: number;
+  name: string;
+  description: string;
+  categoryName: string | null;
+  thumbnailUrl: string | null;
+  productStatus: RegularSalesManagementStatus;
+  price: number;
+  location: string;
+  canEdit: boolean;
+  canDelete: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RegularSalesManagementListResponse {
+  content: RegularSalesManagementItemResponse[];
+  page: number;
+  size: number;
+  totalElements: number;
+  hasNext: boolean;
+}
+
+export interface AuctionSalesManagementItemResponse {
+  productId: number;
+  auctionId: number;
+  name: string;
+  description: string;
+  categoryName: string | null;
+  thumbnailUrl: string | null;
+  auctionStatus: AuctionSalesManagementStatus;
+  startPrice: number | null;
+  currentPrice: number | null;
+  minimumNextBidPrice: number | null;
+  bidCount: number;
+  bidderCount: number;
+  startAt: string | null;
+  endAt: string | null;
+  canEdit: boolean;
+  canDelete: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AuctionSalesManagementListResponse {
+  content: AuctionSalesManagementItemResponse[];
+  page: number;
+  size: number;
+  totalElements: number;
+  hasNext: boolean;
+}
+
+export interface SalesManagementListSummary {
+  regularCount: number;
+  auctionCount: number;
+}
+
+export interface ProductEditDetailResponse {
+  productId: number;
+  name: string;
+  description: string;
+  categoryId: number;
+  categoryName: string | null;
+  location: string;
+  images: {
+    imageId: number;
+    imageUrl: string;
+    sortOrder: number;
+  }[];
+  price: number;
+  allowOffer: boolean;
+  status: RegularSalesManagementStatus;
+  editable: boolean;
+}
+
+export interface AuctionEditDetailResponse {
+  productId: number;
+  auctionId: number;
+  name: string;
+  description: string;
+  categoryId: number;
+  categoryName: string | null;
+  location: string;
+  images: {
+    imageId: number;
+    imageUrl: string;
+    sortOrder: number;
+  }[];
+  startPrice: number;
+  auctionDurationDays: number;
+  auctionStatus: AuctionSalesManagementStatus;
+  bidCount: number;
+  bidderCount: number;
+  canEdit: boolean;
+}
+
+export interface UpdateRegularSalesManagementProductRequest {
+  name: string;
+  description: string;
+  categoryId: number;
+  price: number;
+  allowOffer: boolean;
+  location: string;
+  images: {
+    imageId: number;
+    imageUrl: string;
+    sortOrder: number;
+  }[];
+}
+
+export interface UpdateAuctionSalesManagementProductRequest {
+  name: string;
+  description: string;
+  categoryId: number;
+  startPrice: number;
+  auctionDurationDays: number;
+  location: string;
+  images: {
+    imageId: number;
+    imageUrl: string;
+    sortOrder: number;
+  }[];
+}
+
+export interface SalesManagementItemViewModel {
+  id: string;
+  productId: number;
+  auctionId?: number;
+  type: "regular" | "auction";
+  name: string;
+  description: string;
+  status: string;
+  statusLabel: string;
+  price: number;
+  priceLabel: string;
+  imageUrl: string | null;
+  category: string;
+  location: string | null;
+  bidders: number | null;
+  bidderCount: number | null;
+  editable: boolean;
+  deletable: boolean;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
### 🚀 Summary

판매 관리 기능 구조 구성 및 백엔드 API 연동 흐름 정리
마이페이지 판매 관리 화면에서 판매중 일반상품/경매상품 조회, 수정, 삭제 흐름을 page -> service -> api 구조로 분리
상품 등록 후 판매 관리 화면에 등록 상품이 반영되도록 연결
경매 상품 중복 표시 및 수정/삭제 ID 매칭

---

### ✨ Description

판매 관리 요청 흐름
page.tsx에서 사용자가 판매 관리 화면 진입
→ service.ts가 일반상품/경매상품 판매중 목록을 조회하고 화면용 데이터로 정리
→ api.ts가 실제 서버 API 호출
→ 응답을 화면에서 받아 판매중 목록, 개수, 수정/삭제 상태에 반영

주요 코드

page.tsx
/mypage/sales-management 하위에 있음
판매 관리 화면 상태 관리
전체/일반/경매 필터 관리
판매중 상품 목록 조회 시 fetchSalesManagementProducts() 호출
수정 버튼 클릭 시 상품 종류에 맞는 수정 초기 데이터 조회
삭제 버튼 클릭 시 상품 종류에 맞는 삭제 API 호출
수정 완료 후 판매 관리 목록 재조회

types.ts
SalesManagementItemViewModel - 판매 관리 화면 표시용 모델
RegularSalesManagementListResponse - 일반상품 판매중 목록 응답 타입
AuctionSalesManagementListResponse - 경매상품 판매중 목록 응답 타입
ProductEditDetailResponse - 일반상품 수정 초기 데이터 응답 타입
AuctionEditDetailResponse - 경매상품 수정 초기 데이터 응답 타입
UpdateRegularSalesManagementProductRequest - 일반상품 수정 요청 DTO
UpdateAuctionSalesManagementProductRequest - 경매상품 수정 요청 DTO

api.ts
getRegularSalesManagementProducts - 일반상품 판매중 목록 조회
getAuctionSalesManagementProducts - 경매상품 판매중 목록 조회
getRegularSalesManagementEditDetail - 일반상품 수정 정보 조회
getAuctionSalesManagementEditDetail - 경매상품 수정 정보 조회
updateRegularSalesManagementProduct - 일반상품 수정
updateAuctionSalesManagementProduct - 경매상품 수정
deleteRegularSalesManagementProduct - 일반상품 삭제
deleteAuctionSalesManagementProduct - 경매상품 삭제

service.ts
fetchSalesManagementProducts - 일반/경매 판매중 목록 조회 후 화면용 데이터로 변환
fetchSalesManagementSummary - 판매중 개수 요약 조회
fetchSalesManagementCount - 마이페이지 판매중 개수 계산
deleteSalesManagementProduct - 상품 종류에 맞는 삭제 API 위임
fetchRegularSalesManagementEditInitialData - 일반상품 수정 화면 초기값 생성
fetchAuctionSalesManagementEditInitialData - 경매상품 수정 화면 초기값 생성
updateRegularSalesManagementProduct - 일반상품 수정 요청 조립 후 API 호출
updateAuctionSalesManagementProduct - 경매상품 수정 요청 조립 후 API 호출

수정 사항

경매 상품 등록 후 판매중 목록에 같은 상품이 2개씩 보이던 문제 수정
일반상품 목록에 경매 상품이 함께 내려오는 경우 productId 기준으로 중복 제거
경매 상품 수정/삭제 시 productId가 아니라 auctionId를 사용하도록 수정
상품 등록 요청 DTO를 백엔드 명세에 맞게 정리하여 등록 실패 문제 수정
판매중 개수를 판매 관리 API 기준으로 반영하도록 정리

사진

판매 중 내역

<img width="497" height="577" alt="화면 캡처 2026-05-02 124054" src="https://github.com/user-attachments/assets/232f7180-932e-40aa-8901-cd84a285ebf8" />

수정

<img width="480" height="493" alt="화면 캡처 2026-05-02 124137" src="https://github.com/user-attachments/assets/6ec5d20a-e765-4206-b13a-4829dab543a3" />

삭제

<img width="541" height="468" alt="화면 캡처 2026-05-02 124156" src="https://github.com/user-attachments/assets/50d80e0d-c0e2-4f0f-bac7-abb0c466e3bb" />




---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #41
