### PR TITLE
[feat] 경매 찜기능 추가

### DIFF
--- a/src/app/(main)/home/index.tsx
+++ b/src/app/(main)/home/index.tsx
@@ -46,6 +46,7 @@ import { fetchPopularRegularProducts } from "@/services/product/popular/service"
 import { fetchHotRegularProducts } from "@/services/product/hotList/service";
 import type { PopularProductItemViewModel } from "@/services/product/popular/types";
 import { useEventStream } from "@/services/events/EventStreamProvider";
+import { fetchRegularWishlist } from "@/services/wishlist/service";
 
 type PopularHomeItem = PopularProductItemViewModel | AuctionListItemViewModel;
 
@@ -95,6 +96,9 @@ export default function HomeScreen({
   const [hotProducts, setHotProducts] = useState<any[]>([]);
   const [isHotLoading, setIsHotLoading] = useState(false);
   const [hotErrorMessage, setHotErrorMessage] = useState("");
+  const [likedProductIds, setLikedProductIds] = useState<Set<number>>(
+    () => new Set(),
+  );
   const banners =
     mode === "regular"
       ? [
@@ -230,6 +234,65 @@ export default function HomeScreen({
       ignore = true;
     };
   }, [mode]);
+
+  useEffect(() => {
+    if (mode !== "regular") {
+      setLikedProductIds(new Set());
+      return;
+    }
+
+    let ignore = false;
+
+    fetchRegularWishlist()
+      .then((items) => {
+        if (!ignore) {
+          setLikedProductIds(new Set(items.map((item) => item.productId)));
+        }
+      })
+      .catch(() => {
+        if (!ignore) {
+          setLikedProductIds(new Set());
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [mode]);
+
+  const handleWishlistChange = (
+    productId: number,
+    liked: boolean,
+    favoriteCount: number,
+  ) => {
+    setLikedProductIds((current) => {
+      const next = new Set(current);
+
+      if (liked) {
+        next.add(productId);
+      } else {
+        next.delete(productId);
+      }
+
+      return next;
+    });
+
+    const applyFavoriteCount = <T extends { productId: number; favoriteCount?: number }>(
+      item: T,
+    ): T =>
+      item.productId === productId ? { ...item, favoriteCount } : item;
+
+    setHotProducts((currentProducts) =>
+      currentProducts.map(applyFavoriteCount),
+    );
+    setPopularProducts((currentProducts) =>
+      currentProducts.map((item) =>
+        !isAuctionHomeItem(item) && item.productId === productId
+          ? { ...item, favoriteCount }
+          : item,
+      ),
+    );
+  };
 
   return (
     <div className="flex flex-col h-full bg-white">
@@ -582,6 +645,10 @@ export default function HomeScreen({
                     mode={mode}
                     themeColor={themeColor}
                     onProductClick={onProductClick}
+                    initialLiked={
+                      mode === "regular" && likedProductIds.has(p.productId)
+                    }
+                    onWishlistChange={handleWishlistChange}
                   />
                 ))}
               </div>

--- a/src/app/(main)/wishlist/index.tsx
+++ b/src/app/(main)/wishlist/index.tsx
@@ -1,23 +1,30 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { ChevronLeft, Heart, Image as ImageIcon, MessageCircle } from "lucide-react";
+import {
+  ChevronLeft,
+  Heart,
+  Image as ImageIcon,
+  MessageCircle,
+} from "lucide-react";
 import { motion } from "motion/react";
 
 import { getErrorMessage } from "@/services/apiError";
 import {
-  fetchRegularWishlist,
-  removeRegularWishlist,
+  fetchMyWishlist,
+  removeWishlist,
 } from "@/services/wishlist/service";
 import type { WishlistItemViewModel } from "@/services/wishlist/types";
 
 export default function WishlistScreen({
   onBack,
   onProductClick,
+  onAuctionClick,
   themeColor,
 }: {
   onBack: () => void;
   onProductClick: (id: number) => void;
+  onAuctionClick?: (id: number) => void;
   themeColor: string;
   key?: string;
 }) {
@@ -36,7 +43,7 @@ export default function WishlistScreen({
     setIsLoading(true);
     setErrorMessage("");
 
-    fetchRegularWishlist()
+    fetchMyWishlist()
       .then((items) => {
         if (!ignore) {
           setWishlistItems(items);
@@ -61,6 +68,15 @@ export default function WishlistScreen({
     };
   }, []);
 
+  const handleItemClick = (item: WishlistItemViewModel) => {
+    if (item.itemType === "AUCTION" && item.auctionId != null) {
+      onAuctionClick?.(item.auctionId);
+      return;
+    }
+
+    onProductClick(item.productId);
+  };
+
   const handleUnlike = async (productId: number) => {
     if (removingProductId !== null) {
       return;
@@ -70,7 +86,7 @@ export default function WishlistScreen({
     setErrorMessage("");
 
     try {
-      await removeRegularWishlist(productId);
+      await removeWishlist(productId);
       setWishlistItems((currentItems) =>
         currentItems.filter((item) => item.productId !== productId),
       );
@@ -114,14 +130,14 @@ export default function WishlistScreen({
         ) : wishlistItems.length > 0 ? (
           wishlistItems.map((item) => (
             <div
-              key={item.productId}
-              onClick={() => onProductClick(item.productId)}
+              key={`${item.itemType}-${item.productId}`}
+              onClick={() => handleItemClick(item)}
               role="button"
               tabIndex={0}
               onKeyDown={(event) => {
                 if (event.key === "Enter" || event.key === " ") {
                   event.preventDefault();
-                  onProductClick(item.productId);
+                  handleItemClick(item);
                 }
               }}
               className="flex items-center space-x-4 p-3 bg-white border border-gray-50 rounded-2xl hover:shadow-md transition-all cursor-pointer group"
@@ -140,7 +156,7 @@ export default function WishlistScreen({
                 )}
               </div>
               <div className="flex-1 min-w-0 space-y-1.5">
-                <div className="flex justify-between items-start">
+                <div className="flex justify-between items-start gap-2">
                   <h4 className="font-bold text-sm truncate text-gray-800">
                     {item.name}
                   </h4>
@@ -158,7 +174,7 @@ export default function WishlistScreen({
                   </button>
                 </div>
                 <p className="text-xs text-gray-500 font-medium">
-                  판매가{" "}
+                  {item.itemType === "AUCTION" ? "현재가" : "판매가"}{" "}
                   <span className="text-sm font-bold text-black ml-1">
                     {item.priceLabel}
                   </span>
@@ -173,7 +189,7 @@ export default function WishlistScreen({
                   </div>
                   <div className="flex items-center space-x-1">
                     <MessageCircle size={10} />
-                    <span>일반 상품</span>
+                    <span>{item.metaLabel}</span>
                   </div>
                 </div>
               </div>
@@ -182,7 +198,7 @@ export default function WishlistScreen({
         ) : (
           <div className="flex flex-col items-center justify-center text-gray-400 space-y-4 h-[400px]">
             <Heart size={48} className="opacity-20" />
-            <p>찜한 일반 상품이 없습니다.</p>
+            <p>찜한 상품이 없습니다.</p>
           </div>
         )}
       </div>

--- a/src/app/(main)/wishlist/page.tsx
+++ b/src/app/(main)/wishlist/page.tsx
@@ -11,6 +11,7 @@ export default function WishlistPage() {
     <WishlistScreen
       onBack={() => router.back()}
       onProductClick={(id) => router.push(`/products/${id}`)}
+      onAuctionClick={(id) => router.push(`/auctions/${id}`)}
       themeColor="#98E446"
     />
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -997,6 +997,7 @@ export default function App() {
                 key="wishlist"
                 onBack={() => navigateTo("main")}
                 onProductClick={navigateToProduct}
+                onAuctionClick={(id) => router.push(`/auctions/${id}`)}
                 themeColor={themeColor}
               />
             )}

--- a/src/app/products/[productId]/index.tsx
+++ b/src/app/products/[productId]/index.tsx
@@ -322,8 +322,6 @@ export default function ProductDetailScreen({
         }
 
         setAuctionDetail(data);
-        setIsLiked(data.liked);
-        setFavoriteCount(data.favoriteCount);
         setAuctionClockOffsetMs(
           new Date(data.serverTime).getTime() - Date.now(),
         );

--- a/src/app/products/[productId]/index.tsx
+++ b/src/app/products/[productId]/index.tsx
@@ -30,9 +30,9 @@ import type { AuctionEventStreamEvent } from "@/services/events/types";
 import * as productDetailService from "@/services/product/productDetail/service";
 import type { ProductDetailResponse } from "@/services/product/productDetail/types";
 import {
-  addRegularWishlist,
+  addWishlist,
   fetchRegularWishlist,
-  removeRegularWishlist,
+  removeWishlist,
 } from "@/services/wishlist/service";
 
 type AuctionStatus =
@@ -256,8 +256,14 @@ export default function ProductDetailScreen({
   }, [resolvedFavoriteCount]);
 
   useEffect(() => {
+    if (!isRegular && auctionDetail) {
+      setIsLiked(auctionDetail.liked);
+      setFavoriteCount(auctionDetail.favoriteCount);
+    }
+  }, [auctionDetail, isRegular]);
+
+  useEffect(() => {
     if (!isRegular || productId == null) {
-      setIsLiked(false);
       return;
     }
 
@@ -316,6 +322,8 @@ export default function ProductDetailScreen({
         }
 
         setAuctionDetail(data);
+        setIsLiked(data.liked);
+        setFavoriteCount(data.favoriteCount);
         setAuctionClockOffsetMs(
           new Date(data.serverTime).getTime() - Date.now(),
         );
@@ -477,11 +485,13 @@ export default function ProductDetailScreen({
   };
 
   const handleWishlistClick = async () => {
-    if (!isRegular || productId == null || isWishlistSubmitting) {
+    const wishlistProductId = isRegular ? productId : auctionDetail?.productId;
+
+    if (wishlistProductId == null || isWishlistSubmitting) {
       return;
     }
 
-    if (!productData?.canFavorite && !isLiked) {
+    if (isRegular && !productData?.canFavorite && !isLiked) {
       showToast("찜할 수 없는 상품입니다.");
       return;
     }
@@ -490,8 +500,8 @@ export default function ProductDetailScreen({
 
     try {
       const result = isLiked
-        ? await removeRegularWishlist(productId)
-        : await addRegularWishlist(productId);
+        ? await removeWishlist(wishlistProductId)
+        : await addWishlist(wishlistProductId);
 
       setIsLiked(result.liked);
       setFavoriteCount(result.favoriteCount);
@@ -549,20 +559,18 @@ export default function ProductDetailScreen({
           <ChevronLeft size={24} />
         </button>
         <div className="flex space-x-2">
-          {isRegular && (
-            <button
-              onClick={handleWishlistClick}
-              disabled={isWishlistSubmitting}
-              className="w-10 h-10 bg-white/80 backdrop-blur rounded-full flex items-center justify-center shadow-sm disabled:opacity-60"
-              aria-label={isLiked ? "찜 취소" : "찜 추가"}
-            >
-              <Heart
-                size={20}
-                fill={isLiked ? "#FF3B30" : "none"}
-                color={isLiked ? "#FF3B30" : "currentColor"}
-              />
-            </button>
-          )}
+          <button
+            onClick={handleWishlistClick}
+            disabled={isWishlistSubmitting}
+            className="w-10 h-10 bg-white/80 backdrop-blur rounded-full flex items-center justify-center shadow-sm disabled:opacity-60"
+            aria-label={isLiked ? "찜 취소" : "찜 추가"}
+          >
+            <Heart
+              size={20}
+              fill={isLiked ? "#FF3B30" : "none"}
+              color={isLiked ? "#FF3B30" : "currentColor"}
+            />
+          </button>
           <div className="relative">
             <button
               onClick={() => setShowMoreMenu(!showMoreMenu)}

--- a/src/app/products/index.tsx
+++ b/src/app/products/index.tsx
@@ -12,6 +12,7 @@ import {
 import { getErrorMessage } from "@/services/apiError";
 import { fetchHotRegularProducts } from "@/services/product/hotList/service";
 import { fetchPopularRegularProducts } from "@/services/product/popular/service";
+import { fetchRegularWishlist } from "@/services/wishlist/service";
 
 type ProductListType = "all" | "closing_soon" | "recent";
 
@@ -47,6 +48,9 @@ export default function ProductListScreen({
   const [products, setProducts] = useState<any[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+  const [likedProductIds, setLikedProductIds] = useState<Set<number>>(
+    () => new Set(),
+  );
 
   useEffect(() => {
     let ignore = false;
@@ -116,6 +120,55 @@ export default function ProductListScreen({
     };
   }, [categoryName, listType, mode]);
 
+  useEffect(() => {
+    if (mode !== "regular") {
+      setLikedProductIds(new Set());
+      return;
+    }
+
+    let ignore = false;
+
+    fetchRegularWishlist()
+      .then((items) => {
+        if (!ignore) {
+          setLikedProductIds(new Set(items.map((item) => item.productId)));
+        }
+      })
+      .catch(() => {
+        if (!ignore) {
+          setLikedProductIds(new Set());
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [mode]);
+
+  const handleWishlistChange = (
+    productId: number,
+    liked: boolean,
+    favoriteCount: number,
+  ) => {
+    setLikedProductIds((current) => {
+      const next = new Set(current);
+
+      if (liked) {
+        next.add(productId);
+      } else {
+        next.delete(productId);
+      }
+
+      return next;
+    });
+
+    setProducts((currentProducts) =>
+      currentProducts.map((item) =>
+        item.productId === productId ? { ...item, favoriteCount } : item,
+      ),
+    );
+  };
+
   return (
     <motion.div
       initial={{ opacity: 0, x: 20 }}
@@ -160,6 +213,10 @@ export default function ProductListScreen({
               mode={mode}
               themeColor={themeColor}
               onProductClick={onProductClick}
+              initialLiked={
+                mode === "regular" && likedProductIds.has(product.productId)
+              }
+              onWishlistChange={handleWishlistChange}
             />
           ))
         ) : (

--- a/src/components/product/ProductListItem.tsx
+++ b/src/components/product/ProductListItem.tsx
@@ -23,6 +23,7 @@ export default function ProductListItem({
   onProductClick,
   initialLiked = false,
   onUnlike,
+  onWishlistChange,
 }: {
   i?: number;
   product?: {
@@ -52,6 +53,7 @@ export default function ProductListItem({
   onProductClick: (id: number) => void;
   initialLiked?: boolean;
   onUnlike?: () => void;
+  onWishlistChange?: (productId: number, liked: boolean, favoriteCount: number) => void;
   key?: string | number;
 }) {
   const useData = product !== undefined && product !== null;
@@ -79,6 +81,10 @@ export default function ProductListItem({
   const [displayFavoriteCount, setDisplayFavoriteCount] = useState(
     product?.favoriteCount ?? 132,
   );
+
+  useEffect(() => {
+    setIsLiked(initialLiked);
+  }, [initialLiked]);
 
   useEffect(() => {
     if (useData) {
@@ -201,6 +207,9 @@ export default function ProductListItem({
 
       setIsLiked(result.liked);
       setDisplayFavoriteCount(result.favoriteCount);
+      onWishlistChange?.(productId, result.liked, result.favoriteCount);
+    } catch {
+      // Keep the card stable when the backend rejects the toggle.
     } finally {
       setIsWishlistSubmitting(false);
     }
@@ -231,7 +240,8 @@ export default function ProductListItem({
             <h4 className="font-bold text-sm truncate text-gray-800">{name}</h4>
             <button
               onClick={handleLikeClick}
-              className="p-1"
+              disabled={isWishlistSubmitting}
+              className="p-1 disabled:opacity-50"
               aria-label="찜하기"
             >
               <Heart

--- a/src/services/auction/detail/types.ts
+++ b/src/services/auction/detail/types.ts
@@ -39,6 +39,8 @@ export interface AuctionDetailResponse {
   endsAt: string;
   serverTime: string;
   status: AuctionDetailStatus;
+  liked: boolean;
+  favoriteCount: number;
 }
 
 export interface CreateAuctionBidRequest {

--- a/src/services/wishlist/api.ts
+++ b/src/services/wishlist/api.ts
@@ -4,6 +4,7 @@ import {
   handleUnauthorizedAccess,
 } from "@/services/auth/service";
 import type {
+  AuctionWishlistListResponse,
   WishlistListResponse,
   WishlistToggleResponse,
 } from "@/services/wishlist/types";
@@ -42,6 +43,30 @@ export async function getMyWishlist(
     await throwWishlistApiError(
       response,
       "찜 목록을 불러오지 못했습니다.",
+    );
+  }
+
+  return response.json();
+}
+
+export async function getMyAuctionWishlist(
+  page = 0,
+  size = 20,
+): Promise<AuctionWishlistListResponse> {
+  const params = new URLSearchParams({
+    page: String(page),
+    size: String(size),
+  });
+  const response = await fetch(`${API_BASE}/mypage/wishlist/auctions?${params}`, {
+    method: "GET",
+    headers: getAuthorizationHeaders(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    await throwWishlistApiError(
+      response,
+      "경매 찜 목록을 불러오지 못했습니다.",
     );
   }
 

--- a/src/services/wishlist/service.ts
+++ b/src/services/wishlist/service.ts
@@ -1,5 +1,6 @@
 import * as wishlistApi from "@/services/wishlist/api";
 import type {
+  AuctionWishlistItemResponse,
   WishlistItemResponse,
   WishlistItemViewModel,
 } from "@/services/wishlist/types";
@@ -15,6 +16,8 @@ function toWishlistItemViewModel(
   item: WishlistItemResponse,
 ): WishlistItemViewModel {
   return {
+    itemType: "REGULAR",
+    auctionId: null,
     productId: item.productId,
     name: item.name,
     status: item.status,
@@ -24,12 +27,38 @@ function toWishlistItemViewModel(
     location: item.location ?? DEFAULT_LOCATION_LABEL,
     favoriteCount: item.favoriteCount,
     likedAt: item.likedAt,
+    metaLabel: "일반 상품",
   };
 }
 
-export async function fetchRegularWishlist(): Promise<
-  WishlistItemViewModel[]
-> {
+function toAuctionWishlistItemViewModel(
+  item: AuctionWishlistItemResponse,
+): WishlistItemViewModel {
+  return {
+    itemType: "AUCTION",
+    auctionId: item.auctionId,
+    productId: item.productId,
+    name: item.name,
+    status: item.auctionStatus,
+    thumbnailUrl: item.thumbnailUrl,
+    priceLabel: formatPrice(item.currentPrice),
+    categoryName: item.categoryName ?? DEFAULT_CATEGORY_LABEL,
+    location: item.location ?? DEFAULT_LOCATION_LABEL,
+    favoriteCount: item.favoriteCount,
+    likedAt: item.likedAt,
+    metaLabel: `경매 상품 · 입찰 ${item.bidCount}명`,
+  };
+}
+
+function sortByLikedAtDesc(
+  items: WishlistItemViewModel[],
+): WishlistItemViewModel[] {
+  return [...items].sort(
+    (a, b) => new Date(b.likedAt).getTime() - new Date(a.likedAt).getTime(),
+  );
+}
+
+export async function fetchRegularWishlist(): Promise<WishlistItemViewModel[]> {
   const response = await wishlistApi.getMyWishlist();
 
   return response.content
@@ -37,10 +66,33 @@ export async function fetchRegularWishlist(): Promise<
     .map(toWishlistItemViewModel);
 }
 
-export async function addRegularWishlist(productId: number) {
+export async function fetchAuctionWishlist(): Promise<WishlistItemViewModel[]> {
+  const response = await wishlistApi.getMyAuctionWishlist();
+
+  return response.content.map(toAuctionWishlistItemViewModel);
+}
+
+export async function fetchMyWishlist(): Promise<WishlistItemViewModel[]> {
+  const [regularItems, auctionItems] = await Promise.all([
+    fetchRegularWishlist(),
+    fetchAuctionWishlist(),
+  ]);
+
+  return sortByLikedAtDesc([...regularItems, ...auctionItems]);
+}
+
+export async function addWishlist(productId: number) {
   return wishlistApi.addWishlist(productId);
 }
 
-export async function removeRegularWishlist(productId: number) {
+export async function removeWishlist(productId: number) {
   return wishlistApi.removeWishlist(productId);
+}
+
+export async function addRegularWishlist(productId: number) {
+  return addWishlist(productId);
+}
+
+export async function removeRegularWishlist(productId: number) {
+  return removeWishlist(productId);
 }

--- a/src/services/wishlist/types.ts
+++ b/src/services/wishlist/types.ts
@@ -21,6 +21,29 @@ export interface WishlistListResponse {
   hasNext: boolean;
 }
 
+export interface AuctionWishlistItemResponse {
+  auctionId: number;
+  productId: number;
+  name: string;
+  thumbnailUrl: string | null;
+  categoryName: string | null;
+  location: string | null;
+  favoriteCount: number;
+  currentPrice: number;
+  bidCount: number;
+  auctionStatus: string;
+  endedAt: string;
+  likedAt: string;
+}
+
+export interface AuctionWishlistListResponse {
+  content: AuctionWishlistItemResponse[];
+  page: number;
+  size: number;
+  totalElements: number;
+  hasNext: boolean;
+}
+
 export interface WishlistToggleResponse {
   productId: number;
   liked: boolean;
@@ -28,6 +51,8 @@ export interface WishlistToggleResponse {
 }
 
 export interface WishlistItemViewModel {
+  itemType: WishlistSaleType;
+  auctionId: number | null;
   productId: number;
   name: string;
   status: string;
@@ -37,4 +62,5 @@ export interface WishlistItemViewModel {
   location: string;
   favoriteCount: number;
   likedAt: string;
+  metaLabel: string;
 }


### PR DESCRIPTION
### 🚀 Summary

경매 상품 찜 기능 추가 및 일반/경매 찜목록 통합
경매 상세 페이지에서 일반 상품 상세 페이지와 동일하게 하트 토글로 찜 추가/취소 가능하도록 구현
마이페이지 찜목록에서 일반 상품과 경매 상품을 함께 조회하고, 각 상품 상세 페이지로 이동 가능하도록 정리
홈/상품 목록의 일반 상품 하트 상태도 찜목록과 연동되도록 수정

---

### ✨ Description

찜 기능 처리 흐름
상품 상세/목록에서 사용자가 하트 버튼 클릭
→ service.ts가 찜 추가/취소 요청 위임
→ api.ts가 /api/v1/wishlist/{productId} 호출
→ 응답의 liked, favoriteCount를 화면 상태에 반영
→ 찜목록에서는 일반 상품 목록 + 경매 상품 찜 목록을 함께 불러와 표시

주요 코드

products/[productId]/index.tsx
상품 상세 화면 관리
일반 상품/경매 상품 하트 토글 처리
경매 상세 조회 응답의 productId, liked, favoriteCount를 기준으로 찜 상태 반영
경매 상품도 찜 추가/취소 가능하도록 수정

wishlist/index.tsx
마이페이지 찜목록 화면 관리
일반 상품과 경매 상품 찜 목록 통합 표시
일반 상품 클릭 시 /products/{productId} 이동
경매 상품 클릭 시 /auctions/{auctionId} 이동
찜 취소 시 목록에서 제거

home/index.tsx
홈 상품 카드의 하트 상태 연동
내 일반 상품 찜 목록을 조회해 이미 찜한 상품은 빨간 하트로 표시
홈에서 하트 클릭 시 찜 수 즉시 증가/감소 반영

products/index.tsx
일반 상품 전체목록/핫한 상품 목록 하트 상태 연동
찜 목록 기준으로 초기 하트 상태 표시
목록에서 찜 추가/취소 시 카드의 찜 수 즉시 반영

ProductListItem.tsx
상품 카드 하트 토글 공통 처리
찜 API 실패 시 화면이 깨지지 않도록 예외 처리
부모 화면으로 liked, favoriteCount 변경값 전달

types.ts
AuctionDetailResponse - liked, favoriteCount 추가
AuctionWishlistItemResponse - 경매 찜 목록 응답 타입 추가
AuctionWishlistListResponse - 경매 찜 목록 페이지 응답 타입 추가
WishlistItemViewModel - 일반/경매 통합 표시용 모델로 확장

api.ts
getMyAuctionWishlist - 경매 찜 목록 조회
addWishlist - 찜 추가
removeWishlist - 찜 취소

service.ts
fetchRegularWishlist - 일반 상품 찜 목록 조회
fetchAuctionWishlist - 경매 상품 찜 목록 조회
fetchMyWishlist - 일반/경매 찜 목록 통합 조회
addWishlist/removeWishlist - 일반/경매 공통 찜 토글 요청

사진
경매 상세페이지 하트 토글 추가
<img width="1194" height="623" alt="화면 캡처 2026-05-16 194051" src="https://github.com/user-attachments/assets/f07c5803-5db2-4307-8781-65d6eee55567" />


찜 목록
<img width="546" height="309" alt="찜" src="https://github.com/user-attachments/assets/f8e0cb24-9c1a-4f95-92f0-72c7dc8a9119" />


---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #85 