### PR TITLE
[feat] 재경매 알림 화면 구현

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -26,6 +26,14 @@ function resolveNotificationTargetUrl(notification) {
   const fcmMessage = data.FCM_MSG || {};
   const fcmData = fcmMessage.data || {};
   const fcmOptions = fcmMessage.fcmOptions || fcmMessage.webpush?.fcmOptions || {};
+  const pushType = data.type || fcmData.type;
+  const isNoBidAuctionNotification = pushType === "AUCTION_NO_BID";
+
+  const appendReauctionPrompt = (targetUrl) => {
+    const url = new URL(targetUrl, self.location.origin);
+    url.searchParams.set("reauctionPrompt", "1");
+    return `${url.pathname}${url.search}${url.hash}`;
+  };
 
   const targetUrl =
     data.targetUrl ||
@@ -35,7 +43,9 @@ function resolveNotificationTargetUrl(notification) {
     fcmData.click_action;
 
   if (targetUrl) {
-    return targetUrl;
+    return isNoBidAuctionNotification
+      ? appendReauctionPrompt(targetUrl)
+      : targetUrl;
   }
 
   const roomId = data.roomId || fcmData.roomId;
@@ -50,7 +60,10 @@ function resolveNotificationTargetUrl(notification) {
 
   const auctionId = data.auctionId || fcmData.auctionId;
   if (auctionId) {
-    return `/auctions/${auctionId}`;
+    const auctionTargetUrl = `/auctions/${auctionId}`;
+    return isNoBidAuctionNotification
+      ? appendReauctionPrompt(auctionTargetUrl)
+      : auctionTargetUrl;
   }
 
   return "/";

--- a/src/app/(main)/notifications/index.tsx
+++ b/src/app/(main)/notifications/index.tsx
@@ -112,6 +112,24 @@ function toUnreadTypeCountMap(
   );
 }
 
+function isNoBidAuctionNotification(notification: NotificationResponse) {
+  return (
+    notification.type === "AUCTION" &&
+    (notification.title.includes("유찰") ||
+      notification.content.includes("재등록"))
+  );
+}
+
+function appendReauctionPrompt(targetUrl: string) {
+  if (typeof window === "undefined") {
+    return targetUrl;
+  }
+
+  const url = new URL(targetUrl, window.location.origin);
+  url.searchParams.set("reauctionPrompt", "1");
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
 export default function NotificationScreen({
   onBack,
   onChatClick,
@@ -268,10 +286,13 @@ export default function NotificationScreen({
 
     const targetUrl = notification.targetUrl?.trim();
     if (targetUrl) {
+      const resolvedTargetUrl = isNoBidAuctionNotification(notification)
+        ? appendReauctionPrompt(targetUrl)
+        : targetUrl;
       if (onTargetUrl) {
-        onTargetUrl(targetUrl);
+        onTargetUrl(resolvedTargetUrl);
       } else {
-        window.location.assign(targetUrl);
+        window.location.assign(resolvedTargetUrl);
       }
       return;
     }

--- a/src/app/auctions/[auctionId]/page.tsx
+++ b/src/app/auctions/[auctionId]/page.tsx
@@ -144,6 +144,12 @@ export default function AuctionDetailPage() {
                   >
                     게시글 수정하기
                   </button>
+                  <button
+                    onClick={() => {}}
+                    className="h-14 rounded-2xl bg-gray-100 text-sm font-black text-gray-500 transition-colors hover:bg-gray-200"
+                  >
+                    재등록 안 하기
+                  </button>
                 </div>
               </div>
             </div>

--- a/src/app/auctions/[auctionId]/page.tsx
+++ b/src/app/auctions/[auctionId]/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { ChevronLeft } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 
 import AuctionDetailScreen from "./index";
 import { findExistingChatRoomByProductId } from "@/services/chats/service";
@@ -15,8 +16,18 @@ type BidCompleteData = {
 export default function AuctionDetailPage() {
   const params = useParams<{ auctionId: string }>();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const auctionId = Number(params.auctionId) || 1;
   const [isOpeningChat, setIsOpeningChat] = useState(false);
+  const [showReauctionPrompt, setShowReauctionPrompt] = useState(
+    () => searchParams.get("reauctionPrompt") === "1",
+  );
+
+  useEffect(() => {
+    if (searchParams.get("reauctionPrompt") === "1") {
+      setShowReauctionPrompt(true);
+    }
+  }, [searchParams]);
 
   const handleChatClick = async () => {
     if (isOpeningChat) {
@@ -60,6 +71,76 @@ export default function AuctionDetailPage() {
         mode="auction"
         showToast={() => {}}
       />
+      {showReauctionPrompt && (
+        <div className="fixed inset-0 z-[100] flex justify-center bg-white text-[#17181d]">
+          <div className="flex h-full w-full max-w-[430px] flex-col px-7 pb-8 pt-5">
+            <div className="flex h-14 items-center justify-between">
+              <button
+                onClick={() => {
+                  router.back();
+                }}
+                className="-ml-2 flex h-11 w-11 items-center justify-center rounded-full text-[#17181d]"
+                aria-label="뒤로가기"
+              >
+                <ChevronLeft size={34} strokeWidth={2.4} />
+              </button>
+              <div className="h-11 w-11" />
+            </div>
+
+            <div className="mt-7 space-y-6">
+              <div className="space-y-3">
+                <div className="space-y-2">
+                  <h2 className="whitespace-nowrap text-[clamp(22px,6vw,28px)] font-black leading-tight tracking-[-0.02em] text-[#17181d]">
+                    유찰된 경매를 다시 올려볼까요?
+                  </h2>
+                  <p className="text-base font-bold leading-relaxed text-gray-500">
+                    지금 선택하면 게시글을 수정하거나 그대로 다시 준비할 수 있어요.
+                  </p>
+                </div>
+              </div>
+
+              <button
+                type="button"
+                onClick={() => {}}
+                className="w-full rounded-2xl bg-gray-100 p-4 text-left transition-colors hover:bg-gray-200"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="flex h-20 w-20 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-white text-xs font-bold text-gray-500">
+                    유찰
+                  </div>
+                  <div className="min-w-0">
+                    <p className="truncate text-lg font-bold text-[#17181d]">
+                      유찰된 경매 #{auctionId}
+                    </p>
+                    <p className="mt-1 text-xl font-black text-[#17181d]">
+                      재경매 대기
+                    </p>
+                  </div>
+                </div>
+              </button>
+
+            </div>
+
+            <div className="mt-3 space-y-3">
+              <div className="grid grid-cols-1 gap-3">
+                <button
+                  onClick={() => {}}
+                  className="h-14 rounded-2xl bg-gray-100 text-sm font-black text-[#17181d] transition-colors hover:bg-gray-200"
+                >
+                  그대로 올리기
+                </button>
+                <button
+                  onClick={() => {}}
+                  className="h-14 rounded-2xl bg-[#F64257] text-sm font-black text-white transition-opacity hover:opacity-90"
+                >
+                  게시글 수정하기
+                </button>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      )}
     </EventStreamProvider>
   );
 }

--- a/src/services/notifications/ForegroundNotificationListener.tsx
+++ b/src/services/notifications/ForegroundNotificationListener.tsx
@@ -10,14 +10,34 @@ import { requestFcmToken } from "./firebase";
 const FCM_TOKEN_STORAGE_KEY = "dealit:fcm-token";
 const AUTH_TOKEN_CHANGED_EVENT = "dealit:auth-token-changed";
 
+function appendReauctionPrompt(targetUrl: string) {
+  const url = new URL(targetUrl, window.location.origin);
+  url.searchParams.set("reauctionPrompt", "1");
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
 function resolvePayloadTargetUrl(payload: { data?: Record<string, string>; fcmOptions?: { link?: string } }) {
   const data = payload.data || {};
+  const isNoBidAuctionNotification = data.type === "AUCTION_NO_BID";
 
-  if (data.targetUrl) return data.targetUrl;
-  if (payload.fcmOptions?.link) return payload.fcmOptions.link;
+  if (data.targetUrl) {
+    return isNoBidAuctionNotification
+      ? appendReauctionPrompt(data.targetUrl)
+      : data.targetUrl;
+  }
+  if (payload.fcmOptions?.link) {
+    return isNoBidAuctionNotification
+      ? appendReauctionPrompt(payload.fcmOptions.link)
+      : payload.fcmOptions.link;
+  }
   if (data.roomId) return `/chats/${data.roomId}`;
   if (data.productId) return `/products/${data.productId}`;
-  if (data.auctionId) return `/auctions/${data.auctionId}`;
+  if (data.auctionId) {
+    const targetUrl = `/auctions/${data.auctionId}`;
+    return isNoBidAuctionNotification
+      ? appendReauctionPrompt(targetUrl)
+      : targetUrl;
+  }
 
   return "/";
 }


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
유찰 알림 클릭 시 재경매 선택 화면으로 이동하도록 프론트 UI를 추가했습니다.
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
  - 유찰 알림 클릭 이동 처리
      - FCM 푸쉬 알림, 알림센터 알림 클릭 시 동일하게 재경매 선택 화면으로 이동
      
  - 재경매 선택 UI 추가
      - 유찰 경매 카드(누르면 유찰 게시물로 이동)
      - 그대로 올리기
      - 게시글 수정하기
      
<img width="406" height="517" alt="스크린샷 2026-05-17 오전 2 16 36" src="https://github.com/user-attachments/assets/afed8d95-9526-4d2e-af82-473289d16c5f" />

  - 네비게이션 처리
      - 왼쪽 상단 화살표 클릭 시 이전 화면 이동
      
  - 테스트
      - npm run build 통과
---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #87 
