### PR TITLE
[feat]  경매 SSE 이벤트 수신 처리를 추가, 경매 상세/입찰 현황 실시간 갱신 구현

### DIFF
--- a/src/app/auctions/[auctionId]/bidding-status/index.tsx
+++ b/src/app/auctions/[auctionId]/bidding-status/index.tsx
@@ -37,24 +37,37 @@ import { Screen, Tab } from '../../../../types/index';
 import { ExploreIcon } from '../../../../components/common/ExploreIcon';
 import { getErrorMessage } from '@/services/apiError';
 import {
+  fetchAuctionBidHistory,
   fetchAuctionDetail,
   getAuctionDisplayCurrentPrice,
 } from '@/services/auction/detail/service';
-import type { AuctionDetailResponse } from '@/services/auction/detail/types';
+import type { AuctionBidHistoryResponse, AuctionDetailResponse } from '@/services/auction/detail/types';
+import { useEventStream } from '@/services/events/EventStreamProvider';
+
+function formatBidTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
+}
 
 export default function BiddingStatusScreen({ auctionId, onBack, themeColor }: { auctionId: number | null; onBack: () => void; themeColor: string; key?: string }) {
   const [auctionDetail, setAuctionDetail] = useState<AuctionDetailResponse | null>(null);
+  const [bidHistory, setBidHistory] = useState<AuctionBidHistoryResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
-  const bids: Array<{
-    user: string;
-    price: string;
-    time: string;
-    active: boolean;
-    img: string;
-  }> = [];
-  const currentDisplayPrice = getAuctionDisplayCurrentPrice(auctionDetail);
-  const bidCount = auctionDetail?.bidCount ?? 0;
+  const { latestAuctionEvent } = useEventStream();
+  const bids = bidHistory?.bids ?? [];
+  const currentDisplayPrice = bidHistory?.currentPrice ?? getAuctionDisplayCurrentPrice(auctionDetail);
+  const bidCount = bidHistory?.bidCount ?? auctionDetail?.bidCount ?? 0;
   const priceHelperText = bidCount > 0 ? "현재 최고 입찰가" : "입찰 기록 없음";
 
   useEffect(() => {
@@ -67,10 +80,14 @@ export default function BiddingStatusScreen({ auctionId, onBack, themeColor }: {
     setIsLoading(true);
     setErrorMessage("");
 
-    fetchAuctionDetail(auctionId)
-      .then((data) => {
+    Promise.all([
+      fetchAuctionDetail(auctionId),
+      fetchAuctionBidHistory(auctionId),
+    ])
+      .then(([detail, history]) => {
         if (!ignore) {
-          setAuctionDetail(data);
+          setAuctionDetail(detail);
+          setBidHistory(history);
         }
       })
       .catch((error) => {
@@ -90,6 +107,41 @@ export default function BiddingStatusScreen({ auctionId, onBack, themeColor }: {
       ignore = true;
     };
   }, [auctionId]);
+
+  useEffect(() => {
+    if (auctionId == null || latestAuctionEvent?.auctionId !== auctionId) {
+      return;
+    }
+
+    if (
+      latestAuctionEvent.type !== "AUCTION_BID_UPDATED" &&
+      latestAuctionEvent.type !== "BID_UPDATED" &&
+      latestAuctionEvent.type !== "BID_RECEIVED" &&
+      latestAuctionEvent.type !== "OUTBID"
+    ) {
+      return;
+    }
+
+    let ignore = false;
+
+    fetchAuctionBidHistory(auctionId)
+      .then((history) => {
+        if (!ignore) {
+          setBidHistory(history);
+        }
+      })
+      .catch((error) => {
+        if (!ignore) {
+          setErrorMessage(
+            getErrorMessage(error, "입찰 현황을 갱신하지 못했습니다."),
+          );
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [auctionId, latestAuctionEvent]);
 
   return (
     <motion.div
@@ -132,33 +184,33 @@ export default function BiddingStatusScreen({ auctionId, onBack, themeColor }: {
           {bids.length > 0 ? (
             <div className="space-y-4">
               {bids.map((bid, idx) => (
-                <div key={idx} className="relative">
+                <div key={bid.bidId} className="relative">
                   {idx !== bids.length - 1 && (
                     <div className="absolute left-5 top-10 bottom-[-16px] w-px bg-gray-100"></div>
                   )}
                   
                   <div className="flex items-start space-x-4">
-                    <div className={`w-10 h-10 rounded-full overflow-hidden shrink-0 border-2 ${bid.active ? 'ring-2 ring-offset-2' : 'border-gray-100'}`} style={{ '--tw-ring-color': bid.active ? themeColor : 'transparent', borderColor: bid.active ? themeColor : '#F3F4F6' } as React.CSSProperties}>
-                      <img src={bid.img} alt={bid.user} className="w-full h-full object-cover" />
+                    <div className={`w-10 h-10 rounded-full overflow-hidden shrink-0 border-2 bg-gray-100 flex items-center justify-center ${bid.highest ? 'ring-2 ring-offset-2' : 'border-gray-100'}`} style={{ '--tw-ring-color': bid.highest ? themeColor : 'transparent', borderColor: bid.highest ? themeColor : '#F3F4F6' } as React.CSSProperties}>
+                      <User size={18} className="text-gray-400" />
                     </div>
                     
                     <div className="flex-1 min-w-0 pt-0.5">
                       <div className="flex items-center justify-between mb-1">
                         <div className="flex items-center space-x-2">
-                          <span className={`text-sm font-bold ${bid.active ? 'text-black' : 'text-gray-600'}`}>{bid.user}</span>
-                          {bid.active && (
+                          <span className={`text-sm font-bold ${bid.highest ? 'text-black' : 'text-gray-600'}`}>{bid.bidderNickname}</span>
+                          {bid.highest && (
                             <span className="px-2 py-0.5 text-white text-[8px] font-black rounded-full uppercase tracking-wider" style={{ backgroundColor: themeColor }}>
                               Highest
                             </span>
                           )}
                         </div>
-                        <span className="text-[10px] text-gray-400 font-medium">{bid.time}</span>
+                        <span className="text-[10px] text-gray-400 font-medium">{formatBidTime(bid.bidAt)}</span>
                       </div>
                       <div className="flex items-baseline space-x-1">
-                        <span className={`text-lg font-black ${bid.active ? '' : 'text-gray-400'}`} style={{ color: bid.active ? themeColor : undefined }}>
-                          ₩{bid.price.replace('원', '')}
+                        <span className={`text-lg font-black ${bid.highest ? '' : 'text-gray-400'}`} style={{ color: bid.highest ? themeColor : undefined }}>
+                          ₩{bid.bidPrice.toLocaleString()}
                         </span>
-                        {bid.active && <span className="text-[10px] font-bold text-gray-400">입찰 중</span>}
+                        {bid.highest && <span className="text-[10px] font-bold text-gray-400">입찰 중</span>}
                       </div>
                     </div>
                   </div>

--- a/src/app/auctions/[auctionId]/bidding-status/page.tsx
+++ b/src/app/auctions/[auctionId]/bidding-status/page.tsx
@@ -4,6 +4,7 @@ import { useParams } from "next/navigation";
 import { useRouter } from "next/navigation";
 
 import BiddingStatusScreen from "./index";
+import { EventStreamProvider } from "@/services/events/EventStreamProvider";
 
 export default function BiddingStatusPage() {
   const router = useRouter();
@@ -11,10 +12,12 @@ export default function BiddingStatusPage() {
   const auctionId = Number(params.auctionId);
 
   return (
-    <BiddingStatusScreen
-      auctionId={Number.isFinite(auctionId) ? auctionId : null}
-      onBack={() => router.back()}
-      themeColor="#F64257"
-    />
+    <EventStreamProvider enabled>
+      <BiddingStatusScreen
+        auctionId={Number.isFinite(auctionId) ? auctionId : null}
+        onBack={() => router.back()}
+        themeColor="#F64257"
+      />
+    </EventStreamProvider>
   );
 }

--- a/src/app/auctions/[auctionId]/page.tsx
+++ b/src/app/auctions/[auctionId]/page.tsx
@@ -3,6 +3,7 @@
 import { useParams, useRouter } from "next/navigation";
 
 import AuctionDetailScreen from "./index";
+import { EventStreamProvider } from "@/services/events/EventStreamProvider";
 
 type BidCompleteData = {
   bidAmount: number;
@@ -14,21 +15,23 @@ export default function AuctionDetailPage() {
   const auctionId = Number(params.auctionId) || 1;
 
   return (
-    <AuctionDetailScreen
-      productId={auctionId}
-      onBack={() => router.back()}
-      onBidStatusClick={() => router.push(`/auctions/${auctionId}/bidding-status`)}
-      onChatClick={() => router.push("/chats/1")}
-      onReportClick={() => router.push(`/products/${auctionId}/report`)}
-      onPurchaseClick={() => router.push(`/products/${auctionId}/payment`)}
-      onBidComplete={(data: BidCompleteData) => {
-        router.replace(
-          `/auctions/${auctionId}/bid-complete?bidPrice=${data.bidAmount}`,
-        );
-      }}
-      themeColor="#F64257"
-      mode="auction"
-      showToast={() => {}}
-    />
+    <EventStreamProvider enabled>
+      <AuctionDetailScreen
+        productId={auctionId}
+        onBack={() => router.back()}
+        onBidStatusClick={() => router.push(`/auctions/${auctionId}/bidding-status`)}
+        onChatClick={() => router.push("/chats/1")}
+        onReportClick={() => router.push(`/products/${auctionId}/report`)}
+        onPurchaseClick={() => router.push(`/products/${auctionId}/payment`)}
+        onBidComplete={(data: BidCompleteData) => {
+          router.replace(
+            `/auctions/${auctionId}/bid-complete?bidPrice=${data.bidAmount}`,
+          );
+        }}
+        themeColor="#F64257"
+        mode="auction"
+        showToast={() => {}}
+      />
+    </EventStreamProvider>
   );
 }

--- a/src/app/products/[productId]/index.tsx
+++ b/src/app/products/[productId]/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ChevronLeft,
   ChevronRight,
@@ -24,6 +24,8 @@ import {
   placeAuctionBid,
 } from "@/services/auction/detail/service";
 import type { AuctionDetailResponse } from "@/services/auction/detail/types";
+import { useEventStream } from "@/services/events/EventStreamProvider";
+import type { AuctionEventStreamEvent } from "@/services/events/types";
 import * as productDetailService from "@/services/product/productDetail/service";
 import type { ProductDetailResponse } from "@/services/product/productDetail/types";
 
@@ -31,7 +33,10 @@ type AuctionStatus =
   | "AUCTION_SCHEDULED"
   | "AUCTION_LIVE"
   | "AUCTION_ENDED"
-  | "ENDED";
+  | "ONGOING"
+  | "ENDED"
+  | "NO_BID"
+  | "SUCCESSFUL_BID";
 
 interface ProductDetailScreenProps {
   productId: number | null;
@@ -96,6 +101,13 @@ function formatScheduleLabel(value?: string) {
   }).format(new Date(value));
 }
 
+function isAuctionEventForProduct(
+  event: AuctionEventStreamEvent | null,
+  productId: number | null,
+): event is AuctionEventStreamEvent {
+  return event != null && productId != null && event.auctionId === productId;
+}
+
 export default function ProductDetailScreen({
   productId,
   productData,
@@ -122,6 +134,8 @@ export default function ProductDetailScreen({
   const [auctionErrorMessage, setAuctionErrorMessage] = useState("");
   const [currentTimeMs, setCurrentTimeMs] = useState(() => Date.now());
   const [auctionClockOffsetMs, setAuctionClockOffsetMs] = useState(0);
+  const { latestAuctionEvent } = useEventStream();
+  const showToastRef = useRef(showToast);
 
   const resolvedMode =
     productData?.saleType === "AUCTION" ? "auction" : mode;
@@ -147,6 +161,8 @@ export default function ProductDetailScreen({
     !isRegular &&
     (effectiveAuctionStatus === "AUCTION_ENDED" ||
       effectiveAuctionStatus === "ENDED" ||
+      effectiveAuctionStatus === "NO_BID" ||
+      effectiveAuctionStatus === "SUCCESSFUL_BID" ||
       hasAuctionTimeEnded);
   const bidUnit = auctionDetail?.minimumBidAmount ?? 10000;
   const minBidAmount =
@@ -187,6 +203,10 @@ export default function ProductDetailScreen({
     ? formatRemainingTime(auctionRemainingMs)
     : "정보 없음";
   const scheduledStartLabel = formatScheduleLabel(auctionStartAt);
+
+  useEffect(() => {
+    showToastRef.current = showToast;
+  }, [showToast]);
 
   // 새롭게 추가된 판매자 프로필용 변수 (API 연동 전 임시 데이터)
   const displaySellerBio = "좋은 거래 부탁드려요.";
@@ -264,6 +284,71 @@ export default function ProductDetailScreen({
       ignore = true;
     };
   }, [isRegular, productId]);
+
+  useEffect(() => {
+    if (isRegular || !isAuctionEventForProduct(latestAuctionEvent, productId)) {
+      return;
+    }
+
+    if (latestAuctionEvent.type === "AUCTION_BID_UPDATED") {
+      setCurrentPrice(latestAuctionEvent.currentPrice);
+      setBidCount(latestAuctionEvent.bidCount);
+      setInputBidAmount(latestAuctionEvent.minimumNextBidPrice);
+      setAuctionClockOffsetMs(
+        new Date(latestAuctionEvent.serverTime).getTime() - Date.now(),
+      );
+      setAuctionDetail((previous) =>
+        previous
+          ? {
+              ...previous,
+              currentPrice: latestAuctionEvent.currentPrice,
+              minimumNextBidPrice: latestAuctionEvent.minimumNextBidPrice,
+              bidCount: latestAuctionEvent.bidCount,
+              bidderCount: latestAuctionEvent.bidderCount,
+              serverTime: latestAuctionEvent.serverTime,
+            }
+          : previous,
+      );
+      return;
+    }
+
+    if (latestAuctionEvent.type === "BID_RECEIVED") {
+      showToastRef.current(
+        latestAuctionEvent.firstBid
+          ? "첫 입찰이 발생했습니다."
+          : "새로운 입찰이 발생했습니다.",
+      );
+      return;
+    }
+
+    if (latestAuctionEvent.type === "OUTBID") {
+      showToastRef.current("상위 입찰자가 생겼습니다.");
+      return;
+    }
+
+    if (latestAuctionEvent.type === "AUCTION_ENDED") {
+      const endedStatus = latestAuctionEvent.status;
+      setAuctionDetail((previous) =>
+        previous
+          ? {
+              ...previous,
+              currentPrice: latestAuctionEvent.finalPrice ?? previous.currentPrice,
+              minimumNextBidPrice: latestAuctionEvent.finalPrice ?? previous.minimumNextBidPrice,
+              serverTime: latestAuctionEvent.serverTime,
+              status:
+                endedStatus === "SUCCESSFUL_BID" || endedStatus === "NO_BID"
+                  ? endedStatus
+                  : "ENDED",
+            }
+          : previous,
+      );
+      showToastRef.current(
+        endedStatus === "NO_BID"
+          ? "경매가 유찰되었습니다."
+          : "경매가 종료되었습니다.",
+      );
+    }
+  }, [isRegular, latestAuctionEvent, productId]);
 
   const handleBidSubmit = async (bidPrice: number) => {
     if (isRegular || productId == null || isBidSubmitting) {

--- a/src/app/products/[productId]/index.tsx
+++ b/src/app/products/[productId]/index.tsx
@@ -24,6 +24,7 @@ import {
   placeAuctionBid,
 } from "@/services/auction/detail/service";
 import type { AuctionDetailResponse } from "@/services/auction/detail/types";
+import { fetchCurrentMember } from "@/services/auth/service";
 import { useEventStream } from "@/services/events/EventStreamProvider";
 import type { AuctionEventStreamEvent } from "@/services/events/types";
 import * as productDetailService from "@/services/product/productDetail/service";
@@ -134,6 +135,7 @@ export default function ProductDetailScreen({
   const [auctionErrorMessage, setAuctionErrorMessage] = useState("");
   const [currentTimeMs, setCurrentTimeMs] = useState(() => Date.now());
   const [auctionClockOffsetMs, setAuctionClockOffsetMs] = useState(0);
+  const [currentMemberId, setCurrentMemberId] = useState<number | null>(null);
   const { latestAuctionEvent } = useEventStream();
   const showToastRef = useRef(showToast);
 
@@ -164,6 +166,10 @@ export default function ProductDetailScreen({
       effectiveAuctionStatus === "NO_BID" ||
       effectiveAuctionStatus === "SUCCESSFUL_BID" ||
       hasAuctionTimeEnded);
+  const isAuctionOwner =
+    !isRegular &&
+    currentMemberId != null &&
+    auctionDetail?.seller.memberId === currentMemberId;
   const bidUnit = auctionDetail?.minimumBidAmount ?? 10000;
   const minBidAmount =
     auctionDetail?.minimumNextBidPrice ?? currentPrice + bidUnit;
@@ -286,6 +292,30 @@ export default function ProductDetailScreen({
   }, [isRegular, productId]);
 
   useEffect(() => {
+    if (isRegular) {
+      return;
+    }
+
+    let ignore = false;
+
+    fetchCurrentMember()
+      .then((member) => {
+        if (!ignore) {
+          setCurrentMemberId(member.memberId);
+        }
+      })
+      .catch(() => {
+        if (!ignore) {
+          setCurrentMemberId(null);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [isRegular]);
+
+  useEffect(() => {
     if (isRegular || !isAuctionEventForProduct(latestAuctionEvent, productId)) {
       return;
     }
@@ -352,6 +382,11 @@ export default function ProductDetailScreen({
 
   const handleBidSubmit = async (bidPrice: number) => {
     if (isRegular || productId == null || isBidSubmitting) {
+      return;
+    }
+
+    if (isAuctionOwner) {
+      showToast("자신이 등록한 경매에는 입찰할 수 없습니다.");
       return;
     }
 
@@ -650,17 +685,17 @@ export default function ProductDetailScreen({
           </button>
         ) : (
           <button
-            onClick={() =>
-              !isAuctionScheduled && !isAuctionEnded && setShowBidSheet(true)
+          onClick={() =>
+              !isAuctionScheduled && !isAuctionEnded && !isAuctionOwner && setShowBidSheet(true)
             }
-            disabled={isAuctionScheduled || isAuctionEnded}
+            disabled={isAuctionScheduled || isAuctionEnded || isAuctionOwner}
             className={`flex-1 h-14 font-bold rounded-xl transition-colors ${
-              isAuctionScheduled || isAuctionEnded
+              isAuctionScheduled || isAuctionEnded || isAuctionOwner
                 ? "bg-gray-100 text-gray-400 cursor-not-allowed"
                 : "text-white shadow-lg"
             }`}
             style={
-              isAuctionScheduled || isAuctionEnded
+              isAuctionScheduled || isAuctionEnded || isAuctionOwner
                 ? undefined
                 : ({ backgroundColor: themeColor } as React.CSSProperties)
             }
@@ -669,6 +704,8 @@ export default function ProductDetailScreen({
               ? "경매 종료"
               : isAuctionScheduled
                 ? "입찰은 시작 후 가능해요"
+                : isAuctionOwner
+                  ? "내 경매입니다"
                 : "입찰하기"}
           </button>
         )}

--- a/src/app/products/[productId]/page.tsx
+++ b/src/app/products/[productId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 
 import ProductDetailScreen from "./index";
 import { findExistingChatRoomByProductId } from "@/services/chats/service";
+import { EventStreamProvider } from "@/services/events/EventStreamProvider";
 import * as productDetailService from "@/services/product/productDetail/service";
 import type { ProductDetailResponse } from "@/services/product/productDetail/types";
 
@@ -99,24 +100,26 @@ export default function ProductDetailPage() {
   }
 
   return (
-    <ProductDetailScreen
-      productId={productId}
-      productData={productData}
-      onBack={() => router.back()}
-      onChatClick={handleChatClick}
-      onReportClick={() => router.push(`/products/${productId}/report`)}
-      onPurchaseClick={() =>
-        router.push(`/products/${productId}/regular-purchase`)
-      }
-      onBidStatusClick={() =>
-        router.push(`/auctions/${productId}/bidding-status`)
-      }
-      onBidComplete={(data) =>
-        router.push(`/auctions/${productId}/bid-complete?bidPrice=${data.bidAmount}`)
-      }
-      themeColor={productData.saleType === "AUCTION" ? "#F64257" : "#98E446"}
-      mode={productData.saleType === "AUCTION" ? "auction" : "regular"}
-      showToast={() => {}}
-    />
+    <EventStreamProvider enabled>
+      <ProductDetailScreen
+        productId={productId}
+        productData={productData}
+        onBack={() => router.back()}
+        onChatClick={handleChatClick}
+        onReportClick={() => router.push(`/products/${productId}/report`)}
+        onPurchaseClick={() =>
+          router.push(`/products/${productId}/regular-purchase`)
+        }
+        onBidStatusClick={() =>
+          router.push(`/auctions/${productId}/bidding-status`)
+        }
+        onBidComplete={(data) =>
+          router.push(`/auctions/${productId}/bid-complete?bidPrice=${data.bidAmount}`)
+        }
+        themeColor={productData.saleType === "AUCTION" ? "#F64257" : "#98E446"}
+        mode={productData.saleType === "AUCTION" ? "auction" : "regular"}
+        showToast={() => {}}
+      />
+    </EventStreamProvider>
   );
 }

--- a/src/services/auction/detail/api.ts
+++ b/src/services/auction/detail/api.ts
@@ -4,6 +4,7 @@ import {
   handleUnauthorizedAccess,
 } from "@/services/auth/service";
 import type {
+  AuctionBidHistoryResponse,
   AuctionDetailResponse,
   CreateAuctionBidRequest,
   CreateAuctionBidResponse,
@@ -37,6 +38,28 @@ export async function getAuctionDetail(
     await throwProtectedApiError(
       response,
       "경매 상품 정보를 불러오지 못했습니다.",
+    );
+  }
+
+  return response.json();
+}
+
+export async function getAuctionBidHistory(
+  auctionId: number,
+): Promise<AuctionBidHistoryResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/v1/auctions/${auctionId}/bids`,
+    {
+      method: "GET",
+      headers: getAuthorizationHeaders(),
+      cache: "no-store",
+    },
+  );
+
+  if (!response.ok) {
+    await throwProtectedApiError(
+      response,
+      "입찰 현황을 불러오지 못했습니다.",
     );
   }
 

--- a/src/services/auction/detail/service.ts
+++ b/src/services/auction/detail/service.ts
@@ -5,6 +5,10 @@ export async function fetchAuctionDetail(auctionId: number) {
   return auctionDetailApi.getAuctionDetail(auctionId);
 }
 
+export async function fetchAuctionBidHistory(auctionId: number) {
+  return auctionDetailApi.getAuctionBidHistory(auctionId);
+}
+
 export async function placeAuctionBid(auctionId: number, bidPrice: number) {
   return auctionDetailApi.postAuctionBid(auctionId, { bidPrice });
 }

--- a/src/services/auction/detail/types.ts
+++ b/src/services/auction/detail/types.ts
@@ -2,7 +2,10 @@ export type AuctionDetailStatus =
   | "AUCTION_SCHEDULED"
   | "AUCTION_LIVE"
   | "AUCTION_ENDED"
-  | "ENDED";
+  | "ONGOING"
+  | "ENDED"
+  | "NO_BID"
+  | "SUCCESSFUL_BID";
 
 export interface AuctionDetailImage {
   imageId: number;
@@ -47,4 +50,20 @@ export interface CreateAuctionBidResponse {
   currentPrice: number;
   bidderId: number;
   serverTime: string;
+}
+
+export interface AuctionBidHistoryItem {
+  bidId: number;
+  bidderId: number;
+  bidderNickname: string;
+  bidPrice: number;
+  bidAt: string;
+  highest: boolean;
+}
+
+export interface AuctionBidHistoryResponse {
+  auctionId: number;
+  currentPrice: number;
+  bidCount: number;
+  bids: AuctionBidHistoryItem[];
 }

--- a/src/services/events/EventStreamProvider.tsx
+++ b/src/services/events/EventStreamProvider.tsx
@@ -13,6 +13,7 @@ import {
 import { fetchTotalUnreadCount } from "../chats/service";
 import type {
   AppEventStreamEvent,
+  AuctionEventStreamEvent,
   ChatRoomUpdatedEvent,
   ChatUnreadCountUpdatedEvent,
 } from "./types";
@@ -21,6 +22,7 @@ import { subscribeEventStream } from "./stream";
 interface EventStreamContextValue {
   chatUnreadCount: number;
   latestChatRoomEvent: ChatRoomUpdatedEvent | null;
+  latestAuctionEvent: AuctionEventStreamEvent | null;
   setChatUnreadCount: (count: number) => void;
 }
 
@@ -51,6 +53,18 @@ function isChatRoomUpdatedEvent(
   );
 }
 
+function isAuctionEvent(
+  event: AppEventStreamEvent,
+): event is AuctionEventStreamEvent {
+  return (
+    event.type === "BID_UPDATED" ||
+    event.type === "OUTBID" ||
+    event.type === "AUCTION_ENDED" ||
+    event.type === "BID_RECEIVED" ||
+    event.type === "AUCTION_BID_UPDATED"
+  );
+}
+
 export function EventStreamProvider({
   enabled,
   children,
@@ -61,6 +75,8 @@ export function EventStreamProvider({
   const [chatUnreadCount, setChatUnreadCountState] = useState(0);
   const [latestChatRoomEvent, setLatestChatRoomEvent] =
     useState<ChatRoomUpdatedEvent | null>(null);
+  const [latestAuctionEvent, setLatestAuctionEvent] =
+    useState<AuctionEventStreamEvent | null>(null);
 
   const setChatUnreadCount = useCallback((count: number) => {
     setChatUnreadCountState(Math.max(0, count));
@@ -70,6 +86,7 @@ export function EventStreamProvider({
     if (!enabled || !hasAccessToken()) {
       setChatUnreadCount(0);
       setLatestChatRoomEvent(null);
+      setLatestAuctionEvent(null);
       return;
     }
 
@@ -94,6 +111,11 @@ export function EventStreamProvider({
 
         if (isChatRoomUpdatedEvent(event)) {
           setLatestChatRoomEvent(event);
+          return;
+        }
+
+        if (isAuctionEvent(event)) {
+          setLatestAuctionEvent(event);
         }
       },
       onError: (error) => {
@@ -111,9 +133,10 @@ export function EventStreamProvider({
     () => ({
       chatUnreadCount,
       latestChatRoomEvent,
+      latestAuctionEvent,
       setChatUnreadCount,
     }),
-    [chatUnreadCount, latestChatRoomEvent, setChatUnreadCount],
+    [chatUnreadCount, latestAuctionEvent, latestChatRoomEvent, setChatUnreadCount],
   );
 
   return (
@@ -129,6 +152,7 @@ export function useEventStream() {
     context ?? {
       chatUnreadCount: 0,
       latestChatRoomEvent: null,
+      latestAuctionEvent: null,
       setChatUnreadCount: () => {},
     }
   );

--- a/src/services/events/types.ts
+++ b/src/services/events/types.ts
@@ -18,8 +18,62 @@ export interface ChatUnreadCountUpdatedEvent {
   emittedAt: string;
 }
 
+export interface AuctionBidUpdatedEvent {
+  type: "AUCTION_BID_UPDATED";
+  auctionId: number;
+  currentPrice: number;
+  minimumNextBidPrice: number;
+  bidCount: number;
+  bidderCount: number;
+  serverTime: string;
+}
+
+export interface AuctionBidReceivedEvent {
+  type: "BID_RECEIVED";
+  auctionId: number;
+  bidderId: number;
+  currentPrice: number;
+  bidCount: number;
+  firstBid: boolean;
+  serverTime: string;
+}
+
+export interface AuctionOutbidEvent {
+  type: "OUTBID";
+  auctionId: number;
+  previousBidderId: number;
+  newBidderId: number;
+  currentPrice: number;
+  serverTime: string;
+}
+
+export interface AuctionEndedEvent {
+  type: "AUCTION_ENDED";
+  auctionId: number;
+  winnerId: number | null;
+  finalPrice: number | null;
+  status: "SUCCESSFUL_BID" | "NO_BID" | "ENDED" | string;
+  serverTime: string;
+}
+
+export interface AuctionBidSubmittedEvent {
+  type: "BID_UPDATED";
+  auctionId: number;
+  currentPrice: number;
+  bidderId: number;
+  serverTime: string;
+}
+
+export type AuctionEventStreamEvent =
+  | AuctionBidUpdatedEvent
+  | AuctionBidReceivedEvent
+  | AuctionOutbidEvent
+  | AuctionEndedEvent
+  | AuctionBidSubmittedEvent;
+
 export type AppEventStreamEvent =
   | EventStreamConnectedEvent
   | ChatRoomUpdatedEvent
   | ChatUnreadCountUpdatedEvent
+  | AuctionEventStreamEvent
   | { type: string; [key: string]: unknown };


### PR DESCRIPTION
### 🚀 Summary

  경매 SSE 이벤트 수신 처리를 추가하고, 경매 상세/입찰 현황 화면이 실시간으로 갱신되도록 구현했습니다.

  ---

  ### ✨ Description

  - 전역 SSE Provider에 경매 이벤트 타입 처리를 추가했습니다.
    - `BID_UPDATED`
    - `OUTBID`
    - `AUCTION_ENDED`
    - `BID_RECEIVED`
    - `AUCTION_BID_UPDATED`
  - 경매 상세 화면에서 SSE 수신 시 실시간으로 값을 갱신합니다.
    - 현재가
    - 최소 다음 입찰가
    - 입찰 수
    - 경매 종료 상태
  - 입찰 현황 화면에서 실제 입찰 기록 API를 조회하도록 수정했습니다.
    - 기존 빈 배열 하드코딩 제거
    - 최신순 입찰 기록 표시
    - 최고 입찰자 표시
  - 입찰 현황 화면에서 SSE 수신 시 입찰 기록을 재조회하여 실시간 반영합니다.
  - 직접 URL 진입 시에도 SSE가 동작하도록 상세/입찰현황 라우트에 Provider를 적용했습니다.
  - 판매자가 본인 경매 상세에 들어간 경우 입찰 버튼을 비활성화하고 `내 경매입니다`로 표시합니다.
  - 검증
    - `npm run build`
    - `npx tsc --noEmit`
<img width="3024" height="1722" alt="image" src="https://github.com/user-attachments/assets/0234bf08-56ab-43dc-9842-b0b217faf652" />


### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #56 
