### PR TITLE
[refactor] 경매 상세페이지

### DIFF
--- a/src/app/(main)/mypage/sales-management/index.tsx
+++ b/src/app/(main)/mypage/sales-management/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { ChevronLeft, ImageIcon, ShoppingBag } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 
@@ -78,6 +79,7 @@ export default function SalesManagementScreen({
   onBack,
   themeColor,
 }: SalesManagementScreenProps) {
+  const router = useRouter();
   const [products, setProducts] = useState<SalesManagementItemViewModel[]>([]);
   const [filter, setFilter] = useState<SalesManagementFilter>("all");
   const [itemToDelete, setItemToDelete] =
@@ -108,7 +110,7 @@ export default function SalesManagementScreen({
   };
 
   useEffect(() => {
-    loadProducts();
+    void loadProducts();
   }, []);
 
   const handleDeleteConfirm = async () => {
@@ -155,6 +157,14 @@ export default function SalesManagementScreen({
     } finally {
       setEditingProductId(null);
     }
+  };
+
+  const handleItemClick = (product: SalesManagementItemViewModel) => {
+    if (product.type !== "auction") {
+      return;
+    }
+
+    router.push(`/auctions/${product.auctionId ?? product.productId}`);
   };
 
   const filteredProducts = products.filter(
@@ -270,7 +280,23 @@ export default function SalesManagementScreen({
           filteredProducts.map((item) => (
             <div
               key={item.id}
-              className="p-4 bg-white border border-gray-100 rounded-2xl space-y-4"
+              onClick={() => handleItemClick(item)}
+              role={item.type === "auction" ? "button" : undefined}
+              tabIndex={item.type === "auction" ? 0 : undefined}
+              onKeyDown={(event) => {
+                if (
+                  item.type === "auction" &&
+                  (event.key === "Enter" || event.key === " ")
+                ) {
+                  event.preventDefault();
+                  handleItemClick(item);
+                }
+              }}
+              className={`p-4 bg-white border border-gray-100 rounded-2xl space-y-4 ${
+                item.type === "auction"
+                  ? "cursor-pointer hover:border-rose-100 hover:shadow-sm transition-all"
+                  : ""
+              }`}
             >
               <div className="flex items-start space-x-4">
                 <div className="w-24 h-24 rounded-lg overflow-hidden bg-gray-50 shrink-0">
@@ -303,7 +329,10 @@ export default function SalesManagementScreen({
               <div className="grid grid-cols-2 gap-3">
                 <button
                   type="button"
-                  onClick={() => handleEditClick(item)}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    void handleEditClick(item);
+                  }}
                   disabled={!item.editable || editingProductId === item.id}
                   className="h-14 bg-gray-50 rounded-xl text-sm font-bold transition-colors disabled:text-gray-300 enabled:hover:bg-gray-100"
                 >
@@ -311,7 +340,10 @@ export default function SalesManagementScreen({
                 </button>
                 <button
                   type="button"
-                  onClick={() => setItemToDelete(item)}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setItemToDelete(item);
+                  }}
                   disabled={!item.deletable}
                   className="h-14 bg-gray-50 rounded-xl text-sm font-bold text-red-500 transition-colors disabled:text-gray-300 enabled:hover:bg-gray-100"
                 >

--- a/src/app/auctions/[auctionId]/bid-complete/index.tsx
+++ b/src/app/auctions/[auctionId]/bid-complete/index.tsx
@@ -42,6 +42,8 @@ export default function BidPlacementCompleteScreen({
   bidAmount, 
   remainingTime, 
   productId,
+  productImageUrl,
+  onBack,
   onBrowseOther, 
   onProductDetail, 
   themeColor 
@@ -51,6 +53,8 @@ export default function BidPlacementCompleteScreen({
   bidAmount: number; 
   remainingTime: string; 
   productId: number;
+  productImageUrl?: string;
+  onBack: () => void;
   onBrowseOther: () => void; 
   onProductDetail: () => void; 
   themeColor: string; 
@@ -66,7 +70,10 @@ export default function BidPlacementCompleteScreen({
       className="flex-1 flex flex-col bg-white"
     >
       <div className="h-16 flex items-center px-4 border-b border-gray-100">
-        <h1 className="flex-1 text-center font-bold text-lg">입찰 완료</h1>
+        <button onClick={onBack} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+          <ChevronLeft size={24} />
+        </button>
+        <h1 className="flex-1 text-center font-bold text-lg mr-10">입찰 완료</h1>
       </div>
 
       <div className="flex-1 overflow-y-auto no-scrollbar p-8 flex flex-col items-center justify-center space-y-8">
@@ -83,7 +90,11 @@ export default function BidPlacementCompleteScreen({
           <div className="w-full bg-gray-50 rounded-3xl p-6 space-y-4">
             <div className="flex items-center space-x-4">
               <div className="w-16 h-16 rounded-xl overflow-hidden bg-gray-200">
-                <img src={`https://picsum.photos/seed/${productId}/200/200`} alt="Product" className="w-full h-full object-cover" />
+                {productImageUrl ? (
+                  <img src={productImageUrl} alt={productName} className="w-full h-full object-cover" />
+                ) : (
+                  <img src={`https://picsum.photos/seed/${productId}/200/200`} alt={productName} className="w-full h-full object-cover" />
+                )}
               </div>
               <div className="flex-1">
                 <p className="text-xs text-gray-400">내 입찰가</p>

--- a/src/app/auctions/[auctionId]/bid-complete/page.tsx
+++ b/src/app/auctions/[auctionId]/bid-complete/page.tsx
@@ -1,21 +1,53 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 
 import BidPlacementCompleteScreen from "./index";
+import {
+  fetchAuctionDetail,
+  getAuctionMainImageUrl,
+  getAuctionRemainingTimeLabel,
+} from "@/services/auction/detail/service";
+import type { AuctionDetailResponse } from "@/services/auction/detail/types";
 
 export default function BidCompletePage() {
   const router = useRouter();
+  const params = useParams<{ auctionId: string }>();
+  const searchParams = useSearchParams();
+  const auctionId = Number(params.auctionId);
+  const safeAuctionId = Number.isFinite(auctionId) ? auctionId : 0;
+  const bidPrice = Number(searchParams.get("bidPrice"));
+  const safeBidPrice = Number.isFinite(bidPrice) ? bidPrice : 0;
+  const [auctionDetail, setAuctionDetail] =
+    useState<AuctionDetailResponse | null>(null);
+
+  useEffect(() => {
+    if (safeAuctionId > 0) {
+      fetchAuctionDetail(safeAuctionId)
+        .then(setAuctionDetail)
+        .catch(() => setAuctionDetail(null));
+    }
+  }, [safeAuctionId]);
 
   return (
     <BidPlacementCompleteScreen
-      productName=""
-      sellerName=""
-      bidAmount={0}
-      remainingTime=""
-      productId={0}
+      productName={auctionDetail?.name ?? ""}
+      sellerName={auctionDetail?.seller.nickname ?? ""}
+      bidAmount={safeBidPrice}
+      remainingTime={
+        auctionDetail
+          ? getAuctionRemainingTimeLabel(
+              auctionDetail.endsAt,
+              auctionDetail.serverTime,
+            )
+          : ""
+      }
+      productId={auctionDetail?.productId ?? safeAuctionId}
+      productImageUrl={getAuctionMainImageUrl(auctionDetail)}
+      onBack={() => router.push(`/auctions/${safeAuctionId}`)}
       onBrowseOther={() => router.push("/auctions")}
-      onProductDetail={() => router.push("/auctions")}
+      onProductDetail={() => router.push(`/auctions/${safeAuctionId}`)}
       themeColor="#F64257"
     />
   );

--- a/src/app/auctions/[auctionId]/bid-complete/page.tsx
+++ b/src/app/auctions/[auctionId]/bid-complete/page.tsx
@@ -45,9 +45,9 @@ export default function BidCompletePage() {
       }
       productId={auctionDetail?.productId ?? safeAuctionId}
       productImageUrl={getAuctionMainImageUrl(auctionDetail)}
-      onBack={() => router.push(`/auctions/${safeAuctionId}`)}
+      onBack={() => router.replace(`/auctions/${safeAuctionId}`)}
       onBrowseOther={() => router.push("/auctions")}
-      onProductDetail={() => router.push(`/auctions/${safeAuctionId}`)}
+      onProductDetail={() => router.replace(`/auctions/${safeAuctionId}`)}
       themeColor="#F64257"
     />
   );

--- a/src/app/auctions/[auctionId]/bidding-status/index.tsx
+++ b/src/app/auctions/[auctionId]/bidding-status/index.tsx
@@ -35,8 +35,17 @@ import { motion, AnimatePresence } from 'motion/react';
 
 import { Screen, Tab } from '../../../../types/index';
 import { ExploreIcon } from '../../../../components/common/ExploreIcon';
+import { getErrorMessage } from '@/services/apiError';
+import {
+  fetchAuctionDetail,
+  getAuctionDisplayCurrentPrice,
+} from '@/services/auction/detail/service';
+import type { AuctionDetailResponse } from '@/services/auction/detail/types';
 
-export default function BiddingStatusScreen({ onBack, themeColor }: { onBack: () => void; themeColor: string; key?: string }) {
+export default function BiddingStatusScreen({ auctionId, onBack, themeColor }: { auctionId: number | null; onBack: () => void; themeColor: string; key?: string }) {
+  const [auctionDetail, setAuctionDetail] = useState<AuctionDetailResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
   const bids: Array<{
     user: string;
     price: string;
@@ -44,6 +53,43 @@ export default function BiddingStatusScreen({ onBack, themeColor }: { onBack: ()
     active: boolean;
     img: string;
   }> = [];
+  const currentDisplayPrice = getAuctionDisplayCurrentPrice(auctionDetail);
+  const bidCount = auctionDetail?.bidCount ?? 0;
+  const priceHelperText = bidCount > 0 ? "현재 최고 입찰가" : "입찰 기록 없음";
+
+  useEffect(() => {
+    if (auctionId == null) {
+      return;
+    }
+
+    let ignore = false;
+
+    setIsLoading(true);
+    setErrorMessage("");
+
+    fetchAuctionDetail(auctionId)
+      .then((data) => {
+        if (!ignore) {
+          setAuctionDetail(data);
+        }
+      })
+      .catch((error) => {
+        if (!ignore) {
+          setErrorMessage(
+            getErrorMessage(error, "입찰 현황을 불러오지 못했습니다."),
+          );
+        }
+      })
+      .finally(() => {
+        if (!ignore) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [auctionId]);
 
   return (
     <motion.div
@@ -64,11 +110,15 @@ export default function BiddingStatusScreen({ onBack, themeColor }: { onBack: ()
         <div className="p-6 bg-gray-50/50 border-b border-gray-50">
           <div className="flex items-center justify-between mb-4">
             <span className="text-sm text-gray-500 font-medium">현재 최고가</span>
-            <span className="text-xs text-gray-400">총 0회 입찰</span>
+            <span className="text-xs text-gray-400">총 {bidCount}회 입찰</span>
           </div>
           <div className="flex items-baseline space-x-2">
-            <span className="text-3xl font-black" style={{ color: themeColor }}>₩0</span>
-            <span className="text-xs font-bold text-gray-400 flex items-center">입찰 기록 없음</span>
+            <span className="text-3xl font-black" style={{ color: themeColor }}>
+              {isLoading ? "불러오는 중" : `₩${currentDisplayPrice.toLocaleString()}`}
+            </span>
+            <span className="text-xs font-bold text-gray-400 flex items-center">
+              {errorMessage || priceHelperText}
+            </span>
           </div>
         </div>
 

--- a/src/app/auctions/[auctionId]/bidding-status/page.tsx
+++ b/src/app/auctions/[auctionId]/bidding-status/page.tsx
@@ -1,11 +1,20 @@
 "use client";
 
+import { useParams } from "next/navigation";
 import { useRouter } from "next/navigation";
 
 import BiddingStatusScreen from "./index";
 
 export default function BiddingStatusPage() {
   const router = useRouter();
+  const params = useParams<{ auctionId: string }>();
+  const auctionId = Number(params.auctionId);
 
-  return <BiddingStatusScreen onBack={() => router.back()} themeColor="#F64257" />;
+  return (
+    <BiddingStatusScreen
+      auctionId={Number.isFinite(auctionId) ? auctionId : null}
+      onBack={() => router.back()}
+      themeColor="#F64257"
+    />
+  );
 }

--- a/src/app/auctions/[auctionId]/page.tsx
+++ b/src/app/auctions/[auctionId]/page.tsx
@@ -4,6 +4,10 @@ import { useParams, useRouter } from "next/navigation";
 
 import AuctionDetailScreen from "./index";
 
+type BidCompleteData = {
+  bidAmount: number;
+};
+
 export default function AuctionDetailPage() {
   const params = useParams<{ auctionId: string }>();
   const router = useRouter();
@@ -17,7 +21,11 @@ export default function AuctionDetailPage() {
       onChatClick={() => router.push("/chats/1")}
       onReportClick={() => router.push(`/products/${auctionId}/report`)}
       onPurchaseClick={() => router.push(`/products/${auctionId}/payment`)}
-      onBidComplete={() => router.push(`/auctions/${auctionId}/bid-complete`)}
+      onBidComplete={(data: BidCompleteData) => {
+        router.push(
+          `/auctions/${auctionId}/bid-complete?bidPrice=${data.bidAmount}`,
+        );
+      }}
       themeColor="#F64257"
       mode="auction"
       showToast={() => {}}

--- a/src/app/auctions/[auctionId]/page.tsx
+++ b/src/app/auctions/[auctionId]/page.tsx
@@ -22,7 +22,7 @@ export default function AuctionDetailPage() {
       onReportClick={() => router.push(`/products/${auctionId}/report`)}
       onPurchaseClick={() => router.push(`/products/${auctionId}/payment`)}
       onBidComplete={(data: BidCompleteData) => {
-        router.push(
+        router.replace(
           `/auctions/${auctionId}/bid-complete?bidPrice=${data.bidAmount}`,
         );
       }}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -133,6 +133,7 @@ export default function App() {
     sellerName: string;
     bidAmount: number;
     remainingTime: string;
+    productImageUrl?: string;
   } | null>(null);
 
   const showToast = (message: string) => {
@@ -488,6 +489,11 @@ export default function App() {
               bidAmount={bidData.bidAmount}
               remainingTime={bidData.remainingTime}
               productId={bidData.productId}
+              productImageUrl={bidData.productImageUrl}
+              onBack={() => {
+                setSelectedProductId(bidData.productId);
+                navigateTo("product_detail");
+              }}
               onBrowseOther={() => {
                 setCurrentTab("home");
                 navigateTo("main");
@@ -569,6 +575,7 @@ export default function App() {
           {currentScreen === "bidding_status" && (
             <BiddingStatusScreen
               key="bidding_status"
+              auctionId={selectedProductId}
               onBack={() => navigateTo("product_detail")}
               themeColor={themeColor}
             />

--- a/src/app/products/[productId]/index.tsx
+++ b/src/app/products/[productId]/index.tsx
@@ -47,6 +47,32 @@ import type { AuctionDetailResponse } from '@/services/auction/detail/types';
 
 type AuctionStatus = 'AUCTION_SCHEDULED' | 'AUCTION_LIVE' | 'AUCTION_ENDED' | 'ENDED';
 
+function formatAuctionRemainingTimeWithSeconds(remainingMs: number) {
+  if (!Number.isFinite(remainingMs) || remainingMs <= 0) {
+    return '경매 종료';
+  }
+
+  const totalSeconds = Math.floor(remainingMs / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (days > 0) {
+    return `${days}일 ${hours}시간 ${minutes}분 ${seconds}초 남음`;
+  }
+
+  if (hours > 0) {
+    return `${hours}시간 ${minutes}분 ${seconds}초 남음`;
+  }
+
+  if (minutes > 0) {
+    return `${minutes}분 ${seconds}초 남음`;
+  }
+
+  return `${seconds}초 남음`;
+}
+
 export default function ProductDetailScreen({ 
   productId, 
   onBack,
@@ -86,10 +112,20 @@ export default function ProductDetailScreen({
   const [currentPrice, setCurrentPrice] = useState(850000);
   const [bidCount, setBidCount] = useState(23);
   const [inputBidAmount, setInputBidAmount] = useState(860000);
+  const [currentTimeMs, setCurrentTimeMs] = useState(() => Date.now());
+  const [auctionClockOffsetMs, setAuctionClockOffsetMs] = useState(0);
   const isRegular = mode === 'regular';
   const effectiveAuctionStatus = auctionDetail?.status ?? auctionStatus;
   const isAuctionScheduled = !isRegular && effectiveAuctionStatus === 'AUCTION_SCHEDULED';
-  const isAuctionEnded = !isRegular && (effectiveAuctionStatus === 'AUCTION_ENDED' || effectiveAuctionStatus === 'ENDED');
+  const auctionRemainingMs = auctionDetail
+    ? new Date(auctionDetail.endsAt).getTime() - (currentTimeMs + auctionClockOffsetMs)
+    : Number.POSITIVE_INFINITY;
+  const hasAuctionTimeEnded = !isRegular && auctionRemainingMs <= 0;
+  const isAuctionEnded = !isRegular && (
+    effectiveAuctionStatus === 'AUCTION_ENDED' ||
+    effectiveAuctionStatus === 'ENDED' ||
+    hasAuctionTimeEnded
+  );
   const bidUnit = auctionDetail?.minimumBidAmount ?? 10000;
   const minBidAmount = auctionDetail?.minimumNextBidPrice ?? currentPrice + bidUnit;
   const displayName = auctionDetail?.name ?? '아이폰 14 Pro 256GB 딥퍼플';
@@ -102,7 +138,7 @@ export default function ProductDetailScreen({
   const displaySellerImageUrl = auctionDetail?.seller.profileImageUrl ?? 'https://picsum.photos/seed/seller/100/100';
   const displayLocation = auctionDetail?.location ?? '서울 강남구';
   const displayEndLabel = auctionDetail
-    ? getAuctionRemainingTimeLabel(auctionDetail.endsAt, auctionDetail.serverTime)
+    ? formatAuctionRemainingTimeWithSeconds(auctionRemainingMs)
     : '2시간 35분 남음';
 
   const scheduledStartLabel = auctionStartAt
@@ -122,6 +158,20 @@ export default function ProductDetailScreen({
   }, [showBidSheet, minBidAmount]);
 
   useEffect(() => {
+    if (isRegular) {
+      return;
+    }
+
+    const timerId = window.setInterval(() => {
+      setCurrentTimeMs(Date.now());
+    }, 1000);
+
+    return () => {
+      window.clearInterval(timerId);
+    };
+  }, [isRegular]);
+
+  useEffect(() => {
     if (isRegular || productId == null) {
       return;
     }
@@ -138,6 +188,9 @@ export default function ProductDetailScreen({
         }
 
         setAuctionDetail(data);
+        setAuctionClockOffsetMs(
+          new Date(data.serverTime).getTime() - Date.now(),
+        );
         setCurrentPrice(getAuctionDisplayCurrentPrice(data));
         setBidCount(data.bidCount);
         setInputBidAmount(data.minimumNextBidPrice);
@@ -176,6 +229,9 @@ export default function ProductDetailScreen({
       const nextAuctionDetail = await fetchAuctionDetail(productId);
 
       setAuctionDetail(nextAuctionDetail);
+      setAuctionClockOffsetMs(
+        new Date(nextAuctionDetail.serverTime).getTime() - Date.now(),
+      );
       setCurrentPrice(getAuctionDisplayCurrentPrice(nextAuctionDetail));
       setBidCount(nextAuctionDetail.bidCount);
       setInputBidAmount(nextAuctionDetail.minimumNextBidPrice);

--- a/src/app/products/[productId]/index.tsx
+++ b/src/app/products/[productId]/index.tsx
@@ -35,8 +35,17 @@ import { motion, AnimatePresence } from 'motion/react';
 
 import { Screen, Tab } from '../../../types/index';
 import { ExploreIcon } from '../../../components/common/ExploreIcon';
+import { getErrorMessage } from '@/services/apiError';
+import {
+  fetchAuctionDetail,
+  getAuctionDisplayCurrentPrice,
+  getAuctionMainImageUrl,
+  getAuctionRemainingTimeLabel,
+  placeAuctionBid,
+} from '@/services/auction/detail/service';
+import type { AuctionDetailResponse } from '@/services/auction/detail/types';
 
-type AuctionStatus = 'AUCTION_SCHEDULED' | 'AUCTION_LIVE' | 'ENDED';
+type AuctionStatus = 'AUCTION_SCHEDULED' | 'AUCTION_LIVE' | 'AUCTION_ENDED' | 'ENDED';
 
 export default function ProductDetailScreen({ 
   productId, 
@@ -57,7 +66,7 @@ export default function ProductDetailScreen({
   onBidStatusClick: () => void;
   onChatClick: () => void;
   onReportClick: () => void;
-  onBidComplete: (data: { productId: number; productName: string; sellerName: string; bidAmount: number; remainingTime: string }) => void;
+  onBidComplete: (data: { productId: number; productName: string; sellerName: string; bidAmount: number; remainingTime: string; productImageUrl?: string }) => void;
   onPurchaseClick?: () => void;
   themeColor: string;
   mode: 'regular' | 'auction';
@@ -70,19 +79,31 @@ export default function ProductDetailScreen({
   const [isLiked, setIsLiked] = useState(false);
   const [showMoreMenu, setShowMoreMenu] = useState(false);
   const [showSellerProfile, setShowSellerProfile] = useState(false);
+  const [auctionDetail, setAuctionDetail] = useState<AuctionDetailResponse | null>(null);
+  const [isAuctionLoading, setIsAuctionLoading] = useState(false);
+  const [isBidSubmitting, setIsBidSubmitting] = useState(false);
+  const [auctionErrorMessage, setAuctionErrorMessage] = useState("");
   const [currentPrice, setCurrentPrice] = useState(850000);
   const [bidCount, setBidCount] = useState(23);
   const [inputBidAmount, setInputBidAmount] = useState(860000);
   const isRegular = mode === 'regular';
-  const isAuctionScheduled = !isRegular && auctionStatus === 'AUCTION_SCHEDULED';
-  const bidUnit = 10000;
-  const minBidAmount = currentPrice + bidUnit;
-  const displayName = '아이폰 14 Pro 256GB 딥퍼플';
-  const displayDescription = '아이폰 14 Pro 256GB 딥퍼플 색상입니다. 구매한지 6개월 정도 되었고 항상 케이스와 필름을 부착하여 상태 매우 깨끗합니다. 배터리 효율은 98%이며 모든 기능 정상 작동합니다. 박스와 구성품 모두 포함된 풀박스 구성입니다. 직거래는 강남역 인근에서 가능하며 택배 거래 시 배송비는 별도입니다.';
-  const displayImageUrl = `https://picsum.photos/seed/${productId}/600/600`;
-  const displayCategoryName = '전자제품';
-  const displaySellerName = '판매자123';
-  const displayEndLabel = '2시간 35분 남음';
+  const effectiveAuctionStatus = auctionDetail?.status ?? auctionStatus;
+  const isAuctionScheduled = !isRegular && effectiveAuctionStatus === 'AUCTION_SCHEDULED';
+  const isAuctionEnded = !isRegular && (effectiveAuctionStatus === 'AUCTION_ENDED' || effectiveAuctionStatus === 'ENDED');
+  const bidUnit = auctionDetail?.minimumBidAmount ?? 10000;
+  const minBidAmount = auctionDetail?.minimumNextBidPrice ?? currentPrice + bidUnit;
+  const displayName = auctionDetail?.name ?? '아이폰 14 Pro 256GB 딥퍼플';
+  const displayDescription = auctionDetail?.description ?? '아이폰 14 Pro 256GB 딥퍼플 색상입니다. 구매한지 6개월 정도 되었고 항상 케이스와 필름을 부착하여 상태 매우 깨끗합니다. 배터리 효율은 98%이며 모든 기능 정상 작동합니다. 박스와 구성품 모두 포함된 풀박스 구성입니다. 직거래는 강남역 인근에서 가능하며 택배 거래 시 배송비는 별도입니다.';
+  const displayImageUrl = !isRegular
+    ? getAuctionMainImageUrl(auctionDetail)
+    : `https://picsum.photos/seed/${productId}/600/600`;
+  const displayCategoryName = auctionDetail?.categoryName ?? '전자제품';
+  const displaySellerName = auctionDetail?.seller.nickname ?? '판매자123';
+  const displaySellerImageUrl = auctionDetail?.seller.profileImageUrl ?? 'https://picsum.photos/seed/seller/100/100';
+  const displayLocation = auctionDetail?.location ?? '서울 강남구';
+  const displayEndLabel = auctionDetail
+    ? getAuctionRemainingTimeLabel(auctionDetail.endsAt, auctionDetail.serverTime)
+    : '2시간 35분 남음';
 
   const scheduledStartLabel = auctionStartAt
     ? new Intl.DateTimeFormat('ko-KR', {
@@ -96,11 +117,88 @@ export default function ProductDetailScreen({
 
   useEffect(() => {
     if (showBidSheet) {
-      setInputBidAmount(currentPrice + bidUnit);
+      setInputBidAmount(minBidAmount);
     }
-  }, [showBidSheet, currentPrice]);
+  }, [showBidSheet, minBidAmount]);
 
-  if (!isRegular) {
+  useEffect(() => {
+    if (isRegular || productId == null) {
+      return;
+    }
+
+    let ignore = false;
+
+    setIsAuctionLoading(true);
+    setAuctionErrorMessage("");
+
+    fetchAuctionDetail(productId)
+      .then((data) => {
+        if (ignore) {
+          return;
+        }
+
+        setAuctionDetail(data);
+        setCurrentPrice(getAuctionDisplayCurrentPrice(data));
+        setBidCount(data.bidCount);
+        setInputBidAmount(data.minimumNextBidPrice);
+      })
+      .catch((error) => {
+        if (!ignore) {
+          setAuctionErrorMessage(
+            getErrorMessage(error, "경매 상품 정보를 불러오지 못했습니다."),
+          );
+        }
+      })
+      .finally(() => {
+        if (!ignore) {
+          setIsAuctionLoading(false);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [isRegular, productId]);
+
+  const handleBidSubmit = async (bidPrice: number) => {
+    if (isRegular || productId == null || isBidSubmitting) {
+      return;
+    }
+
+    if (bidPrice < minBidAmount) {
+      showToast(`최소 입찰가는 ${minBidAmount.toLocaleString()}원입니다.`);
+      return;
+    }
+
+    try {
+      setIsBidSubmitting(true);
+      await placeAuctionBid(productId, bidPrice);
+      const nextAuctionDetail = await fetchAuctionDetail(productId);
+
+      setAuctionDetail(nextAuctionDetail);
+      setCurrentPrice(getAuctionDisplayCurrentPrice(nextAuctionDetail));
+      setBidCount(nextAuctionDetail.bidCount);
+      setInputBidAmount(nextAuctionDetail.minimumNextBidPrice);
+      setShowBidSheet(false);
+      onBidComplete({
+        productId: productId || 0,
+        productName: nextAuctionDetail.name,
+        sellerName: nextAuctionDetail.seller.nickname,
+        bidAmount: bidPrice,
+        remainingTime: getAuctionRemainingTimeLabel(
+          nextAuctionDetail.endsAt,
+          nextAuctionDetail.serverTime,
+        ),
+        productImageUrl: getAuctionMainImageUrl(nextAuctionDetail),
+      });
+    } catch (error) {
+      showToast(getErrorMessage(error, "입찰에 실패했습니다."));
+    } finally {
+      setIsBidSubmitting(false);
+    }
+  };
+
+  if (!isRegular && isAuctionLoading) {
     return (
       <motion.div
         initial={{ opacity: 0, y: 20 }}
@@ -116,7 +214,29 @@ export default function ProductDetailScreen({
         </div>
         <div className="flex-1 flex flex-col items-center justify-center p-8 text-gray-400 space-y-3">
           <ShoppingBag size={56} className="opacity-20" />
-          <p className="text-sm font-medium">등록된 경매 상품이 없습니다</p>
+          <p className="text-sm font-medium">경매 상품 정보를 불러오는 중입니다</p>
+        </div>
+      </motion.div>
+    );
+  }
+
+  if (!isRegular && auctionErrorMessage) {
+    return (
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 20 }}
+        className="flex-1 flex flex-col bg-white"
+      >
+        <div className="h-16 flex items-center px-4 border-b border-gray-100">
+          <button onClick={onBack} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+            <ChevronLeft size={24} />
+          </button>
+          <h1 className="flex-1 text-center font-bold text-lg mr-10">경매 상품</h1>
+        </div>
+        <div className="flex-1 flex flex-col items-center justify-center p-8 text-gray-400 space-y-3 text-center">
+          <ShoppingBag size={56} className="opacity-20" />
+          <p className="text-sm font-medium">{auctionErrorMessage}</p>
         </div>
       </motion.div>
     );
@@ -183,7 +303,7 @@ export default function ProductDetailScreen({
           <div className="space-y-4">
             <div className="flex items-center space-x-2">
               <span className="px-2 py-1 text-white text-[10px] font-bold rounded" style={{ backgroundColor: themeColor }}>
-                {isRegular ? '일반 판매' : isAuctionScheduled ? '경매 예정' : '진행중'}
+                {isRegular ? '일반 판매' : isAuctionEnded ? '경매 종료' : isAuctionScheduled ? '경매 예정' : '진행중'}
               </span>
               <span className="text-xs text-gray-400">{displayCategoryName}</span>
             </div>
@@ -192,13 +312,13 @@ export default function ProductDetailScreen({
             <div 
               className={`rounded-2xl p-6 space-y-2 cursor-pointer transition-transform active:scale-[0.98] ${!isRegular ? 'hover:brightness-95' : ''}`}
               style={{ backgroundColor: `${themeColor}10` }}
-              onClick={() => !isRegular && !isAuctionScheduled && onBidStatusClick()}
+              onClick={() => !isRegular && !isAuctionScheduled && !isAuctionEnded && onBidStatusClick()}
             >
               <div className="flex items-center justify-between">
                 <span className="text-sm font-medium" style={{ color: themeColor }}>{isRegular ? '판매가' : '현재가'}</span>
                 <div className="flex items-center space-x-1">
                   <span className="text-2xl font-bold" style={{ color: themeColor }}>₩{currentPrice.toLocaleString()}</span>
-                  {!isRegular && !isAuctionScheduled && <ChevronRight size={20} style={{ color: themeColor }} />}
+                  {!isRegular && !isAuctionScheduled && !isAuctionEnded && <ChevronRight size={20} style={{ color: themeColor }} />}
                 </div>
               </div>
               
@@ -226,9 +346,9 @@ export default function ProductDetailScreen({
                       <span>{isAuctionScheduled ? scheduledStartLabel : displayEndLabel}</span>
                     </div>
                   </div>
-                  {isAuctionScheduled && (
+                  {(isAuctionScheduled || isAuctionEnded) && (
                     <p className="text-xs font-medium pt-1" style={{ color: themeColor }}>
-                      아직 시작 전인 경매입니다. 시작 시간 이후 참여할 수 있어요.
+                      {isAuctionScheduled ? '아직 시작 전인 경매입니다. 시작 시간 이후 참여할 수 있어요.' : '종료된 경매입니다.'}
                     </p>
                   )}
                 </>
@@ -242,7 +362,7 @@ export default function ProductDetailScreen({
           >
             <div className="flex items-center space-x-3">
               <div className="w-12 h-12 rounded-full bg-gray-100 overflow-hidden">
-                <img src="https://picsum.photos/seed/seller/100/100" alt="Seller" />
+                <img src={displaySellerImageUrl} alt="Seller" />
               </div>
               <div>
                 <p className="font-bold text-sm">{displaySellerName}</p>
@@ -264,7 +384,7 @@ export default function ProductDetailScreen({
               </div>
               <div className="flex justify-between">
                 <span className="text-gray-400">거래지역</span>
-                <span>서울 강남구</span>
+                <span>{displayLocation}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-gray-400">배송비</span>
@@ -305,18 +425,18 @@ export default function ProductDetailScreen({
               <MessageCircle size={24} />
             </button>
             <button 
-              onClick={() => !isAuctionScheduled && setShowBidSheet(true)} 
-              disabled={isAuctionScheduled}
+              onClick={() => !isAuctionScheduled && !isAuctionEnded && setShowBidSheet(true)} 
+              disabled={isAuctionScheduled || isAuctionEnded}
               className={`flex-1 h-14 font-bold rounded-xl transition-colors ${
-                isAuctionScheduled ? 'bg-gray-100 text-gray-400 cursor-not-allowed' : 'text-white shadow-lg'
+                isAuctionScheduled || isAuctionEnded ? 'bg-gray-100 text-gray-400 cursor-not-allowed' : 'text-white shadow-lg'
               }`} 
               style={
-                isAuctionScheduled
+                isAuctionScheduled || isAuctionEnded
                   ? undefined
                   : ({ backgroundColor: themeColor, '--tw-shadow-color': `${themeColor}40` } as React.CSSProperties)
               }
             >
-              {isAuctionScheduled ? '입찰은 시작 후 가능해요' : '입찰하기'}
+              {isAuctionEnded ? '경매 종료' : isAuctionScheduled ? '입찰은 시작 후 가능해요' : '입찰하기'}
             </button>
           </>
         )}
@@ -349,7 +469,7 @@ export default function ProductDetailScreen({
                   </div>
                   <div className="flex justify-between text-sm">
                     <span className="text-gray-400">입찰 단위</span>
-                    <span className="font-bold">₩10,000</span>
+                    <span className="font-bold">₩{bidUnit.toLocaleString()}</span>
                   </div>
                 </div>
 
@@ -414,60 +534,29 @@ export default function ProductDetailScreen({
                   </div>
                   <div className="grid grid-cols-2 gap-2">
                     <button 
-                      onClick={() => {
-                        setCurrentPrice(prev => prev + 30000);
-                        setBidCount(prev => prev + 1);
-                        setShowBidSheet(false);
-                        onBidComplete({
-                          productId: productId || 0,
-                          productName: displayName,
-                          sellerName: displaySellerName,
-                          bidAmount: currentPrice + 30000,
-                          remainingTime: displayEndLabel
-                        });
-                      }}
+                      onClick={() => handleBidSubmit(currentPrice + 30000)}
+                      disabled={isBidSubmitting || currentPrice + 30000 < minBidAmount}
                       className="h-12 border border-blue-200 bg-blue-50 text-blue-700 rounded-xl text-sm font-bold hover:bg-blue-100 transition-colors"
                     >
                       ₩{(currentPrice + 30000).toLocaleString()} (빠른 낙찰)
                     </button>
                     <button 
-                      onClick={() => {
-                        setCurrentPrice(prev => prev + 10000);
-                        setBidCount(prev => prev + 1);
-                        setShowBidSheet(false);
-                        onBidComplete({
-                          productId: productId || 0,
-                          productName: displayName,
-                          sellerName: displaySellerName,
-                          bidAmount: currentPrice + 10000,
-                          remainingTime: displayEndLabel
-                        });
-                      }}
+                      onClick={() => handleBidSubmit(minBidAmount)}
+                      disabled={isBidSubmitting}
                       className="h-12 border border-gray-200 rounded-xl text-sm font-bold hover:bg-gray-50 transition-colors"
                     >
-                      ₩{(currentPrice + 10000).toLocaleString()} (최소 입찰)
+                      ₩{minBidAmount.toLocaleString()} (최소 입찰)
                     </button>
                   </div>
                 </div>
 
                 <button 
-                  disabled={inputBidAmount < minBidAmount}
-                  onClick={() => {
-                    setCurrentPrice(inputBidAmount);
-                    setBidCount(prev => prev + 1);
-                    setShowBidSheet(false);
-                    onBidComplete({
-                      productId: productId || 0,
-                      productName: displayName,
-                      sellerName: displaySellerName,
-                      bidAmount: inputBidAmount,
-                      remainingTime: displayEndLabel
-                    });
-                  }} 
+                  disabled={isBidSubmitting || inputBidAmount < minBidAmount}
+                  onClick={() => handleBidSubmit(inputBidAmount)} 
                   className={`w-full h-14 text-white font-bold rounded-xl transition-all ${inputBidAmount < minBidAmount ? 'bg-gray-300 cursor-not-allowed opacity-50' : 'shadow-lg'}`}
                   style={{ backgroundColor: inputBidAmount < minBidAmount ? undefined : themeColor }}
                 >
-                  입찰하기
+                  {isBidSubmitting ? '입찰 중...' : '입찰하기'}
                 </button>
               </div>
             </motion.div>
@@ -496,10 +585,10 @@ export default function ProductDetailScreen({
               
               <div className="flex items-center space-x-4">
                 <div className="w-16 h-16 rounded-full bg-gray-100 overflow-hidden">
-                  <img src="https://picsum.photos/seed/seller/100/100" alt="Seller" />
+                  <img src={displaySellerImageUrl} alt="Seller" />
                 </div>
                 <div>
-                  <h3 className="text-xl font-bold">판매자123</h3>
+                  <h3 className="text-xl font-bold">{displaySellerName}</h3>
                   <p className="text-sm text-gray-500 mt-1">안녕하세요! 좋은 물건 많이 팝니다.</p>
                 </div>
               </div>

--- a/src/app/products/[productId]/page.tsx
+++ b/src/app/products/[productId]/page.tsx
@@ -36,7 +36,7 @@ export default function ProductDetailPage() {
   return (
     <ProductDetailScreen
       productId={productId}
-      onBack={() => router.back()}
+      onBack={() => router.push("/")}
       onBidStatusClick={() => router.push(`/auctions/${productId}/bidding-status`)}
       onChatClick={handleChatClick}
       onReportClick={() => router.push(`/products/${productId}/report`)}

--- a/src/app/products/register/RegisterScreen.tsx
+++ b/src/app/products/register/RegisterScreen.tsx
@@ -21,7 +21,8 @@ import type {
   ProductImagePayload,
   SaleType,
 } from "@/services/auction/register/types";
-import { fetchMyProfileForm } from "@/services/mypage/service";
+import { getLocationDisplayName } from "@/services/location/service";
+import { fetchMyLocationForm } from "@/services/mypage/service";
 
 export interface RegisterScreenProps {
   onBack?: () => void;
@@ -260,16 +261,16 @@ export default function RegisterScreen({
 
     let isMounted = true;
 
-    fetchMyProfileForm()
-      .then((profileEditData) => {
+    fetchMyLocationForm()
+      .then((locationForm) => {
         if (!isMounted || hasLoadedDraftRef.current || location) {
           return;
         }
 
-        setLocation(profileEditData.form.location);
+        setLocation(getLocationDisplayName(locationForm));
       })
       .catch((error) => {
-        console.error("Failed to fetch profile form", error);
+        console.error("Failed to fetch my location", error);
       });
 
     return () => {

--- a/src/app/products/register/index.tsx
+++ b/src/app/products/register/index.tsx
@@ -10,6 +10,15 @@ import type {
   ProductImagePayload,
   SaleType,
 } from "@/services/auction/register/types";
+import { TEST_AUCTION_DURATION_DAYS } from "@/services/auction/register/service";
+
+const AUCTION_DURATION_OPTIONS = [
+  { value: TEST_AUCTION_DURATION_DAYS, label: "20초 테스트" },
+  { value: 1, label: "1일" },
+  { value: 3, label: "3일" },
+  { value: 5, label: "5일" },
+  { value: 7, label: "7일" },
+];
 
 export interface RegisterScreenViewProps {
   fileInputRef: React.RefObject<HTMLInputElement | null>;
@@ -401,9 +410,9 @@ export default function RegisterScreenView({
                       onChange={(event) => onAuctionDurationChange(event.target.value)}
                       className="w-full h-12 rounded-2xl border border-rose-100 bg-white px-4 text-sm outline-none"
                     >
-                      {[1, 3, 5, 7].map((day) => (
-                        <option key={day} value={day}>
-                          {day}일
+                      {AUCTION_DURATION_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
                         </option>
                       ))}
                     </select>

--- a/src/services/auction/detail/api.ts
+++ b/src/services/auction/detail/api.ts
@@ -1,0 +1,67 @@
+import { ApiRequestError, getApiErrorMessage } from "@/services/apiError";
+import {
+  getAuthorizationHeaders,
+  handleUnauthorizedAccess,
+} from "@/services/auth/service";
+import type {
+  AuctionDetailResponse,
+  CreateAuctionBidRequest,
+  CreateAuctionBidResponse,
+} from "@/services/auction/detail/types";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, "") ?? "";
+
+async function throwProtectedApiError(
+  response: Response,
+  fallbackMessage: string,
+) {
+  if (response.status === 401) {
+    handleUnauthorizedAccess();
+  }
+
+  throw new ApiRequestError(
+    await getApiErrorMessage(response, fallbackMessage),
+    response.status,
+  );
+}
+
+export async function getAuctionDetail(
+  auctionId: number,
+): Promise<AuctionDetailResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/v1/auctions/${auctionId}`, {
+    method: "GET",
+    headers: getAuthorizationHeaders(),
+  });
+
+  if (!response.ok) {
+    await throwProtectedApiError(
+      response,
+      "경매 상품 정보를 불러오지 못했습니다.",
+    );
+  }
+
+  return response.json();
+}
+
+export async function postAuctionBid(
+  auctionId: number,
+  payload: CreateAuctionBidRequest,
+): Promise<CreateAuctionBidResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/v1/auctions/${auctionId}/bids`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...getAuthorizationHeaders(),
+      },
+      body: JSON.stringify(payload),
+    },
+  );
+
+  if (!response.ok) {
+    await throwProtectedApiError(response, "입찰에 실패했습니다.");
+  }
+
+  return response.json();
+}

--- a/src/services/auction/detail/service.ts
+++ b/src/services/auction/detail/service.ts
@@ -1,0 +1,51 @@
+import * as auctionDetailApi from "@/services/auction/detail/api";
+import type { AuctionDetailResponse } from "@/services/auction/detail/types";
+
+export async function fetchAuctionDetail(auctionId: number) {
+  return auctionDetailApi.getAuctionDetail(auctionId);
+}
+
+export async function placeAuctionBid(auctionId: number, bidPrice: number) {
+  return auctionDetailApi.postAuctionBid(auctionId, { bidPrice });
+}
+
+export function getAuctionMainImageUrl(data: AuctionDetailResponse | null) {
+  return data?.images?.[0]?.imageUrl ?? "";
+}
+
+export function getAuctionDisplayCurrentPrice(
+  data: AuctionDetailResponse | null,
+) {
+  return data?.currentPrice ?? 0;
+}
+
+export function getAuctionRemainingTimeLabel(
+  endsAt: string | undefined,
+  serverTime: string | undefined,
+) {
+  if (!endsAt || !serverTime) {
+    return "남은 시간 확인 중";
+  }
+
+  const remainingMs =
+    new Date(endsAt).getTime() - new Date(serverTime).getTime();
+
+  if (!Number.isFinite(remainingMs) || remainingMs <= 0) {
+    return "경매 종료";
+  }
+
+  const totalMinutes = Math.floor(remainingMs / 60000);
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
+
+  if (days > 0) {
+    return `${days}일 ${hours}시간 남음`;
+  }
+
+  if (hours > 0) {
+    return `${hours}시간 ${minutes}분 남음`;
+  }
+
+  return `${minutes}분 남음`;
+}

--- a/src/services/auction/detail/types.ts
+++ b/src/services/auction/detail/types.ts
@@ -1,0 +1,50 @@
+export type AuctionDetailStatus =
+  | "AUCTION_SCHEDULED"
+  | "AUCTION_LIVE"
+  | "AUCTION_ENDED"
+  | "ENDED";
+
+export interface AuctionDetailImage {
+  imageId: number;
+  imageUrl: string;
+  sortOrder: number;
+}
+
+export interface AuctionDetailSeller {
+  memberId: number;
+  nickname: string;
+  profileImageUrl: string | null;
+}
+
+export interface AuctionDetailResponse {
+  auctionId: number;
+  productId: number;
+  name: string;
+  description: string;
+  categoryId: number;
+  categoryName: string;
+  location: string;
+  images: AuctionDetailImage[];
+  seller: AuctionDetailSeller;
+  startPrice: number;
+  currentPrice: number;
+  minimumBidAmount: number;
+  minimumNextBidPrice: number;
+  bidCount: number;
+  bidderCount: number;
+  startAt: string;
+  endsAt: string;
+  serverTime: string;
+  status: AuctionDetailStatus;
+}
+
+export interface CreateAuctionBidRequest {
+  bidPrice: number;
+}
+
+export interface CreateAuctionBidResponse {
+  auctionId: number;
+  currentPrice: number;
+  bidderId: number;
+  serverTime: string;
+}

--- a/src/services/auction/register/service.ts
+++ b/src/services/auction/register/service.ts
@@ -15,6 +15,8 @@ import type {
   UploadAuctionImageResponse,
 } from "@/services/auction/register/types";
 
+export const TEST_AUCTION_DURATION_DAYS = 20 / 86400;
+
 // 화면 초기 렌더링용 기본 폼 상태를 만든다.
 // page.tsx는 이 값을 그대로 useState 초기값으로 사용하면 된다.
 export function createDefaultAuctionForm(): AuctionFormValues {
@@ -88,6 +90,10 @@ export function updateAuctionDuration(
 
 // 경매 기간 표시용 문자열 생성.
 export function formatAuctionSchedule(auction: AuctionFormValues) {
+  if (auction.durationDays === TEST_AUCTION_DURATION_DAYS) {
+    return "20초 동안 진행";
+  }
+
   return `${auction.durationDays}일 동안 진행`;
 }
 

--- a/src/services/auction/register/service.ts
+++ b/src/services/auction/register/service.ts
@@ -166,6 +166,10 @@ export function buildCreateAuctionRequest(
       draft.saleType === "auction"
         ? Number(draft.startPrice || draft.auction.startPrice || 0)
         : null,
+    bidUnit:
+      draft.saleType === "auction" ? Number(draft.auction.bidUnit || 0) : null,
+    minimumBidAmount:
+      draft.saleType === "auction" ? Number(draft.auction.bidUnit || 0) : null,
     auctionDurationDays:
       draft.saleType === "auction" ? draft.auction.durationDays : null,
     allowOffer: draft.allowOffer,
@@ -183,6 +187,8 @@ export function buildUpdateAuctionRequest(
     description: draft.description,
     categoryId: draft.categoryId ?? 0,
     startPrice: Number(draft.startPrice || draft.auction.startPrice || 0),
+    bidUnit: Number(draft.auction.bidUnit || 0),
+    minimumBidAmount: Number(draft.auction.bidUnit || 0),
     auctionDurationDays: draft.auction.durationDays,
     location: draft.location,
     images: normalizeImagePayload(draft.images),

--- a/src/services/auction/register/types.ts
+++ b/src/services/auction/register/types.ts
@@ -69,6 +69,8 @@ export interface AuctionCreateRequest {
   categoryId: number;
   price: number | null;
   startPrice: number | null;
+  bidUnit: number | null;
+  minimumBidAmount: number | null;
   auctionDurationDays: number | null;
   allowOffer: boolean;
   images: ProductImagePayload[];
@@ -81,6 +83,8 @@ export interface AuctionUpdateRequest {
   description: string;
   categoryId: number;
   startPrice: number;
+  bidUnit: number;
+  minimumBidAmount: number;
   auctionDurationDays: number;
   location: string;
   images: ProductImagePayload[];

--- a/src/services/mypage/service.ts
+++ b/src/services/mypage/service.ts
@@ -164,6 +164,7 @@ function formatWon(value: number) {
 
 export function toMySellingAuctionViewModel(
   auction: MySellingAuctionItemResponse,
+  sellerLocation = "",
 ): MySellingAuctionViewModel {
   const displayPrice = auction.currentPrice || auction.startPrice;
 
@@ -178,6 +179,7 @@ export function toMySellingAuctionViewModel(
     description: auction.description,
     category: auction.categoryName,
     categoryId: auction.categoryId ?? null,
+    location: sellerLocation,
     bidders: auction.bidderCount,
     bidCount: auction.bidCount,
     canEdit: auction.canEdit,
@@ -232,11 +234,17 @@ export async function fetchMyPageProfile() {
 }
 
 export async function fetchMySellingAuctions(page = 0, size = 20) {
-  const response = await mypageApi.getMySellingAuctions(page, size);
+  const [response, profile] = await Promise.all([
+    mypageApi.getMySellingAuctions(page, size),
+    mypageApi.getMyProfile(),
+  ]);
+  const sellerLocation = profile.location ?? "";
 
   return {
     ...response,
-    content: response.content.map(toMySellingAuctionViewModel),
+    content: response.content.map((auction) =>
+      toMySellingAuctionViewModel(auction, sellerLocation),
+    ),
   };
 }
 

--- a/src/services/mypage/types.ts
+++ b/src/services/mypage/types.ts
@@ -92,6 +92,7 @@ export interface MySellingAuctionViewModel {
   description: string;
   category: string;
   categoryId: number | null;
+  location: string;
   bidders: number;
   bidCount: number;
   canEdit: boolean;


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->

---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
경매상품 상세화면 (이미지 위에 뜸)
실시간 타이머 구현 (일,시,분,초)
지금 실시간 타이머는 백엔드가 내려준 시간을 기준으로 돌고 있습니다.
경매 상세 API에서 받는 값: endsAt,serverTime
프론트 동작: 
- 서버시간 보정값 = serverTime - 브라우저 현재시간
- 현재 서버 기준 시간 = Date.now() + 서버시간 보정값
- 남은 시간 = endsAt - 현재 서버 기준 시간
그래서 화면은 1초마다 프론트에서 갱신하지만, 기준점은 백엔드 serverTime입니다.
단, 매초마다 백엔드에 시간을 다시 물어보는 구조는 아닙니다. 처음 상세 조회할 때 받은 serverTime으로 보정값을 잡고, 이후에는 프론트 타이머로 흘려보냅니다.
즉: 
- 기준 시간: 백엔드 서버시간 
- 화면 갱신: 프론트 setInterval
- 최종 마감 판정: 반드시 백엔드가 결정해야 함
<img width="1416" height="663" alt="스크린샷 2026-05-02 오후 9 54 02" src="https://github.com/user-attachments/assets/5f0348ce-fd1d-452a-a472-490b6de133f4" />

종료 시
<img width="1416" height="637" alt="스크린샷 2026-05-02 오후 9 54 12" src="https://github.com/user-attachments/assets/d713da80-62b7-4707-b913-a51dd32cebb3" />

PS. 현재 입찰시 갱신은 안됨 물론 입찰 후 다시 이페이지로 돌아오면 갱신되지만 실시간은 SSE역할이고 입찰 상세현황도 랭킹을 위해서 SSE완 연관이 있어서 추후에 구현예정
---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #43 
