### PR TITLE
[feat] 홈화면 인기경매/마감임박 상품 구현

### DIFF
--- a/src/app/(main)/home/index.tsx
+++ b/src/app/(main)/home/index.tsx
@@ -37,9 +37,22 @@ import { Screen, Tab } from "../../../types/index";
 import { ExploreIcon } from "../../../components/common/ExploreIcon";
 import ProductListItem from "../../../components/product/ProductListItem";
 import { getErrorMessage } from "@/services/apiError";
+import {
+  fetchClosingSoonAuctions,
+  fetchPopularAuctions,
+} from "@/services/auction/list/service";
+import type { AuctionListItemViewModel } from "@/services/auction/list/types";
 import { fetchPopularRegularProducts } from "@/services/product/popular/service";
 import { fetchHotRegularProducts } from "@/services/product/hotList/service";
 import type { PopularProductItemViewModel } from "@/services/product/popular/types";
+
+type PopularHomeItem = PopularProductItemViewModel | AuctionListItemViewModel;
+
+function isAuctionHomeItem(
+  item: PopularHomeItem,
+): item is AuctionListItemViewModel {
+  return "auctionId" in item;
+}
 
 export default function HomeScreen({
   onProductClick,
@@ -72,12 +85,14 @@ export default function HomeScreen({
       : "https://i.ibb.co/6RrSfG14/image.png";
 
   const [currentBanner, setCurrentBanner] = useState(0);
-  const [popularProducts, setPopularProducts] = useState<
-    PopularProductItemViewModel[]
-  >([]);
+  const [popularProducts, setPopularProducts] = useState<PopularHomeItem[]>(
+    [],
+  );
   const [isPopularLoading, setIsPopularLoading] = useState(false);
   const [popularErrorMessage, setPopularErrorMessage] = useState("");
   const [hotProducts, setHotProducts] = useState<any[]>([]);
+  const [isHotLoading, setIsHotLoading] = useState(false);
+  const [hotErrorMessage, setHotErrorMessage] = useState("");
   const banners =
     mode === "regular"
       ? [
@@ -129,19 +144,17 @@ export default function HomeScreen({
   }, [banners.length]);
 
   useEffect(() => {
-    if (mode !== "regular") {
-      setPopularProducts([]);
-      setPopularErrorMessage("");
-      setIsPopularLoading(false);
-      return;
-    }
-
     let ignore = false;
 
     setIsPopularLoading(true);
     setPopularErrorMessage("");
 
-    fetchPopularRegularProducts(10)
+    const request =
+      mode === "regular"
+        ? fetchPopularRegularProducts(10)
+        : fetchPopularAuctions(4);
+
+    request
       .then((products) => {
         if (!ignore) {
           setPopularProducts(products);
@@ -151,7 +164,12 @@ export default function HomeScreen({
         if (!ignore) {
           setPopularProducts([]);
           setPopularErrorMessage(
-            getErrorMessage(error, "실시간 인기 상품을 불러오지 못했습니다."),
+            getErrorMessage(
+              error,
+              mode === "regular"
+                ? "실시간 인기 상품을 불러오지 못했습니다."
+                : "실시간 인기 경매를 불러오지 못했습니다.",
+            ),
           );
         }
       })
@@ -167,23 +185,38 @@ export default function HomeScreen({
   }, [mode]);
 
   useEffect(() => {
-    if (mode !== "regular") {
-      setHotProducts([]);
-      return;
-    }
-
     let ignore = false;
 
-    fetchHotRegularProducts(8)
+    setIsHotLoading(true);
+    setHotErrorMessage("");
+
+    const request =
+      mode === "regular"
+        ? fetchHotRegularProducts(8)
+        : fetchClosingSoonAuctions(3);
+
+    request
       .then((products) => {
         if (!ignore) {
-          // Home shows top 3, more page will request up to 8
           setHotProducts(products.slice(0, 3));
         }
       })
-      .catch(() => {
+      .catch((error) => {
         if (!ignore) {
           setHotProducts([]);
+          setHotErrorMessage(
+            getErrorMessage(
+              error,
+              mode === "regular"
+                ? "핫한 상품을 불러오지 못했습니다."
+                : "마감임박 경매를 불러오지 못했습니다.",
+            ),
+          );
+        }
+      })
+      .finally(() => {
+        if (!ignore) {
+          setIsHotLoading(false);
         }
       });
 
@@ -327,13 +360,11 @@ export default function HomeScreen({
               </button>
             </div>
 
-            {mode !== "regular" ? (
+            {isPopularLoading ? (
               <div className="flex h-32 items-center justify-center rounded-2xl border border-dashed border-gray-200 text-sm font-medium text-gray-400">
-                등록된 경매 상품이 없습니다
-              </div>
-            ) : isPopularLoading ? (
-              <div className="flex h-32 items-center justify-center rounded-2xl border border-dashed border-gray-200 text-sm font-medium text-gray-400">
-                실시간 인기 상품을 불러오는 중입니다
+                {mode === "regular"
+                  ? "실시간 인기 상품을 불러오는 중입니다"
+                  : "실시간 인기 경매를 불러오는 중입니다"}
               </div>
             ) : popularErrorMessage ? (
               <div className="flex h-32 items-center justify-center rounded-2xl border border-dashed border-red-100 bg-red-50 px-4 text-center text-sm font-medium text-red-500">
@@ -344,13 +375,23 @@ export default function HomeScreen({
                 {popularProducts.map((product) => (
                   <div
                     key={product.productId}
-                    onClick={() => onProductClick(product.productId)}
+                    onClick={() =>
+                      onProductClick(
+                        isAuctionHomeItem(product)
+                          ? product.auctionId
+                          : product.productId,
+                      )
+                    }
                     role="button"
                     tabIndex={0}
                     onKeyDown={(event) => {
                       if (event.key === "Enter" || event.key === " ") {
                         event.preventDefault();
-                        onProductClick(product.productId);
+                        onProductClick(
+                          isAuctionHomeItem(product)
+                            ? product.auctionId
+                            : product.productId,
+                        );
                       }
                     }}
                     className="w-[140px] shrink-0 space-y-3 cursor-pointer group"
@@ -367,26 +408,53 @@ export default function HomeScreen({
                           <ImageIcon size={28} />
                         </div>
                       )}
+                      {isAuctionHomeItem(product) && (
+                        <div
+                          className={`absolute left-2 top-2 rounded-full px-2 py-0.5 text-[10px] font-bold ${
+                            product.rank === 1
+                              ? "bg-red-500 text-white"
+                              : "bg-black/60 text-white"
+                          }`}
+                        >
+                          {product.rank}위
+                        </div>
+                      )}
                     </div>
                     <div className="space-y-1">
                       <h4 className="text-sm font-semibold truncate text-gray-800">
                         {product.name}
                       </h4>
                       <p className="font-bold text-base text-black">
-                        {product.priceLabel}
+                        {isAuctionHomeItem(product)
+                          ? product.currentPriceLabel
+                          : product.priceLabel}
                       </p>
                       <p className="text-[10px] text-gray-400 font-medium truncate">
                         {product.categoryName} · {product.location}
                       </p>
-                      <div className="flex items-center space-x-2 text-[10px] text-gray-400 font-medium">
-                        <div className="flex items-center space-x-1">
-                          <Eye size={10} />
-                          <span>{product.viewCount}</span>
+                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] text-gray-400 font-medium">
+                        <div className="flex items-center space-x-1 whitespace-nowrap">
+                          {isAuctionHomeItem(product) ? (
+                            <>
+                              <Clock size={10} />
+                              <span>{product.endAtLabel}</span>
+                            </>
+                          ) : (
+                            <>
+                              <Eye size={10} />
+                              <span>{product.viewCount}</span>
+                            </>
+                          )}
                         </div>
-                        <div className="flex items-center space-x-1">
+                        <div className="flex items-center space-x-1 whitespace-nowrap">
                           <TrendingUp size={10} />
                           <span>{product.popularScore.toFixed(1)}</span>
                         </div>
+                        {isAuctionHomeItem(product) && (
+                          <div className="flex items-center space-x-1 whitespace-nowrap">
+                            <span>입찰 {product.bidCount}회</span>
+                          </div>
+                        )}
                       </div>
                     </div>
                   </div>
@@ -394,7 +462,9 @@ export default function HomeScreen({
               </div>
             ) : (
               <div className="flex h-32 items-center justify-center rounded-2xl border border-dashed border-gray-200 text-sm font-medium text-gray-400">
-                등록된 경매 상품이 없습니다
+                {mode === "regular"
+                  ? "등록된 일반 상품이 없습니다"
+                  : "등록된 인기 경매가 없습니다"}
               </div>
             )}
           </div>
@@ -416,7 +486,17 @@ export default function HomeScreen({
               </button>
             </div>
 
-            {hotProducts.length > 0 ? (
+            {isHotLoading ? (
+              <div className="flex h-32 items-center justify-center rounded-2xl border border-dashed border-gray-200 text-sm font-medium text-gray-400">
+                {mode === "regular"
+                  ? "핫한 상품을 불러오는 중입니다"
+                  : "마감임박 경매를 불러오는 중입니다"}
+              </div>
+            ) : hotErrorMessage ? (
+              <div className="flex h-32 items-center justify-center rounded-2xl border border-dashed border-red-100 bg-red-50 px-4 text-center text-sm font-medium text-red-500">
+                {hotErrorMessage}
+              </div>
+            ) : hotProducts.length > 0 ? (
               <div className="space-y-4">
                 {hotProducts.map((p) => (
                   <ProductListItem
@@ -430,7 +510,9 @@ export default function HomeScreen({
               </div>
             ) : (
               <div className="flex h-32 items-center justify-center rounded-2xl border border-dashed border-gray-200 text-sm font-medium text-gray-400">
-                핫한 상품이 없습니다
+                {mode === "regular"
+                  ? "핫한 상품이 없습니다"
+                  : "마감임박 경매가 없습니다"}
               </div>
             )}
           </div>

--- a/src/app/auction/[auctionId]/page.tsx
+++ b/src/app/auction/[auctionId]/page.tsx
@@ -1,0 +1,3 @@
+"use client";
+
+export { default } from "../../auctions/[auctionId]/page";

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -163,6 +163,10 @@ export default function App() {
     router.push(`/products/${id}`);
   };
 
+  const navigateToCatalogItem = (id: number) => {
+    router.push(themeMode === "auction" ? `/auction/${id}` : `/products/${id}`);
+  };
+
   const handleLocationPostcodeSearch = async () => {
     try {
       const nextLocationForm = await openDaumPostcodeSearch(
@@ -489,7 +493,7 @@ export default function App() {
               key="main"
               activeTab={currentTab}
               onTabChange={setCurrentTab}
-              onProductClick={navigateToProduct}
+              onProductClick={navigateToCatalogItem}
               onProductListClick={(type, category) => {
                 setProductListType(type);
                 setSelectedCategory(category || null);
@@ -601,7 +605,7 @@ export default function App() {
                 setSelectedCategory(null);
                 navigateTo("main");
               }}
-              onProductClick={navigateToProduct}
+              onProductClick={navigateToCatalogItem}
               onSearchClick={() => navigateTo("search_detail")}
               themeColor={themeColor}
               mode={themeMode}

--- a/src/app/products/index.tsx
+++ b/src/app/products/index.tsx
@@ -36,6 +36,10 @@ import { motion, AnimatePresence } from "motion/react";
 import { Screen, Tab } from "../../types/index";
 import { ExploreIcon } from "../../components/common/ExploreIcon";
 import ProductListItem from "../../components/product/ProductListItem";
+import {
+  fetchClosingSoonAuctions,
+  fetchPopularAuctions,
+} from "@/services/auction/list/service";
 import { fetchHotRegularProducts } from "@/services/product/hotList/service";
 import { getErrorMessage } from "@/services/apiError";
 
@@ -59,13 +63,15 @@ export default function ProductListScreen({
 }) {
   const title =
     categoryName ||
-    (listType === "all"
-      ? "전체 목록"
-      : listType === "recent"
-        ? "최근 본 상품"
-        : mode === "regular"
-          ? "핫한 상품"
-          : "마감 임박 상품");
+    (mode === "auction" && listType === "all"
+      ? "실시간 인기 경매"
+      : mode === "auction" && listType === "closing_soon"
+        ? "마감 임박 경매"
+        : listType === "all"
+          ? "전체 목록"
+          : listType === "recent"
+            ? "최근 본 상품"
+            : "핫한 상품");
   const [itemIds] = useState<number[]>(
     mode === "auction" ? [] : [1, 2, 3, 4, 5, 6, 7, 8],
   );
@@ -75,17 +81,35 @@ export default function ProductListScreen({
 
   useEffect(() => {
     let ignore = false;
-    if (listType === "closing_soon" && mode === "regular") {
+    if (
+      (listType === "closing_soon" && mode === "regular") ||
+      (mode === "auction" && (listType === "all" || listType === "closing_soon"))
+    ) {
       setIsHotLoading(true);
       setHotError("");
-      fetchHotRegularProducts(8)
+
+      const request =
+        mode === "regular"
+          ? fetchHotRegularProducts(8)
+          : listType === "all"
+            ? fetchPopularAuctions(8)
+            : fetchClosingSoonAuctions(8);
+
+      request
         .then((products) => {
           if (!ignore) setHotProducts(products.slice(0, 8));
         })
         .catch((err) => {
           if (!ignore)
             setHotError(
-              getErrorMessage(err, "핫한 상품을 불러오지 못했습니다."),
+              getErrorMessage(
+                err,
+                mode === "regular"
+                  ? "핫한 상품을 불러오지 못했습니다."
+                  : listType === "all"
+                    ? "실시간 인기 경매를 불러오지 못했습니다."
+                    : "마감임박 경매를 불러오지 못했습니다.",
+              ),
             );
         })
         .finally(() => {
@@ -125,12 +149,17 @@ export default function ProductListScreen({
         </button>
       </div>
       <div className="flex-1 overflow-y-auto no-scrollbar p-4 space-y-4">
-        {listType === "closing_soon" && mode === "regular" ? (
+        {(listType === "closing_soon" && mode === "regular") ||
+        (mode === "auction" && (listType === "all" || listType === "closing_soon")) ? (
           isHotLoading ? (
             <div className="flex flex-col items-center justify-center h-64 text-gray-400 space-y-2">
               <ShoppingBag size={48} className="opacity-20" />
               <p className="text-sm font-medium">
-                핫한 상품을 불러오는 중입니다
+                {mode === "regular"
+                  ? "핫한 상품을 불러오는 중입니다"
+                  : listType === "all"
+                    ? "실시간 인기 경매를 불러오는 중입니다"
+                    : "마감임박 경매를 불러오는 중입니다"}
               </p>
             </div>
           ) : hotError ? (
@@ -150,7 +179,13 @@ export default function ProductListScreen({
           ) : (
             <div className="flex flex-col items-center justify-center h-64 text-gray-400 space-y-2">
               <ShoppingBag size={48} className="opacity-20" />
-              <p className="text-sm font-medium">핫한 상품이 없습니다</p>
+              <p className="text-sm font-medium">
+                {mode === "regular"
+                  ? "핫한 상품이 없습니다"
+                  : listType === "all"
+                    ? "등록된 인기 경매가 없습니다"
+                    : "마감임박 경매가 없습니다"}
+              </p>
             </div>
           )
         ) : itemIds.length > 0 ? (

--- a/src/components/product/ProductListItem.tsx
+++ b/src/components/product/ProductListItem.tsx
@@ -1,6 +1,13 @@
 "use client";
 import React, { useEffect, useState } from "react";
-import { Heart, Image as ImageIcon, MessageCircle } from "lucide-react";
+import {
+  Clock,
+  Gavel,
+  Heart,
+  Image as ImageIcon,
+  MessageCircle,
+  TrendingUp,
+} from "lucide-react";
 
 import ConfirmModal from "../common/modal/ConfirmModal";
 import {
@@ -20,6 +27,7 @@ export default function ProductListItem({
   i?: number;
   product?: {
     productId: number;
+    auctionId?: number;
     name?: string;
     thumbnailUrl?: string | null;
     priceLabel?: string;
@@ -29,6 +37,12 @@ export default function ProductListItem({
     favoriteCount?: number;
     chatCount?: number;
     hotScore?: number;
+    bidCount?: number;
+    currentPriceLabel?: string;
+    startPriceLabel?: string;
+    endAtLabel?: string;
+    auctionStatusLabel?: string;
+    popularScore?: number;
     rank?: number;
     createdAt?: string;
     canFavorite?: boolean;
@@ -42,6 +56,10 @@ export default function ProductListItem({
 }) {
   const useData = product !== undefined && product !== null;
   const productId = useData ? product!.productId : (i ?? 0) + 10;
+  const clickTargetId =
+    mode === "auction" && useData && product!.auctionId != null
+      ? product!.auctionId
+      : productId;
   const thumbnailUrl = useData
     ? product!.thumbnailUrl
     : `https://picsum.photos/seed/hot${i}${mode}/200/200`;
@@ -50,6 +68,7 @@ export default function ProductListItem({
     ? (product!.priceLabel ?? "₩1,200,000")
     : "₩1,200,000";
   const chatCount = useData ? (product!.chatCount ?? 0) : 0;
+  const bidCount = useData ? (product!.bidCount ?? 0) : 0;
   const rank = useData ? (product!.rank ?? null) : null;
   const isTopRank = rank === 1;
   const showRankLabel = rank != null && rank >= 1 && rank <= 3;
@@ -61,10 +80,6 @@ export default function ProductListItem({
     product?.favoriteCount ?? 132,
   );
 
-  if (mode === "auction") {
-    return null;
-  }
-
   useEffect(() => {
     if (useData) {
       setDisplayFavoriteCount(product!.favoriteCount ?? 0);
@@ -72,6 +87,86 @@ export default function ProductListItem({
       setDisplayFavoriteCount(132);
     }
   }, [useData, product?.favoriteCount]);
+
+  if (mode === "auction") {
+    const currentPriceLabel = useData
+      ? (product!.currentPriceLabel ?? priceLabel)
+      : priceLabel;
+    const endAtLabel = useData ? (product!.endAtLabel ?? "마감 시간 없음") : "마감 임박";
+    const auctionStatusLabel = useData
+      ? (product!.auctionStatusLabel ?? "진행중")
+      : "진행중";
+
+    return (
+      <div
+        onClick={() => onProductClick(clickTargetId)}
+        className="flex items-center space-x-4 p-3 bg-white border border-gray-50 rounded-2xl hover:shadow-md transition-all cursor-pointer group"
+      >
+        <div className="w-24 h-24 bg-gray-50 rounded-xl overflow-hidden shrink-0 relative">
+          {thumbnailUrl ? (
+            <img
+              src={thumbnailUrl}
+              alt={name}
+              className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-gray-300">
+              <ImageIcon size={28} />
+            </div>
+          )}
+          <div className="absolute left-2 top-2 rounded-full bg-red-500 px-2 py-0.5 text-[10px] font-bold text-white">
+            {auctionStatusLabel}
+          </div>
+        </div>
+
+        <div className="flex-1 min-w-0 space-y-1.5">
+          <div className="flex justify-between items-start gap-2">
+            <h4 className="font-bold text-sm truncate text-gray-800">{name}</h4>
+            {showRankLabel && (
+              <div
+                className={`shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-bold ${
+                  isTopRank
+                    ? "bg-red-50 text-red-500"
+                    : "bg-gray-50 text-gray-500"
+                }`}
+              >
+                {rank}위
+              </div>
+            )}
+          </div>
+
+          <p className="text-xs text-gray-500 font-medium">
+            현재 입찰가{" "}
+            <span className="text-sm font-bold text-black ml-1">
+              {currentPriceLabel}
+            </span>
+          </p>
+
+          <p className="text-[10px] text-gray-400 font-medium truncate">
+            {product?.categoryName ?? "카테고리 없음"} ·{" "}
+            {product?.location ?? "지역 정보 없음"}
+          </p>
+
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-gray-400 font-medium">
+            <div className="flex items-center space-x-1 whitespace-nowrap">
+              <Gavel size={10} />
+              <span>입찰 {bidCount}회</span>
+            </div>
+            <div className="flex items-center space-x-1 whitespace-nowrap">
+              <Clock size={10} />
+              <span>{endAtLabel}</span>
+            </div>
+            {product?.popularScore != null && (
+              <div className="flex items-center space-x-1 whitespace-nowrap">
+                <TrendingUp size={10} />
+                <span>{product.popularScore.toFixed(1)}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   const handleLikeClick = async (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/src/services/auction/list/api.ts
+++ b/src/services/auction/list/api.ts
@@ -1,0 +1,60 @@
+import { ApiRequestError, getApiErrorMessage } from "@/services/apiError";
+import {
+  getAuthorizationHeaders,
+  handleUnauthorizedAccess,
+} from "@/services/auth/service";
+import type { AuctionListResponse } from "@/services/auction/list/types";
+
+async function throwAuctionListApiError(
+  response: Response,
+  fallbackMessage: string,
+) {
+  if (response.status === 401) {
+    handleUnauthorizedAccess();
+  }
+
+  throw new ApiRequestError(
+    await getApiErrorMessage(response, fallbackMessage),
+    response.status,
+  );
+}
+
+export async function getPopularAuctions(
+  limit = 4,
+): Promise<AuctionListResponse> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  const response = await fetch(`/api/v1/auctions/popular?${params}`, {
+    method: "GET",
+    headers: getAuthorizationHeaders(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    await throwAuctionListApiError(
+      response,
+      "실시간 인기 경매를 불러오지 못했습니다.",
+    );
+  }
+
+  return response.json();
+}
+
+export async function getClosingSoonAuctions(
+  limit = 3,
+): Promise<AuctionListResponse> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  const response = await fetch(`/api/v1/auctions/closing-soon?${params}`, {
+    method: "GET",
+    headers: getAuthorizationHeaders(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    await throwAuctionListApiError(
+      response,
+      "마감임박 경매를 불러오지 못했습니다.",
+    );
+  }
+
+  return response.json();
+}

--- a/src/services/auction/list/service.ts
+++ b/src/services/auction/list/service.ts
@@ -1,0 +1,93 @@
+import * as auctionListApi from "@/services/auction/list/api";
+import type {
+  AuctionListItemResponse,
+  AuctionListItemViewModel,
+  AuctionStatus,
+} from "@/services/auction/list/types";
+
+const DEFAULT_CATEGORY_LABEL = "카테고리 없음";
+const DEFAULT_LOCATION_LABEL = "지역 정보 없음";
+
+function formatPrice(price: number) {
+  return `${Number(price || 0).toLocaleString()}원`;
+}
+
+function formatAuctionStatus(status: AuctionStatus) {
+  switch (status) {
+    case "ONGOING":
+      return "진행중";
+    case "ENDED":
+      return "종료";
+    case "NO_BID":
+      return "유찰";
+    case "SUCCESSFUL_BID":
+      return "낙찰";
+    case "DRAFT":
+    default:
+      return "준비중";
+  }
+}
+
+function formatEndAt(endAt: string) {
+  const endTime = new Date(endAt).getTime();
+  if (!Number.isFinite(endTime)) {
+    return "마감 시간 없음";
+  }
+
+  const diffMs = endTime - Date.now();
+  if (diffMs <= 0) {
+    return "마감";
+  }
+
+  const totalMinutes = Math.floor(diffMs / 60000);
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
+
+  if (days > 0) {
+    return `${days}일 ${hours}시간 남음`;
+  }
+  if (hours > 0) {
+    return `${hours}시간 ${minutes}분 남음`;
+  }
+  return `${Math.max(1, minutes)}분 남음`;
+}
+
+function toAuctionListItemViewModel(
+  item: AuctionListItemResponse,
+): AuctionListItemViewModel {
+  const currentPriceLabel = formatPrice(item.currentPrice);
+  return {
+    productId: item.productId,
+    auctionId: item.auctionId,
+    name: item.title,
+    thumbnailUrl: item.thumbnailUrl,
+    priceLabel: currentPriceLabel,
+    startPriceLabel: formatPrice(item.startPrice),
+    currentPriceLabel,
+    location: item.location ?? DEFAULT_LOCATION_LABEL,
+    categoryName: item.categoryName ?? DEFAULT_CATEGORY_LABEL,
+    bidCount: item.bidCount,
+    endAt: item.endAt,
+    endAtLabel: formatEndAt(item.endAt),
+    auctionStatus: item.auctionStatus,
+    auctionStatusLabel: formatAuctionStatus(item.auctionStatus),
+    popularScore: item.popularScore,
+    rank: item.rank,
+    createdAt: item.createdAt,
+  };
+}
+
+export async function fetchPopularAuctions(
+  limit = 4,
+): Promise<AuctionListItemViewModel[]> {
+  const response = await auctionListApi.getPopularAuctions(limit);
+  return response.content.map(toAuctionListItemViewModel);
+}
+
+export async function fetchClosingSoonAuctions(
+  limit = 3,
+): Promise<AuctionListItemViewModel[]> {
+  const response = await auctionListApi.getClosingSoonAuctions(limit);
+  return response.content.map(toAuctionListItemViewModel);
+}

--- a/src/services/auction/list/types.ts
+++ b/src/services/auction/list/types.ts
@@ -1,0 +1,48 @@
+export type AuctionStatus =
+  | "DRAFT"
+  | "ONGOING"
+  | "ENDED"
+  | "NO_BID"
+  | "SUCCESSFUL_BID";
+
+export interface AuctionListItemResponse {
+  auctionId: number;
+  productId: number;
+  title: string;
+  thumbnailUrl: string | null;
+  startPrice: number;
+  currentPrice: number;
+  bidCount: number;
+  endAt: string;
+  auctionStatus: AuctionStatus;
+  location: string | null;
+  categoryName: string | null;
+  sellerId: number;
+  popularScore: number;
+  rank: number;
+  createdAt: string;
+}
+
+export interface AuctionListResponse {
+  content: AuctionListItemResponse[];
+}
+
+export interface AuctionListItemViewModel {
+  productId: number;
+  auctionId: number;
+  name: string;
+  thumbnailUrl: string | null;
+  priceLabel: string;
+  startPriceLabel: string;
+  currentPriceLabel: string;
+  location: string;
+  categoryName: string;
+  bidCount: number;
+  endAt: string;
+  endAtLabel: string;
+  auctionStatus: AuctionStatus;
+  auctionStatusLabel: string;
+  popularScore: number;
+  rank: number;
+  createdAt: string;
+}


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
- 홈화면 인기경매/ 마감임박 상품 구현
- 순위 붙이기
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
## 작업 내용

- 경매 목록 API 연동 서비스 추가
  - `src/services/auction/list/types.ts`
  - `src/services/auction/list/api.ts`
  - `src/services/auction/list/service.ts`

- 홈 화면 경매 모드 API 연동
  - 실시간 인기 경매: `GET /api/v1/auctions/popular?limit=4`
  - 마감임박 경매: `GET /api/v1/auctions/closing-soon?limit=3`
  - 기존 mock/빈 상태 대신 실제 API 응답 사용
  - 로딩/에러/빈 목록 상태 처리

- 경매 전체/더보기 목록 API 연동
  - 실시간 인기 경매 전체: `limit=8`
  - 마감임박 경매 더보기: `limit=8`
  - `/products` 목록 화면을 경매 모드에서도 재사용

- 경매 카드 UI 추가
  - `ProductListItem`이 경매 모드도 렌더링하도록 확장
  - 현재 입찰가, 입찰 수, 남은 시간, 경매 상태, 순위 표시
  - 텍스트가 카드 안에서 글자 단위로 줄바꿈되지 않도록 메타 텍스트 `nowrap` 처리

- 경매 상세 이동 라우팅 수정
  - 경매 카드 클릭 시 `productId`가 아니라 `auctionId` 사용
  - 경매 모드에서는 `/auction/{auctionId}`로 이동
  - `/auction/[auctionId]` 라우트 추가
  - 기존 `/auctions/[auctionId]` 상세 화면 재사용

- 홈 실시간 인기 경매 순위 표시
  - 카드 이미지 상단에 `1위`, `2위` 배지 표시

#### 경매 실시간 상품
<img width="724" height="339" alt="스크린샷 2026-05-06 오후 3 20 25" src="https://github.com/user-attachments/assets/f075d000-f440-4b05-808a-8954dfcfbd3f" />

#### 실시간 경매 상품 전체목록
<img width="722" height="514" alt="스크린샷 2026-05-06 오후 3 20 33" src="https://github.com/user-attachments/assets/4cefa2d4-c43c-429c-9541-cfc7dbb75826" />

#### 경매 마감임박 상품
<img width="717" height="475" alt="스크린샷 2026-05-06 오후 3 20 41" src="https://github.com/user-attachments/assets/192a9bc5-c1b6-415a-9e54-b077cf9e840e" />

#### 마감임박 상품 더보기
<img width="704" height="554" alt="스크린샷 2026-05-06 오후 3 20 48" src="https://github.com/user-attachments/assets/51427772-37b2-4080-b628-e524bdd4c109" />



## 경매 외 변경사항

- `ProductListItem` 공용 컴포넌트를 수정했습니다.
  - 기존 일반상품 카드 동작은 유지
  - 경매 모드일 때만 별도 카드 UI를 렌더링
  - hook 순서 오류 방지를 위해 useEffect 위치 조정

- src/app/page.tsx 라우팅 함수를 수정했습니다.
  - 일반상품: /products/{id}
  - 경매상품: /auction/{auctionId}

- 홈 화면의 일반상품 빈 상태 문구를 명확히 수정했습니다.
  - 등록된 일반 상품이 없습니다

## 주의사항

- 경매 목록 응답에는 `productId`와 `auctionId`가 모두 포함됩니다.
- 상세 이동에는 `auctionId`를 사용합니다.

## 테스트

- `npm run build`
---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #61 
