### PR TITLE
[Feat] 일반 상품 상세 페이지 목업 제거 및 이미지 크기 제한 & 핫한 상품 페이지 구현

### DIFF
--- a/src/app/(main)/home/index.tsx
+++ b/src/app/(main)/home/index.tsx
@@ -1,21 +1,21 @@
 "use client";
-import React, { useState, useEffect } from 'react';
-import { 
-  ChevronLeft, 
-  Check, 
-  ChevronRight, 
-  User, 
-  Camera, 
-  Search, 
-  Home, 
-  PlusCircle, 
-  MessageCircle, 
-  Heart, 
-  Bell, 
-  Filter, 
+import React, { useState, useEffect } from "react";
+import {
+  ChevronLeft,
+  Check,
+  ChevronRight,
+  User,
+  Camera,
+  Search,
+  Home,
+  PlusCircle,
+  MessageCircle,
+  Heart,
+  Bell,
+  Filter,
   Settings,
-  MoreVertical, 
-  Send, 
+  MoreVertical,
+  Send,
   Star,
   Clock,
   ArrowUpRight,
@@ -29,19 +29,20 @@ import {
   Menu,
   ShoppingBag,
   Store,
-  Receipt
-} from 'lucide-react';
-import { motion, AnimatePresence } from 'motion/react';
+  Receipt,
+} from "lucide-react";
+import { motion, AnimatePresence } from "motion/react";
 
-import { Screen, Tab } from '../../../types/index';
-import { ExploreIcon } from '../../../components/common/ExploreIcon';
-import ProductListItem from '../../../components/product/ProductListItem';
+import { Screen, Tab } from "../../../types/index";
+import { ExploreIcon } from "../../../components/common/ExploreIcon";
+import ProductListItem from "../../../components/product/ProductListItem";
 import { getErrorMessage } from "@/services/apiError";
 import { fetchPopularRegularProducts } from "@/services/product/popular/service";
+import { fetchHotRegularProducts } from "@/services/product/hotList/service";
 import type { PopularProductItemViewModel } from "@/services/product/popular/types";
 
-export default function HomeScreen({ 
-  onProductClick, 
+export default function HomeScreen({
+  onProductClick,
   onProductListClick,
   onNotificationClick,
   onCategoryResetClick,
@@ -49,22 +50,26 @@ export default function HomeScreen({
   onWishlistClick,
   mode,
   onModeChange,
-  onTabChange
-}: { 
-  onProductClick: (id: number) => void; 
-  onProductListClick: (type: 'all' | 'closing_soon' | 'recent', category?: string) => void;
+  onTabChange,
+}: {
+  onProductClick: (id: number) => void;
+  onProductListClick: (
+    type: "all" | "closing_soon" | "recent",
+    category?: string,
+  ) => void;
   onNotificationClick: () => void;
   onCategoryResetClick: () => void;
   onSearchClick: () => void;
   onWishlistClick: () => void;
-  mode: 'regular' | 'auction';
-  onModeChange: (mode: 'regular' | 'auction') => void;
+  mode: "regular" | "auction";
+  onModeChange: (mode: "regular" | "auction") => void;
   onTabChange: (tab: Tab) => void;
 }) {
-  const themeColor = mode === 'regular' ? '#98E446' : '#F64257';
-  const logoUrl = mode === 'regular' 
-    ? 'https://i.ibb.co/FLydFL1L/2026-03-22-201249.png' 
-    : 'https://i.ibb.co/6RrSfG14/image.png';
+  const themeColor = mode === "regular" ? "#98E446" : "#F64257";
+  const logoUrl =
+    mode === "regular"
+      ? "https://i.ibb.co/FLydFL1L/2026-03-22-201249.png"
+      : "https://i.ibb.co/6RrSfG14/image.png";
 
   const [currentBanner, setCurrentBanner] = useState(0);
   const [popularProducts, setPopularProducts] = useState<
@@ -72,40 +77,49 @@ export default function HomeScreen({
   >([]);
   const [isPopularLoading, setIsPopularLoading] = useState(false);
   const [popularErrorMessage, setPopularErrorMessage] = useState("");
-  const closingProductIds = mode === 'auction' ? [] : [1, 2, 3];
-  const banners = mode === 'regular' ? [
-    {
-      title: '봄맞이 일반 판매',
-      subtitle: '최대 70% 할인 기회',
-      image: 'https://images.unsplash.com/photo-1500622944204-b135684e99fd?q=80&w=2061&auto=format&fit=crop',
-    },
-    {
-      title: '새로운 상품 업데이트',
-      subtitle: '매일 만나는 새로운 보물들',
-      image: 'https://images.unsplash.com/photo-1441986300917-64674bd600d8?q=80&w=2070&auto=format&fit=crop',
-    },
-    {
-      title: '안전한 직거래',
-      subtitle: '우리 동네에서 만나는 믿을 수 있는 이웃',
-      image: 'https://images.unsplash.com/photo-1556742049-0cfed4f6a45d?q=80&w=2070&auto=format&fit=crop',
-    }
-  ] : [
-    {
-      title: '프리미엄 옥션',
-      subtitle: '희귀템을 내 손에',
-      image: 'https://images.unsplash.com/photo-1550009158-9ebf69173e03?q=80&w=2001&auto=format&fit=crop',
-    },
-    {
-      title: '실시간 인기경매',
-      subtitle: '지금 핫한 경매상품',
-      image: 'https://images.unsplash.com/photo-1605810230434-7631ac76ec81?q=80&w=2070&auto=format&fit=crop',
-    },
-    {
-      title: '마감 임박 경매',
-      subtitle: '놓치면 후회하는 마지막 기회',
-      image: 'https://images.unsplash.com/photo-1501139083538-0139583c060f?q=80&w=2070&auto=format&fit=crop',
-    }
-  ];
+  const [hotProducts, setHotProducts] = useState<any[]>([]);
+  const banners =
+    mode === "regular"
+      ? [
+          {
+            title: "봄맞이 일반 판매",
+            subtitle: "최대 70% 할인 기회",
+            image:
+              "https://images.unsplash.com/photo-1500622944204-b135684e99fd?q=80&w=2061&auto=format&fit=crop",
+          },
+          {
+            title: "새로운 상품 업데이트",
+            subtitle: "매일 만나는 새로운 보물들",
+            image:
+              "https://images.unsplash.com/photo-1441986300917-64674bd600d8?q=80&w=2070&auto=format&fit=crop",
+          },
+          {
+            title: "안전한 직거래",
+            subtitle: "우리 동네에서 만나는 믿을 수 있는 이웃",
+            image:
+              "https://images.unsplash.com/photo-1556742049-0cfed4f6a45d?q=80&w=2070&auto=format&fit=crop",
+          },
+        ]
+      : [
+          {
+            title: "프리미엄 옥션",
+            subtitle: "희귀템을 내 손에",
+            image:
+              "https://images.unsplash.com/photo-1550009158-9ebf69173e03?q=80&w=2001&auto=format&fit=crop",
+          },
+          {
+            title: "실시간 인기경매",
+            subtitle: "지금 핫한 경매상품",
+            image:
+              "https://images.unsplash.com/photo-1605810230434-7631ac76ec81?q=80&w=2070&auto=format&fit=crop",
+          },
+          {
+            title: "마감 임박 경매",
+            subtitle: "놓치면 후회하는 마지막 기회",
+            image:
+              "https://images.unsplash.com/photo-1501139083538-0139583c060f?q=80&w=2070&auto=format&fit=crop",
+          },
+        ];
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -152,41 +166,85 @@ export default function HomeScreen({
     };
   }, [mode]);
 
+  useEffect(() => {
+    if (mode !== "regular") {
+      setHotProducts([]);
+      return;
+    }
+
+    let ignore = false;
+
+    fetchHotRegularProducts(8)
+      .then((products) => {
+        if (!ignore) {
+          // Home shows top 3, more page will request up to 8
+          setHotProducts(products.slice(0, 3));
+        }
+      })
+      .catch(() => {
+        if (!ignore) {
+          setHotProducts([]);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [mode]);
+
   return (
     <div className="flex flex-col h-full bg-white">
       {/* Header */}
       <div className="h-16 flex items-center px-4 justify-between bg-white z-30 shrink-0 border-b border-gray-50">
         <div className="flex items-center space-x-2">
-          <img src={logoUrl} alt="Deal it" className="h-6 object-contain" referrerPolicy="no-referrer" />
-          
+          <img
+            src={logoUrl}
+            alt="Deal it"
+            className="h-6 object-contain"
+            referrerPolicy="no-referrer"
+          />
+
           {/* Toggle Switch */}
-          <div 
-            onClick={() => onModeChange(mode === 'regular' ? 'auction' : 'regular')}
+          <div
+            onClick={() =>
+              onModeChange(mode === "regular" ? "auction" : "regular")
+            }
             className="h-7 bg-gray-100 rounded-full relative cursor-pointer p-1 transition-colors flex items-center"
-            style={{ width: '110px' }}
+            style={{ width: "110px" }}
           >
-            <motion.div 
-              animate={{ x: mode === 'regular' ? 0 : 48 }}
+            <motion.div
+              animate={{ x: mode === "regular" ? 0 : 48 }}
               className="h-5 rounded-full shadow-sm flex items-center justify-center px-2"
-              style={{ backgroundColor: themeColor, width: '54px' }}
+              style={{ backgroundColor: themeColor, width: "54px" }}
             >
-              <span 
+              <span
                 className="text-[9px] font-black whitespace-nowrap transition-colors duration-300"
-                style={{ color: mode === 'regular' ? '#000000' : '#FFFFFF' }}
+                style={{ color: mode === "regular" ? "#000000" : "#FFFFFF" }}
               >
-                {mode === 'regular' ? '판매상품' : 'Dealit'}
+                {mode === "regular" ? "판매상품" : "Dealit"}
               </span>
             </motion.div>
           </div>
         </div>
-        
+
         <div className="flex items-center space-x-2">
-          <button onClick={onSearchClick} className="p-1.5 hover:bg-gray-50 rounded-full transition-colors"><Search size={22} /></button>
-          <button onClick={onNotificationClick} className="p-1.5 hover:bg-gray-50 rounded-full transition-colors relative">
+          <button
+            onClick={onSearchClick}
+            className="p-1.5 hover:bg-gray-50 rounded-full transition-colors"
+          >
+            <Search size={22} />
+          </button>
+          <button
+            onClick={onNotificationClick}
+            className="p-1.5 hover:bg-gray-50 rounded-full transition-colors relative"
+          >
             <Bell size={22} />
             <span className="absolute top-2 right-2 w-2 h-2 bg-red-500 rounded-full border border-white"></span>
           </button>
-          <button onClick={onWishlistClick} className="p-1.5 hover:bg-gray-50 rounded-full transition-colors">
+          <button
+            onClick={onWishlistClick}
+            className="p-1.5 hover:bg-gray-50 rounded-full transition-colors"
+          >
             <Heart size={22} />
           </button>
         </div>
@@ -205,20 +263,22 @@ export default function HomeScreen({
               transition={{ duration: 0.25, ease: "easeInOut" }}
               className="absolute inset-0"
             >
-              <div 
+              <div
                 className="w-full h-full bg-cover bg-center relative"
-                style={{ backgroundImage: `url(${banners[currentBanner].image})` }}
+                style={{
+                  backgroundImage: `url(${banners[currentBanner].image})`,
+                }}
               >
                 {/* Overlays */}
                 <div className="absolute inset-0 bg-black/20"></div>
-                <div 
+                <div
                   className="absolute inset-0 opacity-40"
                   style={{ backgroundColor: themeColor }}
                 ></div>
-                
+
                 {/* Banner Text */}
                 <div className="absolute inset-0 px-6 flex flex-col justify-center text-white z-10">
-                  <motion.h2 
+                  <motion.h2
                     initial={{ y: 10, opacity: 0 }}
                     animate={{ y: 0, opacity: 1 }}
                     transition={{ delay: 0.2 }}
@@ -226,7 +286,7 @@ export default function HomeScreen({
                   >
                     {banners[currentBanner].title}
                   </motion.h2>
-                  <motion.p 
+                  <motion.p
                     initial={{ y: 10, opacity: 0 }}
                     animate={{ y: 0, opacity: 1 }}
                     transition={{ delay: 0.3 }}
@@ -238,10 +298,12 @@ export default function HomeScreen({
               </div>
             </motion.div>
           </AnimatePresence>
-          
+
           {/* Pagination Indicator */}
           <div className="absolute bottom-4 right-4 bg-black/40 backdrop-blur-md px-3 py-1 rounded-full text-white text-[10px] font-bold flex items-center space-x-1 z-20">
-            <span>{currentBanner + 1} / {banners.length}</span>
+            <span>
+              {currentBanner + 1} / {banners.length}
+            </span>
             <ChevronRight size={12} />
           </div>
         </div>
@@ -253,16 +315,18 @@ export default function HomeScreen({
             <div className="flex items-center justify-between">
               <h3 className="text-lg font-bold flex items-center space-x-1.5">
                 <span className="text-xl">🔥</span>
-                <span>{mode === 'regular' ? '실시간 인기' : '실시간 인기 경매'}</span>
+                <span>
+                  {mode === "regular" ? "실시간 인기" : "실시간 인기 경매"}
+                </span>
               </h3>
-              <button 
-                onClick={() => onProductListClick('all')}
+              <button
+                onClick={() => onProductListClick("all")}
                 className="text-xs text-gray-400 flex items-center hover:text-gray-600 transition-colors"
               >
                 전체목록보기 <ChevronRight size={14} />
               </button>
             </div>
-            
+
             {mode !== "regular" ? (
               <div className="flex h-32 items-center justify-center rounded-2xl border border-dashed border-gray-200 text-sm font-medium text-gray-400">
                 등록된 경매 상품이 없습니다
@@ -339,26 +403,34 @@ export default function HomeScreen({
           <div className="space-y-5">
             <div className="flex items-center justify-between">
               <h3 className="text-lg font-bold flex items-center space-x-1.5">
-                <span className="text-xl">{mode === 'regular' ? '⏰' : '⌛'}</span>
-                <span>{mode === 'regular' ? '핫한 상품' : '마감 임박'}</span>
+                <span className="text-xl">
+                  {mode === "regular" ? "⏰" : "⌛"}
+                </span>
+                <span>{mode === "regular" ? "핫한 상품" : "마감 임박"}</span>
               </h3>
-              <button 
-                onClick={() => onProductListClick('closing_soon')}
+              <button
+                onClick={() => onProductListClick("closing_soon")}
                 className="text-xs text-gray-400 flex items-center hover:text-gray-600 transition-colors"
               >
                 더보기 <ChevronRight size={14} />
               </button>
             </div>
-            
-            {closingProductIds.length > 0 ? (
+
+            {hotProducts.length > 0 ? (
               <div className="space-y-4">
-                {closingProductIds.map((i) => (
-                  <ProductListItem key={i} i={i} mode={mode} themeColor={themeColor} onProductClick={onProductClick} />
+                {hotProducts.map((p) => (
+                  <ProductListItem
+                    key={p.productId}
+                    product={p}
+                    mode={mode}
+                    themeColor={themeColor}
+                    onProductClick={onProductClick}
+                  />
                 ))}
               </div>
             ) : (
               <div className="flex h-32 items-center justify-center rounded-2xl border border-dashed border-gray-200 text-sm font-medium text-gray-400">
-                마감 임박 경매 상품이 없습니다
+                핫한 상품이 없습니다
               </div>
             )}
           </div>

--- a/src/app/products/[productId]/index.tsx
+++ b/src/app/products/[productId]/index.tsx
@@ -129,8 +129,7 @@ export default function ProductDetailScreen({
   const [currentTimeMs, setCurrentTimeMs] = useState(() => Date.now());
   const [auctionClockOffsetMs, setAuctionClockOffsetMs] = useState(0);
 
-  const resolvedMode =
-    productData?.saleType === "AUCTION" ? "auction" : mode;
+  const resolvedMode = productData?.saleType === "AUCTION" ? "auction" : mode;
   const isRegular = resolvedMode === "regular";
   const regularPrice = productData
     ? productDetailService.getProductPrice(productData)
@@ -158,14 +157,15 @@ export default function ProductDetailScreen({
   const minBidAmount =
     auctionDetail?.minimumNextBidPrice ?? currentPrice + bidUnit;
 
-  const displayName = auctionDetail?.name ?? productData?.name ?? "상품 정보 없음";
+  const displayName =
+    auctionDetail?.name ?? productData?.name ?? "상품 정보 없음";
   const displayDescription =
     auctionDetail?.description ??
     productData?.description ??
     "상품 설명이 없습니다.";
   const displayImageUrl = !isRegular
     ? getAuctionMainImageUrl(auctionDetail)
-    : productData?.imageUrls?.[0] ?? null;
+    : (productData?.imageUrls?.[0] ?? null);
   const displayCategoryName =
     auctionDetail?.categoryName ??
     productData?.category?.nameKo ??
@@ -176,9 +176,12 @@ export default function ProductDetailScreen({
     "판매자 정보 없음";
   const displaySellerImageUrl =
     auctionDetail?.seller.profileImageUrl ??
-    "https://picsum.photos/seed/seller/100/100";
+    productData?.seller?.profileImageUrl ??
+    null;
   const displayLocation =
-    auctionDetail?.location ?? productData?.seller?.location ?? "지역 정보 없음";
+    auctionDetail?.location ??
+    productData?.seller?.location ??
+    "지역 정보 없음";
   const displayStatus = productData?.status ?? "정보 없음";
   const resolvedViewCount = productData
     ? productDetailService.getViewCount(productData)
@@ -195,14 +198,25 @@ export default function ProductDetailScreen({
     : "정보 없음";
   const scheduledStartLabel = formatScheduleLabel(auctionStartAt);
 
-  // 새롭게 추가된 판매자 프로필용 변수 (API 연동 전 임시 데이터)
-  const displaySellerBio = "좋은 거래 부탁드려요.";
-  const displaySellerRating = "4.8";
-  const displaySellerWarning = "0회";
+  const displaySellerBio = productData?.seller?.bio ?? "정보없음";
+  const displaySellerRating =
+    productData?.seller?.rating == null
+      ? "정보없음"
+      : productData.seller.rating.toFixed(1);
+  const displaySellerWarning =
+    productData?.seller?.warningCount == null
+      ? "정보없음"
+      : `${productData.seller.warningCount}회`;
   const displaySellerAddress = displayLocation;
-  const sellerRecentSales: Array<{ title: string; price: string; status: string }> = [
-    // 필요 시 여기에 더미 데이터를 추가할 수 있습니다.
-  ];
+  const sellerRecentSales = productData?.seller?.recentSales ?? [];
+
+  function formatSellerRecentSalePrice(price?: number | null) {
+    if (price == null) {
+      return "정보없음";
+    }
+
+    return `${price.toLocaleString()}원`;
+  }
 
   useEffect(() => {
     if (regularPrice != null) {
@@ -361,7 +375,9 @@ export default function ProductDetailScreen({
 
       setIsLiked(result.liked);
       setFavoriteCount(result.favoriteCount);
-      showToast(result.liked ? "찜 목록에 추가했습니다." : "찜을 취소했습니다.");
+      showToast(
+        result.liked ? "찜 목록에 추가했습니다." : "찜을 취소했습니다.",
+      );
     } catch (error) {
       showToast(getErrorMessage(error, "찜 처리에 실패했습니다."));
     } finally {
@@ -452,15 +468,15 @@ export default function ProductDetailScreen({
       </div>
 
       <div className="flex-1 overflow-y-auto pb-24 no-scrollbar">
-        <div className="aspect-square bg-gray-100">
+        <div className="flex w-full justify-center bg-gray-100 p-4">
           {displayImageUrl ? (
             <img
               src={displayImageUrl}
               alt={displayName}
-              className="w-full h-full object-cover"
+              className="max-w-125 max-h-125 w-full h-auto object-contain"
             />
           ) : (
-            <div className="w-full h-full flex items-center justify-center text-gray-300">
+            <div className="flex aspect-square w-full max-w-125 items-center justify-center text-gray-300">
               <ImageIcon size={56} />
             </div>
           )}
@@ -572,13 +588,27 @@ export default function ProductDetailScreen({
           >
             <div className="flex items-center space-x-3">
               <div className="w-12 h-12 rounded-full bg-gray-100 overflow-hidden">
-                <img src={displaySellerImageUrl} alt="Seller" />
+                {displaySellerImageUrl ? (
+                  <img
+                    src={displaySellerImageUrl}
+                    alt="Seller"
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center text-gray-300">
+                    <ImageIcon size={20} />
+                  </div>
+                )}
               </div>
               <div>
                 <p className="font-bold text-sm">{displaySellerName}</p>
                 <div className="flex items-center space-x-1 text-[10px] text-gray-400">
                   <Star size={10} className="fill-yellow-400 text-yellow-400" />
-                  <span>4.8 (거래 34회)</span>
+                  <span>
+                    {displaySellerRating === "정보없음"
+                      ? "정보없음"
+                      : `${displaySellerRating} (거래 ${sellerRecentSales.length}건)`}
+                  </span>
                 </div>
               </div>
             </div>
@@ -706,7 +736,9 @@ export default function ProductDetailScreen({
                 <div className="grid grid-cols-2 gap-2">
                   <button
                     onClick={() => handleBidSubmit(currentPrice + 30000)}
-                    disabled={isBidSubmitting || currentPrice + 30000 < minBidAmount}
+                    disabled={
+                      isBidSubmitting || currentPrice + 30000 < minBidAmount
+                    }
                     className="h-12 border border-blue-200 bg-blue-50 text-blue-700 rounded-xl text-sm font-bold hover:bg-blue-100 transition-colors disabled:opacity-50"
                   >
                     ₩{(currentPrice + 30000).toLocaleString()}
@@ -758,10 +790,17 @@ export default function ProductDetailScreen({
 
               <div className="flex items-center space-x-4">
                 <div className="w-16 h-16 rounded-full bg-gray-100 overflow-hidden">
-                  <img
-                    src={displaySellerImageUrl}
-                    alt="Seller"
-                  />
+                  {displaySellerImageUrl ? (
+                    <img
+                      src={displaySellerImageUrl}
+                      alt="Seller"
+                      className="w-full h-full object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-gray-300">
+                      <ImageIcon size={24} />
+                    </div>
+                  )}
                 </div>
                 <div>
                   <h3 className="text-xl font-bold">{displaySellerName}</h3>
@@ -809,14 +848,16 @@ export default function ProductDetailScreen({
                         className="flex items-center justify-between p-3 bg-gray-50 rounded-xl"
                       >
                         <span className="text-sm font-medium text-gray-800">
-                          {item.title}
+                          {item.title ?? "정보없음"}
                         </span>
                         <div className="text-right">
-                          <p className="text-xs font-bold">{item.price}</p>
+                          <p className="text-xs font-bold">
+                            {formatSellerRecentSalePrice(item.price)}
+                          </p>
                           <p
                             className={`text-[10px] ${item.status === "판매완료" ? "text-gray-400" : "text-blue-500"}`}
                           >
-                            {item.status}
+                            {item.status ?? "정보없음"}
                           </p>
                         </div>
                       </div>

--- a/src/app/products/index.tsx
+++ b/src/app/products/index.tsx
@@ -1,21 +1,21 @@
 "use client";
-import React, { useState, useEffect } from 'react';
-import { 
-  ChevronLeft, 
-  Check, 
-  ChevronRight, 
-  User, 
-  Camera, 
-  Search, 
-  Home, 
-  PlusCircle, 
-  MessageCircle, 
-  Heart, 
-  Bell, 
-  Filter, 
+import React, { useState, useEffect } from "react";
+import {
+  ChevronLeft,
+  Check,
+  ChevronRight,
+  User,
+  Camera,
+  Search,
+  Home,
+  PlusCircle,
+  MessageCircle,
+  Heart,
+  Bell,
+  Filter,
   Settings,
-  MoreVertical, 
-  Send, 
+  MoreVertical,
+  Send,
   Star,
   Clock,
   ArrowUpRight,
@@ -29,17 +29,76 @@ import {
   Menu,
   ShoppingBag,
   Store,
-  Receipt
-} from 'lucide-react';
-import { motion, AnimatePresence } from 'motion/react';
+  Receipt,
+} from "lucide-react";
+import { motion, AnimatePresence } from "motion/react";
 
-import { Screen, Tab } from '../../types/index';
-import { ExploreIcon } from '../../components/common/ExploreIcon';
-import ProductListItem from '../../components/product/ProductListItem';
+import { Screen, Tab } from "../../types/index";
+import { ExploreIcon } from "../../components/common/ExploreIcon";
+import ProductListItem from "../../components/product/ProductListItem";
+import { fetchHotRegularProducts } from "@/services/product/hotList/service";
+import { getErrorMessage } from "@/services/apiError";
 
-export default function ProductListScreen({ listType, categoryName, onBack, onProductClick, onSearchClick, themeColor, mode }: { listType: 'all' | 'closing_soon' | 'recent'; categoryName: string | null; onBack: () => void; onProductClick: (id: number) => void; onSearchClick: () => void; themeColor: string; mode: 'regular' | 'auction'; key?: string | number }) {
-  const title = categoryName || (listType === 'all' ? '전체 목록' : (listType === 'recent' ? '최근 본 상품' : (mode === 'regular' ? '핫한 상품' : '마감 임박 상품')));
-  const itemIds = mode === 'auction' ? [] : [1, 2, 3, 4, 5, 6, 7, 8];
+export default function ProductListScreen({
+  listType,
+  categoryName,
+  onBack,
+  onProductClick,
+  onSearchClick,
+  themeColor,
+  mode,
+}: {
+  listType: "all" | "closing_soon" | "recent";
+  categoryName: string | null;
+  onBack: () => void;
+  onProductClick: (id: number) => void;
+  onSearchClick: () => void;
+  themeColor: string;
+  mode: "regular" | "auction";
+  key?: string | number;
+}) {
+  const title =
+    categoryName ||
+    (listType === "all"
+      ? "전체 목록"
+      : listType === "recent"
+        ? "최근 본 상품"
+        : mode === "regular"
+          ? "핫한 상품"
+          : "마감 임박 상품");
+  const [itemIds] = useState<number[]>(
+    mode === "auction" ? [] : [1, 2, 3, 4, 5, 6, 7, 8],
+  );
+  const [hotProducts, setHotProducts] = useState<any[]>([]);
+  const [isHotLoading, setIsHotLoading] = useState(false);
+  const [hotError, setHotError] = useState<string>("");
+
+  useEffect(() => {
+    let ignore = false;
+    if (listType === "closing_soon" && mode === "regular") {
+      setIsHotLoading(true);
+      setHotError("");
+      fetchHotRegularProducts(8)
+        .then((products) => {
+          if (!ignore) setHotProducts(products.slice(0, 8));
+        })
+        .catch((err) => {
+          if (!ignore)
+            setHotError(
+              getErrorMessage(err, "핫한 상품을 불러오지 못했습니다."),
+            );
+        })
+        .finally(() => {
+          if (!ignore) setIsHotLoading(false);
+        });
+    } else {
+      setHotProducts([]);
+    }
+
+    return () => {
+      ignore = true;
+    };
+  }, [listType, mode]);
 
   return (
     <motion.div
@@ -50,21 +109,59 @@ export default function ProductListScreen({ listType, categoryName, onBack, onPr
     >
       <div className="h-14 flex items-center px-4 border-b border-gray-50 sticky top-0 bg-white/80 backdrop-blur-md z-50 justify-between">
         <div className="flex items-center space-x-1">
-          <button onClick={onBack} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+          <button
+            onClick={onBack}
+            className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+          >
             <ChevronLeft size={24} />
           </button>
-          <h1 className="font-bold text-lg">
-            {title}
-          </h1>
+          <h1 className="font-bold text-lg">{title}</h1>
         </div>
-        <button onClick={onSearchClick} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+        <button
+          onClick={onSearchClick}
+          className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+        >
           <Search size={22} />
         </button>
       </div>
       <div className="flex-1 overflow-y-auto no-scrollbar p-4 space-y-4">
-        {itemIds.length > 0 ? (
+        {listType === "closing_soon" && mode === "regular" ? (
+          isHotLoading ? (
+            <div className="flex flex-col items-center justify-center h-64 text-gray-400 space-y-2">
+              <ShoppingBag size={48} className="opacity-20" />
+              <p className="text-sm font-medium">
+                핫한 상품을 불러오는 중입니다
+              </p>
+            </div>
+          ) : hotError ? (
+            <div className="flex flex-col items-center justify-center h-64 text-red-500 space-y-2">
+              <p className="text-sm font-medium">{hotError}</p>
+            </div>
+          ) : hotProducts.length > 0 ? (
+            hotProducts.map((p) => (
+              <ProductListItem
+                key={p.productId}
+                product={p}
+                mode={mode}
+                themeColor={themeColor}
+                onProductClick={onProductClick}
+              />
+            ))
+          ) : (
+            <div className="flex flex-col items-center justify-center h-64 text-gray-400 space-y-2">
+              <ShoppingBag size={48} className="opacity-20" />
+              <p className="text-sm font-medium">핫한 상품이 없습니다</p>
+            </div>
+          )
+        ) : itemIds.length > 0 ? (
           itemIds.map((i) => (
-            <ProductListItem key={i} i={i} mode={mode} themeColor={themeColor} onProductClick={onProductClick} />
+            <ProductListItem
+              key={i}
+              i={i}
+              mode={mode}
+              themeColor={themeColor}
+              onProductClick={onProductClick}
+            />
           ))
         ) : (
           <div className="flex flex-col items-center justify-center h-64 text-gray-400 space-y-2">

--- a/src/components/product/ProductListItem.tsx
+++ b/src/components/product/ProductListItem.tsx
@@ -1,108 +1,184 @@
 "use client";
-import React, { useState, useEffect } from 'react';
-import { 
-  ChevronLeft, 
-  Check, 
-  ChevronRight, 
-  User, 
-  Camera, 
-  Search, 
-  Home, 
-  PlusCircle, 
-  MessageCircle, 
-  Heart, 
-  Bell, 
-  Filter, 
-  Settings,
-  MoreVertical, 
-  Send, 
-  Star,
-  Clock,
-  ArrowUpRight,
-  X,
-  Trash2,
-  Eye,
-  Image as ImageIcon,
-  ArrowLeft,
-  TrendingUp,
-  Sparkles,
-  Menu,
-  ShoppingBag,
-  Store,
-  Receipt
-} from 'lucide-react';
-import { motion, AnimatePresence } from 'motion/react';
+import React, { useEffect, useState } from "react";
+import { Heart, Image as ImageIcon, MessageCircle } from "lucide-react";
 
-import { Screen, Tab } from '../../types/index';
-import { ExploreIcon } from '../common/ExploreIcon';
-import ConfirmModal from '../common/modal/ConfirmModal';
+import ConfirmModal from "../common/modal/ConfirmModal";
+import {
+  addRegularWishlist,
+  removeRegularWishlist,
+} from "@/services/wishlist/service";
 
-export default function ProductListItem({ 
-  i, 
-  mode, 
-  themeColor, 
-  onProductClick, 
+export default function ProductListItem({
+  i,
+  product,
+  mode,
+  themeColor,
+  onProductClick,
   initialLiked = false,
-  onUnlike
-}: { 
-  i: number; 
-  mode: 'regular' | 'auction'; 
-  themeColor: string; 
-  onProductClick: (id: number) => void; 
+  onUnlike,
+}: {
+  i?: number;
+  product?: {
+    productId: number;
+    name?: string;
+    thumbnailUrl?: string | null;
+    priceLabel?: string;
+    categoryName?: string;
+    location?: string;
+    viewCount?: number;
+    favoriteCount?: number;
+    chatCount?: number;
+    hotScore?: number;
+    rank?: number;
+    createdAt?: string;
+    canFavorite?: boolean;
+  };
+  mode: "regular" | "auction";
+  themeColor: string;
+  onProductClick: (id: number) => void;
   initialLiked?: boolean;
   onUnlike?: () => void;
-  key?: string | number 
+  key?: string | number;
 }) {
+  const useData = product !== undefined && product !== null;
+  const productId = useData ? product!.productId : (i ?? 0) + 10;
+  const thumbnailUrl = useData
+    ? product!.thumbnailUrl
+    : `https://picsum.photos/seed/hot${i}${mode}/200/200`;
+  const name = useData ? (product!.name ?? "상품") : "맥북 에어 M2";
+  const priceLabel = useData
+    ? (product!.priceLabel ?? "₩1,200,000")
+    : "₩1,200,000";
+  const chatCount = useData ? (product!.chatCount ?? 0) : 0;
+  const rank = useData ? (product!.rank ?? null) : null;
+  const isTopRank = rank === 1;
+  const showRankLabel = rank != null && rank >= 1 && rank <= 3;
+
   const [isLiked, setIsLiked] = useState(initialLiked);
   const [showConfirm, setShowConfirm] = useState(false);
-  if (mode === 'auction') {
+  const [isWishlistSubmitting, setIsWishlistSubmitting] = useState(false);
+  const [displayFavoriteCount, setDisplayFavoriteCount] = useState(
+    product?.favoriteCount ?? 132,
+  );
+
+  if (mode === "auction") {
     return null;
   }
-  
-  const handleLikeClick = (e: React.MouseEvent) => {
+
+  useEffect(() => {
+    if (useData) {
+      setDisplayFavoriteCount(product!.favoriteCount ?? 0);
+    } else {
+      setDisplayFavoriteCount(132);
+    }
+  }, [useData, product?.favoriteCount]);
+
+  const handleLikeClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
+
+    if (isWishlistSubmitting) {
+      return;
+    }
+
     if (isLiked && onUnlike) {
       setShowConfirm(true);
-    } else {
+      return;
+    }
+
+    if (!useData) {
       setIsLiked(!isLiked);
+      setDisplayFavoriteCount((currentCount) =>
+        isLiked ? Math.max(0, currentCount - 1) : currentCount + 1,
+      );
+      return;
+    }
+
+    if (product?.canFavorite === false && !isLiked) {
+      return;
+    }
+
+    setIsWishlistSubmitting(true);
+
+    try {
+      const result = isLiked
+        ? await removeRegularWishlist(productId)
+        : await addRegularWishlist(productId);
+
+      setIsLiked(result.liked);
+      setDisplayFavoriteCount(result.favoriteCount);
+    } finally {
+      setIsWishlistSubmitting(false);
     }
   };
 
   return (
     <>
-      <div onClick={() => onProductClick(i + 10)} className="flex items-center space-x-4 p-3 bg-white border border-gray-50 rounded-2xl hover:shadow-md transition-all cursor-pointer group">
+      <div
+        onClick={() => onProductClick(productId)}
+        className="flex items-center space-x-4 p-3 bg-white border border-gray-50 rounded-2xl hover:shadow-md transition-all cursor-pointer group"
+      >
         <div className="w-24 h-24 bg-gray-50 rounded-xl overflow-hidden shrink-0 relative">
-          <img src={`https://picsum.photos/seed/hot${i}${mode}/200/200`} alt="Product" className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" />
+          {thumbnailUrl ? (
+            <img
+              src={thumbnailUrl}
+              alt={name}
+              className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-gray-300">
+              <ImageIcon size={28} />
+            </div>
+          )}
         </div>
+
         <div className="flex-1 min-w-0 space-y-1.5">
           <div className="flex justify-between items-start">
-            <h4 className="font-bold text-sm truncate text-gray-800">맥북 에어 M2</h4>
-            <button 
+            <h4 className="font-bold text-sm truncate text-gray-800">{name}</h4>
+            <button
               onClick={handleLikeClick}
               className="p-1"
+              aria-label="찜하기"
             >
-              <Heart 
-                size={16} 
-                fill={isLiked ? "#FF3B30" : "none"} 
-                color={isLiked ? "#FF3B30" : "#D1D5DB"} 
+              <Heart
+                size={16}
+                fill={isLiked ? "#FF3B30" : "none"}
+                color={isLiked ? "#FF3B30" : "#D1D5DB"}
               />
             </button>
           </div>
-          <p className="text-xs text-gray-500 font-medium">판매가 <span className="text-sm font-bold text-black ml-1">₩1,200,000</span></p>
+
+          <p className="text-xs text-gray-500 font-medium">
+            판매가{" "}
+            <span className="text-sm font-bold text-black ml-1">
+              {priceLabel}
+            </span>
+          </p>
+
           <div className="flex items-center space-x-3 text-[10px] text-gray-400 font-medium">
             <div className="flex items-center space-x-1">
               <Heart size={10} />
-              <span>132</span>
+              <span>{displayFavoriteCount}</span>
             </div>
             <div className="flex items-center space-x-1">
               <MessageCircle size={10} />
-              <span>12</span>
+              <span>{chatCount}</span>
             </div>
+            {showRankLabel && (
+              <div
+                className={`rounded-full px-1.5 py-0.5 text-[10px] font-bold ${
+                  isTopRank
+                    ? "bg-amber-50 text-amber-600"
+                    : "bg-gray-50 text-gray-500"
+                }`}
+              >
+                {rank}위
+              </div>
+            )}
           </div>
         </div>
       </div>
 
-      <ConfirmModal 
+      <ConfirmModal
         isOpen={showConfirm}
         onClose={() => setShowConfirm(false)}
         onConfirm={() => {

--- a/src/services/product/hotList/api.ts
+++ b/src/services/product/hotList/api.ts
@@ -1,0 +1,37 @@
+import { ApiRequestError, getApiErrorMessage } from "@/services/apiError";
+import {
+  getAuthorizationHeaders,
+  handleUnauthorizedAccess,
+} from "@/services/auth/service";
+import type { HotListProductListResponse } from "./types";
+
+async function throwHotListApiError(
+  response: Response,
+  fallbackMessage: string,
+) {
+  if (response.status === 401) {
+    handleUnauthorizedAccess();
+  }
+
+  throw new ApiRequestError(
+    await getApiErrorMessage(response, fallbackMessage),
+    response.status,
+  );
+}
+
+export async function getHotListProducts(
+  size = 8,
+): Promise<HotListProductListResponse> {
+  const params = new URLSearchParams({ size: String(size) });
+  const response = await fetch(`/api/v1/products/hot-list?${params}`, {
+    method: "GET",
+    headers: getAuthorizationHeaders(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    await throwHotListApiError(response, "핫한 상품을 불러오지 못했습니다.");
+  }
+
+  return response.json();
+}

--- a/src/services/product/hotList/service.ts
+++ b/src/services/product/hotList/service.ts
@@ -1,0 +1,50 @@
+import * as hotListApi from "@/services/product/hotList/api";
+import type { HotListProductItemResponse } from "@/services/product/hotList/types";
+
+const DEFAULT_CATEGORY_LABEL = "카테고리 없음";
+const DEFAULT_LOCATION_LABEL = "지역 정보 없음";
+
+function formatPrice(price: number) {
+  return `${Number(price || 0).toLocaleString()}원`;
+}
+
+export interface HotListProductItemViewModel {
+  productId: number;
+  name: string;
+  thumbnailUrl?: string | null;
+  priceLabel: string;
+  location: string;
+  categoryName: string;
+  viewCount: number;
+  favoriteCount: number;
+  chatCount: number;
+  hotScore: number;
+  rank: number;
+  createdAt: string;
+}
+
+function toHotListProductItemViewModel(
+  item: HotListProductItemResponse,
+): HotListProductItemViewModel {
+  return {
+    productId: item.productId,
+    name: item.name,
+    thumbnailUrl: item.thumbnailUrl,
+    priceLabel: formatPrice(item.price),
+    location: item.location ?? DEFAULT_LOCATION_LABEL,
+    categoryName: item.categoryName ?? DEFAULT_CATEGORY_LABEL,
+    viewCount: item.viewCount,
+    favoriteCount: item.favoriteCount,
+    chatCount: item.chatCount ?? 0,
+    hotScore: item.hotScore,
+    rank: item.rank,
+    createdAt: item.createdAt,
+  };
+}
+
+export async function fetchHotRegularProducts(
+  size = 8,
+): Promise<HotListProductItemViewModel[]> {
+  const response = await hotListApi.getHotListProducts(size);
+  return response.content.map(toHotListProductItemViewModel);
+}

--- a/src/services/product/hotList/types.ts
+++ b/src/services/product/hotList/types.ts
@@ -1,0 +1,18 @@
+export interface HotListProductItemResponse {
+  productId: number;
+  name: string;
+  thumbnailUrl?: string | null;
+  price: number;
+  location?: string | null;
+  categoryName?: string | null;
+  viewCount: number;
+  favoriteCount: number;
+  chatCount?: number;
+  hotScore: number;
+  rank: number;
+  createdAt: string;
+}
+
+export interface HotListProductListResponse {
+  content: HotListProductItemResponse[];
+}

--- a/src/services/product/productDetail/types.ts
+++ b/src/services/product/productDetail/types.ts
@@ -8,6 +8,17 @@ export interface Seller {
   memberId: number;
   nickname: string;
   location: string;
+  profileImageUrl?: string | null;
+  bio?: string | null;
+  rating?: number | null;
+  warningCount?: number | null;
+  recentSales?: SellerRecentSale[] | null;
+}
+
+export interface SellerRecentSale {
+  title?: string | null;
+  price?: number | null;
+  status?: string | null;
 }
 
 export interface GeneralSale {


### PR DESCRIPTION
### 🚀 Summary

홈 화면의 핫 상품 목업을 제거하고 백엔드 `hot-list` API를 연동했습니다. 홈에서는 상위 3개만, 상품 더보기(특정 조건)에서는 최대 8개까지 표시되며, 기존 카드 UI 구조와 경매 모드는 변경하지 않았습니다.

---

### ✨ Description

- 변경 요약
  - 하드코딩된 핫 상품 목업 제거 및 신규 서비스 연동
  - 홈: 상위 3개만 노출
  - 상품 더보기: 최대 8개 노출 (조건: `listType === 'closing_soon' && mode === 'regular'`)
  - 카드 UI 유지, `chatCount`가 없으면 클라이언트에서 `0`으로 표시
  - 찜(하트) 버튼은 실제 위시리스트 API와 연동 (목업 항목은 기존 페일백 유지)
  - 상위 3개는 랭크 배지 표시(1위는 약간 강조)

- 클라이언트 동작/제약
  - 호출 엔드포인트: `GET /api/v1/products/hot-list?size={n}` (`size` 기본값: `8`)
  - 응답에 `rank`, `hotScore`, `chatCount` 등이 포함되어야 클라이언트에 정상 반영됩니다. 응답 필드가 없을 경우 클라이언트는 안전하게 기본값을 사용합니다.
  - 경매 모드(`mode === 'auction'`) 관련 로직은 변경 없음.
  - `next.config.mjs`의 rewrites로 `/api/*`가 `NEXT_PUBLIC_API_BASE_URL`로 프록시되므로, 런타임에 프록시/백엔드 상태에 따라 502 등 오류가 발생할 수 있습니다.

- API (참고)
  - `GET /api/v1/products/hot-list?size=8` — 상위 `size`개 핫 상품 반환

- 응답 필드(프론트 기대)
  - productId, name, thumbnailUrl, price, location, categoryName
  - viewCount, favoriteCount, hotScore, rank, createdAt
  - (선택) chatCount

- 변경 파일
  - src/services/product/hotList/types.ts
  - src/services/product/hotList/api.ts
  - src/services/product/hotList/service.ts
  - src/components/product/ProductListItem.tsx
  - src/app/(main)/home/index.tsx
  - src/app/products/index.tsx

- 테스트 및 검증
  1. 개발 서버 실행:
     ```bash
     npm run dev
     ```
  2. 홈에서 상위 3개 핫 상품 노출 확인
  3. 상품 더보기에서 `closing_soon` + `regular` 조건일 때 최대 8개 노출 확인
  4. 브라우저 네트워크 탭에서 `/api/v1/products/hot-list?size=8` 호출 확인
  5. 찜 버튼 클릭 시 위시리스트 API 호출(추가/삭제) 확인
  6. 백엔드가 `chatCount`/`rank`를 반환하지 않으면 카드에 채팅 수가 `0`으로 표시되는지 확인

1) 상세페이지 목업 및 이미지 크기 제한
<img width="2534" height="1286" alt="상세페이지 이미지 크기 및 목업제거" src="https://github.com/user-attachments/assets/c25a5234-e1a8-42c3-bed6-fadc2c4e85d5" />

2) 2개의 일반 판매 상품만 등록을 한 경우
<img width="987" height="800" alt="image" src="https://github.com/user-attachments/assets/97d15330-0621-4216-8dde-fe8f5e0f2c9d" />

3) 공식에 따라 순서 변경도 가능
<img width="870" height="544" alt="공식에 따라 순서변경" src="https://github.com/user-attachments/assets/d9013d9f-f741-467c-b3a2-d31796832b5d" />

4) 더보기 클릭시 이동하는 페이지
<img width="781" height="908" alt="등록된 상품 보여주기" src="https://github.com/user-attachments/assets/10d5e949-6754-4fcd-8ff8-ed501dd896a7" />


  - 향후 개인화(관심 카테고리 기반) 및 정렬 가중치 조정은 별도 작업으로 계획 가능.

---

### 🎲 Issue Number

close #52