### PR TITLE
feat. 관심카테고리 기능 추가

### DIFF
--- a/src/app/(auth)/category-selection/index.tsx
+++ b/src/app/(auth)/category-selection/index.tsx
@@ -1,67 +1,126 @@
 "use client";
-import React, { useState, useEffect } from 'react';
-import { 
-  ChevronLeft, 
-  Check, 
-  ChevronRight, 
-  User, 
-  Camera, 
-  Search, 
-  Home, 
-  PlusCircle, 
-  MessageCircle, 
-  Heart, 
-  Bell, 
-  Filter, 
-  Settings,
-  MoreVertical, 
-  Send, 
-  Star,
-  Clock,
-  ArrowUpRight,
-  X,
-  Trash2,
-  Eye,
-  Image as ImageIcon,
-  ArrowLeft,
-  TrendingUp,
-  Sparkles,
-  Menu,
-  ShoppingBag,
-  Store,
-  Receipt
-} from 'lucide-react';
-import { motion, AnimatePresence } from 'motion/react';
 
-import { Screen, Tab } from '../../../types/index';
-import { ExploreIcon } from '../../../components/common/ExploreIcon';
+import { useEffect, useState } from "react";
+import { ChevronLeft } from "lucide-react";
+import { motion } from "motion/react";
 
