### PR TITLE
[feat] 경매 보증금 입찰 UX 및 1분 경매 옵션 추가

### DIFF
--- a/src/app/auctions/[auctionId]/bid-complete/index.tsx
+++ b/src/app/auctions/[auctionId]/bid-complete/index.tsx
@@ -102,6 +102,10 @@ export default function BidPlacementCompleteScreen({
               </div>
             </div>
             <div className="h-px bg-gray-200"></div>
+            <div className="rounded-2xl bg-white p-4 text-xs leading-relaxed text-gray-500">
+              <p>입찰 금액은 Dealit Pay에서 예치금으로 잠금 처리되었습니다.</p>
+              <p>경매에서 추월당할 경우 예치금은 자동 환불됩니다.</p>
+            </div>
             <div className="space-y-2">
               <div className="flex justify-between text-sm">
                 <span className="text-gray-400">상품명</span>

--- a/src/app/products/[productId]/index.tsx
+++ b/src/app/products/[productId]/index.tsx
@@ -34,6 +34,7 @@ import {
   fetchRegularWishlist,
   removeRegularWishlist,
 } from "@/services/wishlist/service";
+import { fetchWallet, formatWon } from "@/services/wallet/service";
 
 type AuctionStatus =
   | "AUCTION_SCHEDULED"
@@ -138,6 +139,9 @@ export default function ProductDetailScreen({
     useState<AuctionDetailResponse | null>(null);
   const [isAuctionLoading, setIsAuctionLoading] = useState(false);
   const [isBidSubmitting, setIsBidSubmitting] = useState(false);
+  const [walletBalance, setWalletBalance] = useState<number | null>(null);
+  const [isWalletLoading, setIsWalletLoading] = useState(false);
+  const [walletErrorMessage, setWalletErrorMessage] = useState("");
   const [auctionErrorMessage, setAuctionErrorMessage] = useState("");
   const [currentTimeMs, setCurrentTimeMs] = useState(() => Date.now());
   const [auctionClockOffsetMs, setAuctionClockOffsetMs] = useState(0);
@@ -178,6 +182,8 @@ export default function ProductDetailScreen({
   const bidUnit = auctionDetail?.minimumBidAmount ?? 10000;
   const minBidAmount =
     auctionDetail?.minimumNextBidPrice ?? currentPrice + bidUnit;
+  const isWalletBalanceInsufficient =
+    walletBalance != null && walletBalance < inputBidAmount;
 
   const displayName =
     auctionDetail?.name ?? productData?.name ?? "상품 정보 없음";
@@ -285,6 +291,40 @@ export default function ProductDetailScreen({
       setInputBidAmount(minBidAmount);
     }
   }, [showBidSheet, minBidAmount]);
+
+  useEffect(() => {
+    if (!showBidSheet || isRegular) {
+      return;
+    }
+
+    let ignore = false;
+    setIsWalletLoading(true);
+    setWalletErrorMessage("");
+
+    fetchWallet()
+      .then((wallet) => {
+        if (!ignore) {
+          setWalletBalance(wallet.balance);
+        }
+      })
+      .catch((error) => {
+        if (!ignore) {
+          setWalletBalance(null);
+          setWalletErrorMessage(
+            getErrorMessage(error, "Dealit Pay 잔액을 불러오지 못했습니다."),
+          );
+        }
+      })
+      .finally(() => {
+        if (!ignore) {
+          setIsWalletLoading(false);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [showBidSheet, isRegular]);
 
   useEffect(() => {
     if (isRegular) {
@@ -445,9 +485,14 @@ export default function ProductDetailScreen({
       return;
     }
 
+    if (walletBalance != null && walletBalance < bidPrice) {
+      showToast("Dealit Pay 잔액이 부족합니다.");
+      return;
+    }
+
     try {
       setIsBidSubmitting(true);
-      await placeAuctionBid(productId, bidPrice);
+      const bidResult = await placeAuctionBid(productId, bidPrice);
       const nextAuctionDetail = await fetchAuctionDetail(productId);
 
       setAuctionDetail(nextAuctionDetail);
@@ -457,7 +502,13 @@ export default function ProductDetailScreen({
       setCurrentPrice(getAuctionDisplayCurrentPrice(nextAuctionDetail));
       setBidCount(nextAuctionDetail.bidCount);
       setInputBidAmount(nextAuctionDetail.minimumNextBidPrice);
+      setWalletBalance((previous) =>
+        previous == null ? previous : Math.max(previous - bidPrice, 0),
+      );
       setShowBidSheet(false);
+      if (bidResult.messages?.reserveNotice) {
+        showToast(bidResult.messages.reserveNotice);
+      }
       onBidComplete({
         productId,
         productName: nextAuctionDetail.name,
@@ -835,6 +886,20 @@ export default function ProductDetailScreen({
                       ₩{bidUnit.toLocaleString()}
                     </span>
                   </div>
+                  <div className="flex justify-between text-sm">
+                    <span className="text-gray-400">Dealit Pay 잔액</span>
+                    <span
+                      className={`font-bold ${
+                        isWalletBalanceInsufficient ? "text-red-500" : ""
+                      }`}
+                    >
+                      {isWalletLoading
+                        ? "확인 중..."
+                        : walletBalance == null
+                          ? "확인 필요"
+                          : formatWon(walletBalance)}
+                    </span>
+                  </div>
                 </div>
 
                 <div className="space-y-3">
@@ -853,13 +918,29 @@ export default function ProductDetailScreen({
                   <p className="text-[10px] text-gray-400">
                     최소 입찰가: ₩{minBidAmount.toLocaleString()}
                   </p>
+                  {isWalletBalanceInsufficient && (
+                    <p className="text-[10px] font-medium text-red-500">
+                      Dealit Pay 잔액이 입찰가보다 부족합니다.
+                    </p>
+                  )}
+                  {walletErrorMessage && (
+                    <p className="text-[10px] font-medium text-red-500">
+                      {walletErrorMessage}
+                    </p>
+                  )}
+                  <div className="rounded-xl bg-gray-50 px-4 py-3 text-[11px] leading-relaxed text-gray-500">
+                    <p>입찰 시 해당 금액은 Dealit Pay에서 즉시 예치됩니다.</p>
+                    <p>경매에서 추월당할 경우 예치금은 자동 환불됩니다.</p>
+                  </div>
                 </div>
 
                 <div className="grid grid-cols-2 gap-2">
                   <button
                     onClick={() => handleBidSubmit(currentPrice + 30000)}
                     disabled={
-                      isBidSubmitting || currentPrice + 30000 < minBidAmount
+                      isBidSubmitting ||
+                      currentPrice + 30000 < minBidAmount ||
+                      (walletBalance != null && walletBalance < currentPrice + 30000)
                     }
                     className="h-12 border border-blue-200 bg-blue-50 text-blue-700 rounded-xl text-sm font-bold hover:bg-blue-100 transition-colors disabled:opacity-50"
                   >
@@ -867,7 +948,10 @@ export default function ProductDetailScreen({
                   </button>
                   <button
                     onClick={() => handleBidSubmit(minBidAmount)}
-                    disabled={isBidSubmitting}
+                    disabled={
+                      isBidSubmitting ||
+                      (walletBalance != null && walletBalance < minBidAmount)
+                    }
                     className="h-12 border border-gray-200 rounded-xl text-sm font-bold hover:bg-gray-50 transition-colors disabled:opacity-50"
                   >
                     ₩{minBidAmount.toLocaleString()}
@@ -875,12 +959,18 @@ export default function ProductDetailScreen({
                 </div>
 
                 <button
-                  disabled={isBidSubmitting || inputBidAmount < minBidAmount}
+                  disabled={
+                    isBidSubmitting ||
+                    inputBidAmount < minBidAmount ||
+                    isWalletBalanceInsufficient
+                  }
                   onClick={() => handleBidSubmit(inputBidAmount)}
                   className="w-full h-14 text-white font-bold rounded-xl transition-all shadow-lg disabled:bg-gray-300 disabled:opacity-50"
                   style={{
                     backgroundColor:
-                      inputBidAmount < minBidAmount ? undefined : themeColor,
+                      inputBidAmount < minBidAmount || isWalletBalanceInsufficient
+                        ? undefined
+                        : themeColor,
                   }}
                 >
                   {isBidSubmitting ? "입찰 중..." : "입찰하기"}

--- a/src/app/products/register/RegisterScreen.tsx
+++ b/src/app/products/register/RegisterScreen.tsx
@@ -13,6 +13,7 @@ import {
   getAuctionFieldContent,
   sanitizeNumericInput,
   updateAuctionDuration,
+  updateAuctionDurationSeconds,
 } from "@/services/auction/register/service";
 import type {
   AuctionFormValues,
@@ -612,6 +613,14 @@ export default function RegisterScreen({
   };
 
   const handleAuctionDurationChange = (value: string) => {
+    if (value.startsWith("seconds:")) {
+      const nextDurationSeconds = Number(value.replace("seconds:", ""));
+      setAuction((currentAuction) =>
+        updateAuctionDurationSeconds(currentAuction, nextDurationSeconds),
+      );
+      return;
+    }
+
     const nextDuration = Number(value);
     setAuction((currentAuction) =>
       updateAuctionDuration(currentAuction, nextDuration),

--- a/src/app/products/register/index.tsx
+++ b/src/app/products/register/index.tsx
@@ -10,9 +10,13 @@ import type {
   ProductImagePayload,
   SaleType,
 } from "@/services/auction/register/types";
-import { TEST_AUCTION_DURATION_DAYS } from "@/services/auction/register/service";
+import {
+  ONE_MINUTE_AUCTION_DURATION_SECONDS,
+  TEST_AUCTION_DURATION_DAYS,
+} from "@/services/auction/register/service";
 
 const AUCTION_DURATION_OPTIONS = [
+  { value: `seconds:${ONE_MINUTE_AUCTION_DURATION_SECONDS}`, label: "1분" },
   { value: TEST_AUCTION_DURATION_DAYS, label: "20초 테스트" },
   { value: 1, label: "1일" },
   { value: 3, label: "3일" },
@@ -406,7 +410,11 @@ export default function RegisterScreenView({
                       경매 기간
                     </span>
                     <select
-                      value={auction.durationDays}
+                      value={
+                        auction.durationSeconds != null
+                          ? `seconds:${auction.durationSeconds}`
+                          : auction.durationDays
+                      }
                       onChange={(event) => onAuctionDurationChange(event.target.value)}
                       className="w-full h-12 rounded-2xl border border-rose-100 bg-white px-4 text-sm outline-none"
                     >

--- a/src/services/auction/detail/types.ts
+++ b/src/services/auction/detail/types.ts
@@ -50,6 +50,10 @@ export interface CreateAuctionBidResponse {
   currentPrice: number;
   bidderId: number;
   serverTime: string;
+  messages?: {
+    reserveNotice: string;
+    refundNotice: string;
+  };
 }
 
 export interface AuctionBidHistoryItem {

--- a/src/services/auction/register/service.ts
+++ b/src/services/auction/register/service.ts
@@ -16,6 +16,7 @@ import type {
 } from "@/services/auction/register/types";
 
 export const TEST_AUCTION_DURATION_DAYS = 20 / 86400;
+export const ONE_MINUTE_AUCTION_DURATION_SECONDS = 60;
 
 // 화면 초기 렌더링용 기본 폼 상태를 만든다.
 // page.tsx는 이 값을 그대로 useState 초기값으로 사용하면 된다.
@@ -26,6 +27,7 @@ export function createDefaultAuctionForm(): AuctionFormValues {
     startPrice,
     bidUnit: calculateBidUnit(startPrice),
     durationDays: 3,
+    durationSeconds: null,
   };
 }
 
@@ -85,11 +87,33 @@ export function updateAuctionDuration(
   return {
     ...auction,
     durationDays: safeDuration,
+    durationSeconds: null,
+  };
+}
+
+export function updateAuctionDurationSeconds(
+  auction: AuctionFormValues,
+  durationSeconds: number,
+): AuctionFormValues {
+  const safeDuration = Number.isFinite(durationSeconds) ? durationSeconds : 60;
+
+  return {
+    ...auction,
+    durationDays: 0,
+    durationSeconds: safeDuration,
   };
 }
 
 // 경매 기간 표시용 문자열 생성.
 export function formatAuctionSchedule(auction: AuctionFormValues) {
+  if (auction.durationSeconds === ONE_MINUTE_AUCTION_DURATION_SECONDS) {
+    return "1분 동안 진행";
+  }
+
+  if (auction.durationSeconds != null) {
+    return `${auction.durationSeconds}초 동안 진행`;
+  }
+
   if (auction.durationDays === TEST_AUCTION_DURATION_DAYS) {
     return "20초 동안 진행";
   }
@@ -126,6 +150,7 @@ export function createDraft(
       bidUnit: calculateBidUnit(startPrice),
       durationDays:
         draft.auction?.durationDays ?? createDefaultAuctionForm().durationDays,
+      durationSeconds: draft.auction?.durationSeconds ?? null,
     },
   };
 }
@@ -177,7 +202,11 @@ export function buildCreateAuctionRequest(
     minimumBidAmount:
       draft.saleType === "auction" ? Number(draft.auction.bidUnit || 0) : null,
     auctionDurationDays:
-      draft.saleType === "auction" ? draft.auction.durationDays : null,
+      draft.saleType === "auction" && draft.auction.durationSeconds == null
+        ? draft.auction.durationDays
+        : null,
+    auctionDurationSeconds:
+      draft.saleType === "auction" ? draft.auction.durationSeconds : null,
     allowOffer: draft.allowOffer,
     images: normalizeImagePayload(draft.images),
     location: draft.location,

--- a/src/services/auction/register/types.ts
+++ b/src/services/auction/register/types.ts
@@ -41,6 +41,7 @@ export interface AuctionFormValues {
   startPrice: string;
   bidUnit: string;
   durationDays: number;
+  durationSeconds: number | null;
 }
 
 // 등록 화면 전체에서 관리하는 프론트 폼 모델.
@@ -72,6 +73,7 @@ export interface AuctionCreateRequest {
   bidUnit: number | null;
   minimumBidAmount: number | null;
   auctionDurationDays: number | null;
+  auctionDurationSeconds: number | null;
   allowOffer: boolean;
   images: ProductImagePayload[];
   location: string;

--- a/src/services/wallet/service.ts
+++ b/src/services/wallet/service.ts
@@ -83,6 +83,10 @@ function getWalletLedgerTypeLabel(type: WalletLedgerType) {
       return "환불";
     case "WITHDRAWAL":
       return "출금";
+    case "AUCTION_RESERVE":
+      return "경매 예치";
+    case "AUCTION_REFUND":
+      return "경매 환불";
     default:
       return "내역";
   }

--- a/src/services/wallet/types.ts
+++ b/src/services/wallet/types.ts
@@ -1,4 +1,9 @@
-export type WalletLedgerType = "TEMP_CHARGE" | "REFUND" | "WITHDRAWAL";
+export type WalletLedgerType =
+  | "TEMP_CHARGE"
+  | "REFUND"
+  | "WITHDRAWAL"
+  | "AUCTION_RESERVE"
+  | "AUCTION_REFUND";
 
 export interface WalletResponse {
   walletId: number;


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
- 경매 보증금제도 프로세스
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
#### 5만원 충전 후 20만원 경매에 입찰 시도
<img width="715" height="218" alt="스크린샷 2026-05-08 오후 10 09 53" src="https://github.com/user-attachments/assets/a4bf3c8f-81f7-4141-97ce-a768829e18ee" />

#### 입찰 안됨
<img width="1403" height="575" alt="스크린샷 2026-05-08 오후 10 10 23" src="https://github.com/user-attachments/assets/bb163eff-77c1-4699-b846-71c76bb312de" />

#### 20만원 충전 -> 25만원 되었음
<img width="707" height="256" alt="스크린샷 2026-05-08 오후 10 10 45" src="https://github.com/user-attachments/assets/47f5a78d-9671-407e-9b19-04755ccae877" />

#### 입찰성공
<img width="1399" height="540" alt="스크린샷 2026-05-08 오후 10 11 02" src="https://github.com/user-attachments/assets/26be99dd-9477-43fe-95a9-7484a5552cb0" />
<img width="1420" height="711" alt="스크린샷 2026-05-08 오후 10 11 27" src="https://github.com/user-attachments/assets/cabc41ef-da47-41f4-99e2-6885ff03079c" />

#### 다른사람이 입찰하여 추월함
<img width="1416" height="658" alt="스크린샷 2026-05-08 오후 10 13 41" src="https://github.com/user-attachments/assets/af9ffb7a-d46b-4354-8e67-2e9dfca24e95" />

#### 추월되어서 환불됨
<img width="721" height="479" alt="스크린샷 2026-05-08 오후 10 14 07" src="https://github.com/user-attachments/assets/bdcbd0ec-bcb2-4253-a094-d53d10c36256" />



채팅방, 발송/수령 확인, 정산 UX는 이번 PR 범위에서 제외

이번 PR은 백엔드 보증금 예치/환불 API 흐름에 맞춘 입찰 UX까지만 반영
---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #65 
