### PR TITLE
[feat] 딜릿머니 UI구성 및 API연동

### DIFF
--- a/src/app/(main)/mypage/index.tsx
+++ b/src/app/(main)/mypage/index.tsx
@@ -16,6 +16,7 @@ import {
 import { AnimatePresence, motion } from "motion/react";
 
 import { getErrorMessage } from "@/services/apiError";
+import DealitMoneyPanel from "@/components/wallet/DealitMoneyPanel";
 import { fetchMyPageProfile } from "@/services/mypage/service";
 import type { MyPageProfileViewModel } from "@/services/mypage/types";
 
@@ -185,6 +186,8 @@ export default function MyPageScreen({
             <span className="font-bold text-lg">{profile?.wishlistCount ?? 0}</span>
           </button>
         </div>
+
+        <DealitMoneyPanel />
 
         <div className="space-y-2">
           {menus.map((menu) => (

--- a/src/components/wallet/DealitMoneyPanel.tsx
+++ b/src/components/wallet/DealitMoneyPanel.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { Landmark, Plus, ReceiptText, Wallet, X } from "lucide-react";
+
+import { getErrorMessage } from "@/services/apiError";
+import {
+  chargeDealitMoney,
+  fetchWallet,
+  fetchWalletLedgers,
+  formatWon,
+  parseWalletAmount,
+  withdrawDealitMoney,
+} from "@/services/wallet/service";
+import type {
+  WalletLedgerViewModel,
+  WalletViewModel,
+} from "@/services/wallet/service";
+
+type WalletModal = "charge" | "history" | "withdraw" | null;
+
+const QUICK_AMOUNTS = [10000, 30000, 50000, 100000];
+
+export default function DealitMoneyPanel() {
+  const [wallet, setWallet] = useState<WalletViewModel | null>(null);
+  const [ledgers, setLedgers] = useState<WalletLedgerViewModel[]>([]);
+  const [modal, setModal] = useState<WalletModal>(null);
+  const [amountInput, setAmountInput] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isHistoryLoading, setIsHistoryLoading] = useState(false);
+
+  useEffect(() => {
+    let ignore = false;
+
+    fetchWallet()
+      .then((nextWallet) => {
+        if (!ignore) {
+          setWallet(nextWallet);
+          setErrorMessage("");
+        }
+      })
+      .catch((error) => {
+        if (!ignore) {
+          setErrorMessage(
+            getErrorMessage(error, "딜릿머니 잔액을 불러오지 못했습니다."),
+          );
+        }
+      })
+      .finally(() => {
+        if (!ignore) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (modal !== "history") {
+      return;
+    }
+
+    let ignore = false;
+    setIsHistoryLoading(true);
+    fetchWalletLedgers()
+      .then((nextLedgers) => {
+        if (!ignore) {
+          setLedgers(nextLedgers);
+          setErrorMessage("");
+        }
+      })
+      .catch((error) => {
+        if (!ignore) {
+          setErrorMessage(
+            getErrorMessage(error, "딜릿머니 내역을 불러오지 못했습니다."),
+          );
+        }
+      })
+      .finally(() => {
+        if (!ignore) {
+          setIsHistoryLoading(false);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [modal]);
+
+  const openAmountModal = (nextModal: "charge" | "withdraw") => {
+    setAmountInput("");
+    setErrorMessage("");
+    setModal(nextModal);
+  };
+
+  const closeModal = () => {
+    setModal(null);
+    setAmountInput("");
+    setErrorMessage("");
+  };
+
+  const handleSubmitAmount = async () => {
+    const amount = parseWalletAmount(amountInput);
+
+    if (amount <= 0) {
+      setErrorMessage("금액을 입력해주세요.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage("");
+
+    try {
+      const nextWallet =
+        modal === "charge"
+          ? await chargeDealitMoney(amount)
+          : await withdrawDealitMoney(amount);
+      setWallet(nextWallet);
+      closeModal();
+    } catch (error) {
+      setErrorMessage(
+        getErrorMessage(
+          error,
+          modal === "charge"
+            ? "딜릿머니 충전에 실패했습니다."
+            : "출금 신청에 실패했습니다.",
+        ),
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="rounded-2xl bg-black px-5 py-5 text-white shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-sm font-semibold text-white/70">
+            <Wallet size={16} />
+            <span>딜릿머니</span>
+          </div>
+          <div className="text-2xl font-bold tracking-normal">
+            {isLoading ? "불러오는 중" : wallet?.balanceLabel ?? "0원"}
+          </div>
+        </div>
+        <div className="rounded-full bg-white/10 px-3 py-1 text-xs font-semibold text-white/70">
+          DEALIT
+        </div>
+      </div>
+
+      {errorMessage && !modal && (
+        <div className="mt-4 rounded-lg bg-white/10 px-3 py-2 text-xs text-red-100">
+          {errorMessage}
+        </div>
+      )}
+
+      <div className="mt-5 grid grid-cols-3 gap-2">
+        <MoneyActionButton
+          icon={<Plus size={18} />}
+          label="충전"
+          onClick={() => openAmountModal("charge")}
+        />
+        <MoneyActionButton
+          icon={<ReceiptText size={18} />}
+          label="내역"
+          onClick={() => setModal("history")}
+        />
+        <MoneyActionButton
+          icon={<Landmark size={18} />}
+          label="내 계좌로 옮기기"
+          onClick={() => openAmountModal("withdraw")}
+        />
+      </div>
+
+      {modal && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40 p-6 text-black backdrop-blur-sm">
+          <div className="w-full rounded-2xl bg-white p-5 shadow-2xl">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-bold">{getModalTitle(modal)}</h2>
+              <button
+                type="button"
+                onClick={closeModal}
+                className="rounded-full p-2 text-gray-400 hover:bg-gray-100"
+                aria-label="닫기"
+              >
+                <X size={20} />
+              </button>
+            </div>
+
+            {modal === "history" ? (
+              <WalletHistoryContent
+                ledgers={ledgers}
+                isLoading={isHistoryLoading}
+              />
+            ) : (
+              <div className="mt-5 space-y-4">
+                <div className="grid grid-cols-2 gap-2">
+                  {QUICK_AMOUNTS.map((amount) => (
+                    <button
+                      key={amount}
+                      type="button"
+                      onClick={() => setAmountInput(String(amount))}
+                      className="h-11 rounded-lg bg-gray-100 text-sm font-bold hover:bg-gray-200"
+                    >
+                      {formatWon(amount)}
+                    </button>
+                  ))}
+                </div>
+                <input
+                  value={amountInput}
+                  onChange={(event) => setAmountInput(event.target.value)}
+                  inputMode="numeric"
+                  placeholder="금액 직접 입력"
+                  className="h-12 w-full rounded-lg border border-gray-200 px-4 text-base font-semibold outline-none focus:border-black"
+                />
+                {errorMessage && (
+                  <div className="rounded-lg bg-red-50 px-3 py-2 text-xs text-red-500">
+                    {errorMessage}
+                  </div>
+                )}
+                <button
+                  type="button"
+                  onClick={handleSubmitAmount}
+                  disabled={isSubmitting}
+                  className="h-12 w-full rounded-lg bg-black text-sm font-bold text-white disabled:bg-gray-300"
+                >
+                  {isSubmitting ? "처리 중" : getSubmitLabel(modal)}
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function MoneyActionButton({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex h-16 flex-col items-center justify-center gap-1 rounded-xl bg-white/10 px-1 text-[11px] font-bold text-white transition-colors hover:bg-white/15"
+    >
+      {icon}
+      <span className="leading-tight">{label}</span>
+    </button>
+  );
+}
+
+function WalletHistoryContent({
+  ledgers,
+  isLoading,
+}: {
+  ledgers: WalletLedgerViewModel[];
+  isLoading: boolean;
+}) {
+  if (isLoading) {
+    return <div className="py-12 text-center text-sm text-gray-400">불러오는 중</div>;
+  }
+
+  if (ledgers.length === 0) {
+    return (
+      <div className="py-12 text-center text-sm text-gray-400">
+        딜릿머니 내역이 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-4 max-h-80 overflow-y-auto">
+      {ledgers.map((ledger) => (
+        <div
+          key={ledger.id}
+          className="flex items-center justify-between border-b border-gray-100 py-3 last:border-b-0"
+        >
+          <div className="min-w-0">
+            <div className="font-semibold">{ledger.typeLabel}</div>
+            <div className="mt-1 truncate text-xs text-gray-400">
+              {ledger.createdAtLabel || ledger.description}
+            </div>
+          </div>
+          <div className="text-right">
+            <div
+              className={`font-bold ${
+                ledger.isIncome ? "text-green-600" : "text-gray-900"
+              }`}
+            >
+              {ledger.amountLabel}
+            </div>
+            <div className="mt-1 text-xs text-gray-400">
+              잔액 {ledger.balanceAfterLabel}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function getModalTitle(modal: Exclude<WalletModal, null>) {
+  switch (modal) {
+    case "charge":
+      return "딜릿머니 충전";
+    case "withdraw":
+      return "내 계좌로 옮기기";
+    case "history":
+      return "딜릿머니 내역";
+  }
+}
+
+function getSubmitLabel(modal: Exclude<WalletModal, null>) {
+  return modal === "charge" ? "충전하기" : "출금 신청";
+}

--- a/src/services/wallet/api.ts
+++ b/src/services/wallet/api.ts
@@ -1,0 +1,99 @@
+import { ApiRequestError, getApiErrorMessage } from "@/services/apiError";
+import {
+  getAuthorizationHeaders,
+  handleUnauthorizedAccess,
+} from "@/services/auth/service";
+import type {
+  WalletAmountRequest,
+  WalletLedgerListResponse,
+  WalletResponse,
+} from "@/services/wallet/types";
+
+async function throwProtectedApiError(
+  response: Response,
+  fallbackMessage: string,
+) {
+  if (response.status === 401) {
+    handleUnauthorizedAccess();
+  }
+
+  throw new ApiRequestError(
+    await getApiErrorMessage(response, fallbackMessage),
+    response.status,
+  );
+}
+
+export async function getWallet(): Promise<WalletResponse> {
+  const response = await fetch("/api/v1/wallet", {
+    method: "GET",
+    headers: getAuthorizationHeaders(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    await throwProtectedApiError(response, "딜릿머니 잔액을 불러오지 못했습니다.");
+  }
+
+  return response.json();
+}
+
+export async function getWalletLedgers(
+  page = 0,
+  size = 20,
+): Promise<WalletLedgerListResponse> {
+  const searchParams = new URLSearchParams({
+    page: String(page),
+    size: String(size),
+  });
+  const response = await fetch(
+    `/api/v1/wallet/ledgers?${searchParams.toString()}`,
+    {
+      method: "GET",
+      headers: getAuthorizationHeaders(),
+      cache: "no-store",
+    },
+  );
+
+  if (!response.ok) {
+    await throwProtectedApiError(response, "딜릿머니 내역을 불러오지 못했습니다.");
+  }
+
+  return response.json();
+}
+
+export async function chargeWallet(
+  payload: WalletAmountRequest,
+): Promise<WalletResponse> {
+  return postWalletAmount("/api/v1/wallet/charge", payload, "딜릿머니 충전에 실패했습니다.");
+}
+
+export async function withdrawWallet(
+  payload: WalletAmountRequest,
+): Promise<WalletResponse> {
+  return postWalletAmount(
+    "/api/v1/wallet/withdraw",
+    payload,
+    "출금 신청에 실패했습니다.",
+  );
+}
+
+async function postWalletAmount(
+  url: string,
+  payload: WalletAmountRequest,
+  fallbackMessage: string,
+): Promise<WalletResponse> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...getAuthorizationHeaders(),
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    await throwProtectedApiError(response, fallbackMessage);
+  }
+
+  return response.json();
+}

--- a/src/services/wallet/service.ts
+++ b/src/services/wallet/service.ts
@@ -1,0 +1,107 @@
+import * as walletApi from "@/services/wallet/api";
+import type {
+  WalletLedgerResponse,
+  WalletLedgerType,
+  WalletResponse,
+} from "@/services/wallet/types";
+
+export interface WalletViewModel {
+  walletId: number;
+  balance: number;
+  balanceLabel: string;
+}
+
+export interface WalletLedgerViewModel {
+  id: number;
+  type: WalletLedgerType;
+  typeLabel: string;
+  amount: number;
+  amountLabel: string;
+  balanceAfterLabel: string;
+  description: string;
+  createdAtLabel: string;
+  isIncome: boolean;
+}
+
+export function formatWon(value: number) {
+  return `${value.toLocaleString("ko-KR")}원`;
+}
+
+export function parseWalletAmount(value: string) {
+  const numericValue = Number(value.replace(/[^0-9]/g, ""));
+  return Number.isFinite(numericValue) ? numericValue : 0;
+}
+
+export function toWalletViewModel(wallet: WalletResponse): WalletViewModel {
+  return {
+    walletId: wallet.walletId,
+    balance: wallet.balance,
+    balanceLabel: formatWon(wallet.balance),
+  };
+}
+
+export function toWalletLedgerViewModel(
+  ledger: WalletLedgerResponse,
+): WalletLedgerViewModel {
+  const isIncome = ledger.amount > 0;
+
+  return {
+    id: ledger.ledgerId,
+    type: ledger.type,
+    typeLabel: getWalletLedgerTypeLabel(ledger.type),
+    amount: ledger.amount,
+    amountLabel: `${isIncome ? "+" : "-"}${formatWon(Math.abs(ledger.amount))}`,
+    balanceAfterLabel: formatWon(ledger.balanceAfter),
+    description: ledger.description,
+    createdAtLabel: formatWalletDate(ledger.createdAt),
+    isIncome,
+  };
+}
+
+export async function fetchWallet() {
+  return toWalletViewModel(await walletApi.getWallet());
+}
+
+export async function fetchWalletLedgers() {
+  const response = await walletApi.getWalletLedgers();
+  return response.content.map(toWalletLedgerViewModel);
+}
+
+export async function chargeDealitMoney(amount: number) {
+  return toWalletViewModel(await walletApi.chargeWallet({ amount }));
+}
+
+export async function withdrawDealitMoney(amount: number) {
+  return toWalletViewModel(await walletApi.withdrawWallet({ amount }));
+}
+
+function getWalletLedgerTypeLabel(type: WalletLedgerType) {
+  switch (type) {
+    case "TEMP_CHARGE":
+      return "충전";
+    case "REFUND":
+      return "환불";
+    case "WITHDRAWAL":
+      return "출금";
+    default:
+      return "내역";
+  }
+}
+
+function formatWalletDate(value: string | null) {
+  if (!value) {
+    return "";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}

--- a/src/services/wallet/types.ts
+++ b/src/services/wallet/types.ts
@@ -1,0 +1,28 @@
+export type WalletLedgerType = "TEMP_CHARGE" | "REFUND" | "WITHDRAWAL";
+
+export interface WalletResponse {
+  walletId: number;
+  memberId: number;
+  balance: number;
+}
+
+export interface WalletAmountRequest {
+  amount: number;
+}
+
+export interface WalletLedgerResponse {
+  ledgerId: number;
+  type: WalletLedgerType;
+  amount: number;
+  balanceAfter: number;
+  description: string;
+  createdAt: string | null;
+}
+
+export interface WalletLedgerListResponse {
+  content: WalletLedgerResponse[];
+  page: number;
+  size: number;
+  totalElements: number;
+  hasNext: boolean;
+}


### PR DESCRIPTION
 ### 🚀 Summary

  마이페이지에 딜릿머니 컴포넌트를 추가하고, 잔액 조회, 충전, 내역 확인, 출금 신청 UI를 구현했습니다.

  ---

  ### ✨ Description

  - 마이페이지에 딜릿머니 영역을 추가했습니다.
    - 현재 딜릿머니 잔액 표시
    - `충전`, `내역`, `내 계좌로 옮기기` 버튼 제공
  - 딜릿머니 충전 기능을 구현했습니다.
    - 빠른 금액 선택
    - 직접 금액 입력
    - 충전 API 연동
    - 충전 완료 후 잔액 갱신
  - 딜릿머니 내역 모달을 구현했습니다.
    - 충전/환불/출금 내역 표시
    - 입금/차감 금액을 `+`, `-`로 구분
    - 각 내역의 처리 후 잔액 표시
  - 내 계좌로 옮기기 기능 구현했습니다.
    - 출금 금액 입력
    - 출금 신청 API 연동
    - 처리 완료 후 잔액 갱신


  참고 사항:
  - 현재 충전은 외부 결제 연동 없이 백엔드 임시 충전 API를 호출하는 MVP 구현입니다.
  - 내 계좌로 옮기기도 실제 계좌 이체 없이 백엔드 출금 처리 API를 호출하는 임시 구현입니다.


 결과 첨부:
<img width="784" height="677" alt="image" src="https://github.com/user-attachments/assets/c7f2afed-9fd8-4c48-9bb0-8e3dee4314e2" />

<img width="722" height="458" alt="image" src="https://github.com/user-attachments/assets/62d7346f-6114-4614-978a-373eadf8ff37" />



### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #53 