-export default function CategorySelectionScreen({ onBack, onComplete, onNavigateLogin, showSkip = false }: { onBack: () => void; onComplete: () => void; onNavigateLogin?: () => void; showSkip?: boolean; key?: string }) {
-  const categories = [
-    { name: "디지털기기", icon: "💻" },
-    { name: "생활가전", icon: "📺" },
-    { name: "가구/인테리어", icon: "🪑" },
-    { name: "유아동", icon: "👶" },
-    { name: "생활/가공식품", icon: "🍎" },
-    { name: "유아도서", icon: "📚" },
-    { name: "스포츠/레저", icon: "⚽" },
-    { name: "여성잡화", icon: "👜" },
-    { name: "여성의류", icon: "👗" },
-    { name: "남성패션/잡화", icon: "👔" },
-    { name: "게임/취미", icon: "🎮" },
-    { name: "뷰티/미용", icon: "💄" },
-    { name: "반려동물용품", icon: "🐶" },
-    { name: "도서/티켓/음반", icon: "💿" },
-    { name: "식물", icon: "🌿" },
-    { name: "기타", icon: "📦" }
-  ];
-  const [selected, setSelected] = useState<string[]>([]);
+import { getErrorMessage } from "@/services/apiError";
+import { updateSignUpDraft } from "@/services/auth/signUpDraft";
+import {
+  fetchInterestCategoryOptions,
+  fetchMyInterestCategoryIds,
+  saveMyInterestCategories,
+} from "@/services/interest-category/service";
+import type { InterestCategoryOptionViewModel } from "@/services/interest-category/types";
 
-  const toggleCategory = (cat: string) => {
-    if (selected.includes(cat)) {
-      setSelected(selected.filter(c => c !== cat));
-    } else {
-      setSelected([...selected, cat]);
+export default function CategorySelectionScreen({
+  onBack,
+  onComplete,
+  mode = "signup",
+  showToast,
+}: {
+  onBack: () => void;
+  onComplete: () => void | Promise<void>;
+  mode?: "signup" | "edit";
+  showToast?: (message: string) => void;
+  onNavigateLogin?: () => void;
+  showSkip?: boolean;
+  key?: string;
+}) {
+  const [categories, setCategories] = useState<
+    InterestCategoryOptionViewModel[]
+  >([]);
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  useEffect(() => {
+    let ignore = false;
+
+    setIsLoading(true);
+    setErrorMessage("");
+
+    const loadCategories: Promise<[InterestCategoryOptionViewModel[], number[]]> =
+      mode === "edit"
+        ? Promise.all([
+            fetchInterestCategoryOptions(),
+            fetchMyInterestCategoryIds(),
+          ])
+        : fetchInterestCategoryOptions().then((nextCategories) => [
+            nextCategories,
+            [] as number[],
+          ]);
+
+    loadCategories
+      .then(([nextCategories, myCategoryIds]) => {
+        if (!ignore) {
+          setCategories(nextCategories);
+          setSelectedIds(myCategoryIds);
+        }
+      })
+      .catch((error) => {
+        if (!ignore) {
+          setCategories([]);
+          setErrorMessage(
+            getErrorMessage(
+              error,
+              "관심 카테고리를 불러오지 못했습니다.",
+            ),
+          );
+        }
+      })
+      .finally(() => {
+        if (!ignore) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [mode]);
+
+  const selectableCategories = categories.filter((category) => category.fromApi);
+
+  const toggleCategory = (category: InterestCategoryOptionViewModel) => {
+    if (!category.fromApi) {
+      return;
+    }
+
+    setSelectedIds((currentIds) =>
+      currentIds.includes(category.categoryId)
+        ? currentIds.filter((categoryId) => categoryId !== category.categoryId)
+        : [...currentIds, category.categoryId],
+    );
+  };
+
+  const handleComplete = async () => {
+    if (isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage("");
+
+    try {
+      if (mode === "edit") {
+        const savedIds = await saveMyInterestCategories(selectedIds);
+        setSelectedIds(savedIds);
+        showToast?.("관심 카테고리 설정이 저장되었습니다.");
+      } else {
+        updateSignUpDraft({
+          interestCategoryIds: selectedIds,
+        });
+      }
+
+      await onComplete();
+    } catch (error) {
+      setErrorMessage(
+        getErrorMessage(error, "관심 카테고리 저장에 실패했습니다."),
+      );
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -73,72 +132,89 @@ export default function CategorySelectionScreen({ onBack, onComplete, onNavigate
       className="flex-1 flex flex-col bg-white"
     >
       <div className="h-16 flex items-center px-4 border-b border-gray-50">
-        <button onClick={onBack} className="p-2 hover:bg-gray-100 rounded-full transition-colors">
+        <button
+          type="button"
+          onClick={onBack}
+          className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+          aria-label="뒤로가기"
+        >
           <ChevronLeft size={24} />
         </button>
-        <h1 className="flex-1 text-center font-bold text-lg mr-10">관심 카테고리 설정</h1>
+        <h1 className="flex-1 text-center font-bold text-lg mr-10">
+          관심 카테고리 설정
+        </h1>
       </div>
 
       <div className="flex-1 px-6 py-8 space-y-8 overflow-y-auto no-scrollbar">
         <div className="space-y-2">
-          <h2 className="text-2xl font-bold text-gray-900">관심 카테고리 설정</h2>
+          <h2 className="text-2xl font-bold text-gray-900">
+            관심 카테고리 설정
+          </h2>
           <p className="text-sm text-gray-400 leading-relaxed">
-            관심 있는 카테고리를 선택해 주세요.<br />
-            맞춤 상품을 먼저 보여드려요.
+            관심 있는 카테고리를 선택해 주세요.
+            <br />
+            선택한 카테고리는 회원가입 정보에 함께 저장됩니다.
           </p>
         </div>
 
-        <div className="grid grid-cols-4 gap-2">
-          {categories.map((cat) => (
-            <button
-              key={cat.name}
-              onClick={() => toggleCategory(cat.name)}
-              className={`flex flex-col items-center justify-center py-2.5 rounded-xl border transition-all duration-200 ${
-                selected.includes(cat.name) 
-                  ? 'bg-[#98E446]/10 border-[#98E446] ring-1 ring-[#98E446]' 
-                  : 'bg-gray-50 border-transparent text-gray-500'
-              }`}
-            >
-              <span className="text-xl mb-1">{cat.icon}</span>
-              <span className={`text-[9px] font-bold ${selected.includes(cat.name) ? 'text-[#98E446]' : 'text-gray-600'}`}>
-                {cat.name}
-              </span>
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div className="p-6 bg-white border-t border-gray-50 space-y-3">
-        <button 
-          onClick={onComplete}
-          disabled={selected.length === 0}
-          className={`w-full h-14 font-bold rounded-xl transition-all ${
-            selected.length > 0 
-              ? 'bg-[#98E446] hover:bg-[#87d335] text-black shadow-lg shadow-[#98E446]/20' 
-              : 'bg-gray-100 text-gray-400 cursor-not-allowed'
-          }`}
-        >
-          {selected.length > 0 ? `${selected.length}개 선택 완료` : '카테고리를 선택해주세요'}
-        </button>
-        
-        {showSkip && (
-          <div className="flex space-x-3">
-            <button 
-              onClick={onComplete}
-              className="flex-1 h-12 bg-gray-100 hover:bg-gray-200 text-gray-600 font-medium rounded-xl transition-colors"
-            >
-              건너뛰기 (메인으로)
-            </button>
-            {onNavigateLogin && (
-              <button 
-                onClick={onNavigateLogin}
-                className="flex-1 h-12 border border-gray-200 hover:bg-gray-50 text-gray-600 font-medium rounded-xl transition-colors"
-              >
-                로그인으로
-              </button>
-            )}
+        {errorMessage && (
+          <div className="rounded-lg bg-red-50 px-4 py-3 text-xs text-red-500">
+            {errorMessage}
           </div>
         )}
+
+        {isLoading ? (
+          <div className="flex h-48 items-center justify-center rounded-2xl border border-dashed border-gray-200 text-sm font-medium text-gray-400">
+            관심 카테고리를 불러오는 중입니다.
+          </div>
+        ) : (
+          <div className="grid grid-cols-4 gap-2">
+            {categories.map((category) => {
+              const isSelected = selectedIds.includes(category.categoryId);
+              const isDisabled = !category.fromApi;
+
+              return (
+                <button
+                  key={`${category.fromApi ? "api" : "mock"}-${category.categoryId}`}
+                  type="button"
+                  onClick={() => toggleCategory(category)}
+                  disabled={isDisabled}
+                  className={`flex flex-col items-center justify-center py-2.5 rounded-xl border transition-all duration-200 ${
+                    isSelected
+                      ? "bg-[#98E446]/10 border-[#98E446] ring-1 ring-[#98E446]"
+                      : "bg-gray-50 border-transparent text-gray-500"
+                  } ${isDisabled ? "opacity-45 cursor-not-allowed" : ""}`}
+                >
+                  <span className="text-xl mb-1">{category.icon}</span>
+                  <span
+                    className={`text-[9px] font-bold ${
+                      isSelected ? "text-[#98E446]" : "text-gray-600"
+                    }`}
+                  >
+                    {category.name}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      <div className="p-6 bg-white border-t border-gray-50">
+        <button
+          type="button"
+          onClick={handleComplete}
+          disabled={isLoading || isSubmitting || selectableCategories.length === 0}
+          className="w-full h-14 bg-[#98E446] hover:bg-[#87d335] text-black font-bold rounded-xl transition-all shadow-lg shadow-[#98E446]/20 disabled:bg-gray-100 disabled:text-gray-400 disabled:shadow-none disabled:cursor-not-allowed"
+        >
+          {isSubmitting
+            ? "저장 중..."
+            : selectedIds.length > 0
+              ? mode === "edit"
+                ? `${selectedIds.length}개 선택 저장`
+                : `${selectedIds.length}개 선택 완료`
+              : "선택 없이 계속하기"}
+        </button>
       </div>
     </motion.div>
   );

--- a/src/app/(auth)/category-selection/page.tsx
+++ b/src/app/(auth)/category-selection/page.tsx
@@ -11,8 +11,6 @@ export default function CategorySelectionPage() {
     <CategorySelectionScreen
       onBack={() => router.back()}
       onComplete={() => router.push("/")}
-      onNavigateLogin={() => router.push("/login")}
-      showSkip
     />
   );
 }

--- a/src/app/(auth)/profile-setup/index.tsx
+++ b/src/app/(auth)/profile-setup/index.tsx
@@ -9,6 +9,7 @@ import ResultModal from "@/components/common/modal/ResultModal";
 import { checkNicknameAvailability } from "@/services/auth/service";
 import { getSignUpDraft } from "@/services/auth/signUpDraft";
 import { saveMyProfile, uploadMyProfileImage } from "@/services/mypage/service";
+import type { MyProfileFormValues } from "@/services/mypage/types";
 
 type CheckStatus = "idle" | "available" | "duplicate";
 
@@ -16,10 +17,14 @@ export default function ProfileSetupScreen({
   showToast,
   onBack,
   onComplete,
+  deferSave = false,
+  onCompleteDraft,
 }: {
   showToast: (msg: string) => void;
   onBack: () => void;
   onComplete: () => void;
+  deferSave?: boolean;
+  onCompleteDraft?: (form: MyProfileFormValues, imageFile?: File | null) => void;
   key?: string;
 }) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -27,6 +32,7 @@ export default function ProfileSetupScreen({
   const [nickname, setNickname] = useState("비드마스터");
   const [bio, setBio] = useState("안녕하세요! 비드마스터입니다. 좋은 거래 부탁드려요.");
   const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
+  const [profileImageFile, setProfileImageFile] = useState<File | null>(null);
   const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null);
   const [nicknameCheckStatus, setNicknameCheckStatus] =
     useState<CheckStatus>("idle");
@@ -97,6 +103,14 @@ export default function ProfileSetupScreen({
     setIsUploadingImage(true);
     updateImagePreviewUrl(URL.createObjectURL(file));
 
+    if (deferSave) {
+      setProfileImageFile(file);
+      setProfileImageUrl(null);
+      setIsUploadingImage(false);
+      event.target.value = "";
+      return;
+    }
+
     try {
       const uploadedImage = await uploadMyProfileImage(file);
       setProfileImageUrl(uploadedImage.profileImageUrl);
@@ -117,12 +131,23 @@ export default function ProfileSetupScreen({
     setIsSubmitting(true);
 
     try {
-      await saveMyProfile({
+      const formValues = {
         name: getSignUpDraft().name,
         nickname,
         bio,
         profileImageUrl,
         location: "",
+      };
+
+      if (deferSave) {
+        onCompleteDraft?.(formValues, profileImageFile);
+        showToast("?꾨줈???ㅼ젙????λ릺?덉뒿?덈떎.");
+        onComplete();
+        return;
+      }
+
+      await saveMyProfile({
+        ...formValues,
       });
       showToast("프로필 설정이 저장되었습니다.");
       onComplete();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -86,7 +86,13 @@ import {
   resolveCurrentLocation,
 } from "@/services/location/service";
 import type { LocationFormValues } from "@/services/location/types";
-import { fetchMyLocationForm, saveMyLocation } from "@/services/mypage/service";
+import {
+  fetchMyLocationForm,
+  saveMyLocation,
+  saveMyProfile,
+  uploadMyProfileImage,
+} from "@/services/mypage/service";
+import type { MyProfileFormValues } from "@/services/mypage/types";
 import {
   clearMyProfileDraft,
   updateMyProfileDraft,
@@ -121,6 +127,10 @@ export default function App() {
   );
   const [isEditingLocation, setIsEditingLocation] = useState(false);
   const [profileRefreshKey, setProfileRefreshKey] = useState(0);
+  const [signupProfileForm, setSignupProfileForm] =
+    useState<MyProfileFormValues | null>(null);
+  const [signupProfileImageFile, setSignupProfileImageFile] =
+    useState<File | null>(null);
   const [isResolvingCurrentLocation, setIsResolvingCurrentLocation] =
     useState(false);
   const [toast, setToast] = useState<{ message: string; visible: boolean }>({
@@ -269,13 +279,9 @@ export default function App() {
               }}
               onNext={async () => {
                 try {
-                  if (!isEditingLocation && !getAuthToken()) {
-                    const signUpResult = await signUp(getSignUpDraft());
-                    clearSignUpDraft();
-                    showToast(signUpResult.message);
+                  if (isEditingLocation || getAuthToken()) {
+                    await saveMyLocation(userLocationForm);
                   }
-
-                  await saveMyLocation(userLocationForm);
 
                   if (isEditingLocation) {
                     navigateTo("main");
@@ -327,12 +333,17 @@ export default function App() {
             <ProfileSetupScreen
               key="profile_setup"
               showToast={showToast}
+              deferSave={!isEditingProfile && !getAuthToken()}
+              onCompleteDraft={(form, imageFile) => {
+                setSignupProfileForm(form);
+                setSignupProfileImageFile(imageFile ?? null);
+              }}
               onBack={() => {
                 if (isEditingProfile) {
                   navigateTo("main");
                   setIsEditingProfile(false);
                 } else {
-                  navigateTo("terms");
+                  navigateTo("region_setup");
                 }
               }}
               onComplete={() => {
@@ -406,14 +417,66 @@ export default function App() {
             <CategorySelectionScreen
               key="category_selection"
               onBack={() => navigateTo("profile_setup")}
-              onComplete={() => navigateTo("main")}
-              onNavigateLogin={() => navigateTo("login")}
-              showSkip={true}
+              onComplete={async () => {
+                try {
+                  if (!getAuthToken()) {
+                    const signUpResult = await signUp(getSignUpDraft());
+                    showToast(signUpResult.message);
+
+                    try {
+                      await saveMyLocation(userLocationForm);
+                    } catch (locationError) {
+                      showToast(
+                        getErrorMessage(
+                          locationError,
+                          "지역 저장에 실패했습니다.",
+                        ),
+                      );
+                    }
+
+                    if (signupProfileForm) {
+                      try {
+                        let profileImageUrl = signupProfileForm.profileImageUrl;
+
+                        if (signupProfileImageFile) {
+                          const uploadedImage =
+                            await uploadMyProfileImage(signupProfileImageFile);
+                          profileImageUrl = uploadedImage.profileImageUrl;
+                        }
+
+                        await saveMyProfile({
+                          ...signupProfileForm,
+                          profileImageUrl,
+                        });
+                      } catch (profileError) {
+                        showToast(
+                          getErrorMessage(
+                            profileError,
+                            "프로필 저장에 실패했습니다.",
+                          ),
+                        );
+                      }
+                    }
+
+                    clearSignUpDraft();
+                    setSignupProfileForm(null);
+                    setSignupProfileImageFile(null);
+                  }
+
+                  navigateTo("main");
+                } catch (error) {
+                  showToast(
+                    getErrorMessage(error, "회원가입 완료에 실패했습니다."),
+                  );
+                }
+              }}
             />
           )}
           {currentScreen === "category_reset" && (
             <CategorySelectionScreen
               key="category_reset"
+              mode="edit"
+              showToast={showToast}
               onBack={() => navigateTo("main")}
               onComplete={() => navigateTo("main")}
               onNavigateLogin={() => navigateTo("login")}
@@ -475,6 +538,8 @@ export default function App() {
                 clearAuthToken();
                 clearSignUpDraft();
                 clearMyProfileDraft();
+                setSignupProfileForm(null);
+                setSignupProfileImageFile(null);
                 setUserLocationForm(createDefaultLocationForm());
                 setCurrentTab("home");
                 navigateTo("login");

--- a/src/services/auth/service.ts
+++ b/src/services/auth/service.ts
@@ -160,6 +160,7 @@ export function createDefaultSignUpForm(): SignUpFormValues {
     confirmPassword: "",
     email: "",
     name: "",
+    interestCategoryIds: [],
   };
 }
 
@@ -211,6 +212,7 @@ export function buildSignUpRequest(form: SignUpFormValues): SignUpRequest {
     password: form.password,
     email: normalizedEmail === "" ? null : normalizedEmail,
     name: form.name.trim() || null,
+    interestCategoryIds: form.interestCategoryIds,
   };
 }
 

--- a/src/services/auth/types.ts
+++ b/src/services/auth/types.ts
@@ -22,6 +22,7 @@ export interface SignUpRequest {
   password: string;
   email: string | null;
   name: string | null;
+  interestCategoryIds: number[];
 }
 
 export interface SignUpResponse {
@@ -72,6 +73,7 @@ export interface SignUpFormValues {
   confirmPassword: string;
   email: string;
   name: string;
+  interestCategoryIds: number[];
 }
 
 export interface AuthResult<T> {

--- a/src/services/interest-category/api.ts
+++ b/src/services/interest-category/api.ts
@@ -1,0 +1,74 @@
+import { ApiRequestError, getApiErrorMessage } from "@/services/apiError";
+import { getAuthorizationHeaders } from "@/services/auth/service";
+import type {
+  InterestCategoryOptionResponse,
+  UpdateMyInterestCategoriesRequest,
+} from "@/services/interest-category/types";
+
+export async function getInterestCategories(): Promise<
+  InterestCategoryOptionResponse[]
+> {
+  const response = await fetch("/api/v1/members/interest-categories", {
+    method: "GET",
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new ApiRequestError(
+      await getApiErrorMessage(
+        response,
+        "관심 카테고리를 불러오지 못했습니다.",
+      ),
+      response.status,
+    );
+  }
+
+  return response.json();
+}
+
+export async function getMyInterestCategories(): Promise<
+  InterestCategoryOptionResponse[]
+> {
+  const response = await fetch("/api/v1/users/me/interest-categories", {
+    method: "GET",
+    headers: getAuthorizationHeaders(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new ApiRequestError(
+      await getApiErrorMessage(
+        response,
+        "관심 카테고리 설정을 불러오지 못했습니다.",
+      ),
+      response.status,
+    );
+  }
+
+  return response.json();
+}
+
+export async function patchMyInterestCategories(
+  payload: UpdateMyInterestCategoriesRequest,
+): Promise<InterestCategoryOptionResponse[]> {
+  const response = await fetch("/api/v1/users/me/interest-categories", {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+      ...getAuthorizationHeaders(),
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new ApiRequestError(
+      await getApiErrorMessage(
+        response,
+        "관심 카테고리 설정 저장에 실패했습니다.",
+      ),
+      response.status,
+    );
+  }
+
+  return response.json();
+}

--- a/src/services/interest-category/service.ts
+++ b/src/services/interest-category/service.ts
@@ -1,0 +1,173 @@
+import * as interestCategoryApi from "@/services/interest-category/api";
+import type {
+  InterestCategoryOptionResponse,
+  InterestCategoryOptionViewModel,
+} from "@/services/interest-category/types";
+
+const FALLBACK_CATEGORIES: InterestCategoryOptionViewModel[] = [
+  {
+    categoryId: -1,
+    name: "\uB514\uC9C0\uD138\uAE30\uAE30",
+    icon: "\uD83D\uDCBB",
+    fromApi: false,
+  },
+  {
+    categoryId: -2,
+    name: "\uC0DD\uD65C\uAC00\uC804",
+    icon: "\uD83D\uDD0C",
+    fromApi: false,
+  },
+  {
+    categoryId: -3,
+    name: "\uAC00\uAD6C/\uC778\uD14C\uB9AC\uC5B4",
+    icon: "\uD83D\uDECB\uFE0F",
+    fromApi: false,
+  },
+  {
+    categoryId: -4,
+    name: "\uC720\uC544\uB3D9",
+    icon: "\uD83E\uDDF8",
+    fromApi: false,
+  },
+  {
+    categoryId: -5,
+    name: "\uC0DD\uD65C/\uAC00\uACF5\uC2DD\uD488",
+    icon: "\uD83E\uDD6B",
+    fromApi: false,
+  },
+  {
+    categoryId: -6,
+    name: "\uC720\uC544\uB3C4\uC11C",
+    icon: "\uD83D\uDCDA",
+    fromApi: false,
+  },
+  {
+    categoryId: -7,
+    name: "\uC2A4\uD3EC\uCE20/\uB808\uC800",
+    icon: "\u26BD",
+    fromApi: false,
+  },
+  {
+    categoryId: -8,
+    name: "\uC5EC\uC131\uC7A1\uD654",
+    icon: "\uD83D\uDC5C",
+    fromApi: false,
+  },
+  {
+    categoryId: -9,
+    name: "\uC5EC\uC131\uC758\uB958",
+    icon: "\uD83D\uDC57",
+    fromApi: false,
+  },
+  {
+    categoryId: -10,
+    name: "\uB0A8\uC131\uD328\uC158/\uC7A1\uD654",
+    icon: "\uD83D\uDC55",
+    fromApi: false,
+  },
+  {
+    categoryId: -11,
+    name: "\uAC8C\uC784/\uCDE8\uBBF8",
+    icon: "\uD83C\uDFAE",
+    fromApi: false,
+  },
+  {
+    categoryId: -12,
+    name: "\uBDF0\uD2F0/\uBBF8\uC6A9",
+    icon: "\uD83D\uDC84",
+    fromApi: false,
+  },
+  {
+    categoryId: -13,
+    name: "\uBC18\uB824\uB3D9\uBB3C\uC6A9\uD488",
+    icon: "\uD83D\uDC3E",
+    fromApi: false,
+  },
+  {
+    categoryId: -14,
+    name: "\uB3C4\uC11C/\uD2F0\uCF13/\uC74C\uBC18",
+    icon: "\uD83D\uDCDA",
+    fromApi: false,
+  },
+  {
+    categoryId: -15,
+    name: "\uC2DD\uBB3C",
+    icon: "\uD83C\uDF3F",
+    fromApi: false,
+  },
+  {
+    categoryId: -16,
+    name: "\uAE30\uD0C0",
+    icon: "\u2728",
+    fromApi: false,
+  },
+];
+
+const CATEGORY_ICON_RULES = [
+  { keywords: ["\uC804\uC790", "\uB514\uC9C0\uD138"], icon: "\uD83D\uDCBB" },
+  { keywords: ["\uC758\uB958"], icon: "\uD83D\uDC57" },
+  { keywords: ["\uB3C4\uC11C"], icon: "\uD83D\uDCDA" },
+];
+
+function normalizeName(name: string) {
+  return name.trim().replace(/\s+/g, "");
+}
+
+function getIcon(name: string) {
+  const normalizedName = normalizeName(name);
+  const matchedRule = CATEGORY_ICON_RULES.find((rule) =>
+    rule.keywords.some((keyword) => normalizedName.includes(keyword)),
+  );
+
+  if (matchedRule) {
+    return matchedRule.icon;
+  }
+
+  const matchedFallback = FALLBACK_CATEGORIES.find(
+    (category) => normalizeName(category.name) === normalizedName,
+  );
+
+  return matchedFallback?.icon ?? "\u2728";
+}
+
+function toViewModel(
+  category: InterestCategoryOptionResponse,
+): InterestCategoryOptionViewModel {
+  return {
+    categoryId: category.categoryId,
+    name: category.nameKo,
+    icon: getIcon(category.nameKo),
+    fromApi: true,
+  };
+}
+
+export async function fetchInterestCategoryOptions(): Promise<
+  InterestCategoryOptionViewModel[]
+> {
+  const apiCategories = await interestCategoryApi.getInterestCategories();
+  const apiViewModels = apiCategories.map(toViewModel);
+  const apiNameSet = new Set(
+    apiViewModels.map((category) => normalizeName(category.name)),
+  );
+  const missingFallbacks = FALLBACK_CATEGORIES.filter(
+    (category) => !apiNameSet.has(normalizeName(category.name)),
+  );
+
+  return [...apiViewModels, ...missingFallbacks];
+}
+
+export async function fetchMyInterestCategoryIds(): Promise<number[]> {
+  const categories = await interestCategoryApi.getMyInterestCategories();
+
+  return categories.map((category) => category.categoryId);
+}
+
+export async function saveMyInterestCategories(
+  interestCategoryIds: number[],
+): Promise<number[]> {
+  const categories = await interestCategoryApi.patchMyInterestCategories({
+    interestCategoryIds,
+  });
+
+  return categories.map((category) => category.categoryId);
+}

--- a/src/services/interest-category/types.ts
+++ b/src/services/interest-category/types.ts
@@ -1,0 +1,16 @@
+export interface InterestCategoryOptionResponse {
+  categoryId: number;
+  nameKo: string;
+  nameEn: string;
+}
+
+export interface UpdateMyInterestCategoriesRequest {
+  interestCategoryIds: number[];
+}
+
+export interface InterestCategoryOptionViewModel {
+  categoryId: number;
+  name: string;
+  icon: string;
+  fromApi: boolean;
+}


### PR DESCRIPTION
### 🚀 Summary

관심 카테고리 설정 및 수정 기능 추가
회원가입 흐름에서 관심 카테고리를 선택해 가입 요청에 함께 저장하도록 구성
마이페이지에서 기존 관심 카테고리 조회/수정이 가능하도록 API 연동 추가
아직 카테고리 덜 만들어진 곳 비활성화

---

### ✨ Description

관심 카테고리 설정 흐름
회원가입 진행 중 사용자가 관심 카테고리 선택
→ service.ts가 선택한 카테고리 ID를 회원가입 요청 데이터에 반영
→ api.ts가 회원가입/관심 카테고리 API 호출
→ 마이페이지에서는 기존 관심 카테고리를 조회해 선택 상태로 표시
→ 수정 완료 시 PATCH API로 변경된 관심 카테고리 저장

주요 코드

page.tsx
회원가입 흐름을 약관 → 지역설정 → 프로필설정 → 관심카테고리 설정 순서로 연결
관심카테고리 설정 완료 시 회원가입 요청에 선택한 카테고리 ID 포함
마이페이지 관심카테고리 설정 진입 시 수정 모드로 연결

index.tsx
/category-selection 하위에 있음
관심 카테고리 목록 화면 상태 관리
카테고리 선택/해제 이벤트 처리
회원가입 모드에서는 선택값을 회원가입 draft에 저장
마이페이지 수정 모드에서는 기존 선택값을 체크 상태로 표시
수정 완료 시 saveMyInterestCategories() 호출

types.ts
InterestCategoryOptionResponse - 관심 카테고리 목록 응답 타입
InterestCategoryOptionViewModel - 화면 표시용 관심 카테고리 모델
UpdateMyInterestCategoriesRequest - 관심 카테고리 수정 요청 DTO

api.ts
getInterestCategories - 회원가입용 관심 카테고리 목록 조회
getMyInterestCategories - 내 관심 카테고리 목록 조회
patchMyInterestCategories - 내 관심 카테고리 수정 저장

service.ts
fetchInterestCategoryOptions - 관심 카테고리 목록을 화면용 데이터로 변환
fetchMyInterestCategoryIds - 기존 내 관심 카테고리 ID 목록 조회
saveMyInterestCategories - 선택한 관심 카테고리 수정 저장
카테고리명 기준 아이콘 매핑 처리
백엔드에 없는 대분류는 목업 카테고리로 유지

사진 첨부

회원가입 관심 카테고리
<img width="544" height="664" alt="관심 카테고리" src="https://github.com/user-attachments/assets/89ab30ca-81b8-4bdf-8aa2-46fe83fd609c" />


마이페이지 관심 카테고리
<img width="539" height="664" alt="프론트 수정" src="https://github.com/user-attachments/assets/93e1ef9d-dbb5-4ebf-8ebe-4a6897ed819a" />



---

### 🎲 Issue Number


close #58 
