### PR TITLE
feat: 카테고리 기반 검색

### DIFF
--- a/src/app/(main)/index.tsx
+++ b/src/app/(main)/index.tsx
@@ -37,7 +37,7 @@ import { Screen, Tab } from '../../types/index';
 import { ExploreIcon } from '../../components/common/ExploreIcon';
 import AuctionRegisterScreen from '../products/register/AuctionRegisterScreen';
 import HomeScreen from './home';
-import SearchScreen from './search';
+import SearchScreen, { type SelectedSearchCategory } from './search';
 import RegularRegisterScreen from '../products/register/RegularRegisterScreen';
 import ChatListScreen from '../chats';
 import MyPageScreen from './mypage';
@@ -73,7 +73,7 @@ export default function MainLayout({
   activeTab: Tab; 
   onTabChange: (tab: Tab) => void;
   onProductClick: (id: number) => void;
-  onProductListClick: (type: 'all' | 'closing_soon' | 'recent', category?: string) => void;
+  onProductListClick: (type: 'all' | 'closing_soon' | 'recent', category?: SelectedSearchCategory | string) => void;
   onNotificationClick: () => void;
   onReviewClick: () => void;
   onSalesManagementClick: () => void;
@@ -128,11 +128,12 @@ export default function MainLayout({
         {displayTab === 'search' && (
           <SearchScreen 
             onBack={() => onTabChange('home')} 
-            onSearch={(keyword) => {
-              onProductListClick('all', keyword);
+            onCategorySelect={(category) => {
+              onProductListClick('all', category);
             }}
             onSearchDetailClick={onSearchClick}
             onRecentClick={() => onProductListClick('recent')}
+            mode={themeMode}
             themeColor={themeColor} 
           />
         )}

--- a/src/app/(main)/search/detail/index.tsx
+++ b/src/app/(main)/search/detail/index.tsx
@@ -35,16 +35,17 @@ import { motion, AnimatePresence } from 'motion/react';
 
 import { Screen, Tab } from '../../../../types/index';
 import { ExploreIcon } from '../../../../components/common/ExploreIcon';
+import type { SelectedSearchCategory } from '../index';
 
-export default function SearchDetailScreen({ onBack, onSearch, themeColor, initialCategory }: { onBack: () => void; onSearch: (keyword: string) => void; themeColor: string; initialCategory?: string | null; key?: string }) {
+export default function SearchDetailScreen({ onBack, onSearch, themeColor, initialCategory }: { onBack: () => void; onSearch: (keyword: string) => void; themeColor: string; initialCategory?: SelectedSearchCategory | null; key?: string }) {
   const [recentSearches, setRecentSearches] = useState(['아이폰', '노트북', '가방']);
   const [inputValue, setInputValue] = useState('');
-  const [activeCategory, setActiveCategory] = useState<string | null>(initialCategory || null);
+  const [activeCategory, setActiveCategory] = useState<SelectedSearchCategory | null>(initialCategory || null);
 
   const handleSearch = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && inputValue.trim()) {
       const keyword = inputValue.trim();
-      const finalSearch = activeCategory ? `${activeCategory} ${keyword}` : keyword;
+      const finalSearch = activeCategory ? `${activeCategory.name} ${keyword}` : keyword;
       if (!recentSearches.includes(finalSearch)) {
         setRecentSearches([finalSearch, ...recentSearches]);
       }
@@ -77,7 +78,7 @@ export default function SearchDetailScreen({ onBack, onSearch, themeColor, initi
           <div className="flex items-center flex-1 min-w-0 space-x-2">
             {activeCategory && (
               <div className="flex items-center space-x-1 px-2 py-1 bg-white border border-gray-200 rounded-full shrink-0">
-                <span className="text-[10px] font-bold text-gray-700 whitespace-nowrap">{activeCategory}</span>
+                <span className="text-[10px] font-bold text-gray-700 whitespace-nowrap">{activeCategory.name}</span>
                 <button onClick={() => setActiveCategory(null)} className="p-0.5 hover:bg-gray-100 rounded-full">
                   <X size={10} className="text-gray-400" />
                 </button>

--- a/src/app/(main)/search/index.tsx
+++ b/src/app/(main)/search/index.tsx
@@ -1,73 +1,69 @@
 "use client";
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import {
-  ChevronLeft,
-  Check,
-  ChevronRight,
-  User,
-  Camera,
   Search,
-  Home,
-  PlusCircle,
-  MessageCircle,
-  Heart,
-  Bell,
-  Filter,
-  Settings,
-  MoreVertical,
-  Send,
-  Star,
-  Clock,
-  ArrowUpRight,
-  X,
-  Trash2,
-  Eye,
-  Image as ImageIcon,
   ArrowLeft,
-  TrendingUp,
-  Sparkles,
-  Menu,
-  ShoppingBag,
-  Store,
-  Receipt,
 } from "lucide-react";
-import { motion, AnimatePresence } from "motion/react";
+import { motion } from "motion/react";
 
-import { Screen, Tab } from "../../../types/index";
-import { ExploreIcon } from "../../../components/common/ExploreIcon";
+import { getErrorMessage } from "@/services/apiError";
+import { fetchSearchCategoryOptionsByMode } from "@/services/product/search/service";
+import type { SearchCategoryViewModel } from "@/services/product/search/types";
+
+export interface SelectedSearchCategory {
+  id: number;
+  name: string;
+}
 
 export default function SearchScreen({
   onBack,
-  onSearch,
+  onCategorySelect,
   onSearchDetailClick,
   onRecentClick,
-  themeColor,
+  mode = "regular",
 }: {
   onBack: () => void;
-  onSearch: (keyword: string) => void;
+  onCategorySelect: (category: SelectedSearchCategory) => void;
   onSearchDetailClick: () => void;
   onRecentClick: () => void;
-  themeColor: string;
+  mode?: "regular" | "auction";
+  themeColor?: string;
   key?: string;
 }) {
-  const categories = [
-    { name: "디지털기기", icon: "💻" },
-    { name: "생활가전", icon: "📺" },
-    { name: "가구/인테리어", icon: "🪑" },
-    { name: "유아동", icon: "👶" },
-    { name: "생활/가공식품", icon: "🍎" },
-    { name: "유아도서", icon: "📚" },
-    { name: "스포츠/레저", icon: "⚽" },
-    { name: "여성잡화", icon: "👜" },
-    { name: "여성의류", icon: "👗" },
-    { name: "남성패션/잡화", icon: "👔" },
-    { name: "게임/취미", icon: "🎮" },
-    { name: "뷰티/미용", icon: "💄" },
-    { name: "반려동물용품", icon: "🐶" },
-    { name: "도서/티켓/음반", icon: "💿" },
-    { name: "식물", icon: "🌿" },
-    { name: "기타", icon: "📦" },
-  ];
+  const [categories, setCategories] = useState<SearchCategoryViewModel[]>([]);
+  const [isLoadingCategories, setIsLoadingCategories] = useState(false);
+  const [categoryLoadError, setCategoryLoadError] = useState("");
+
+  useEffect(() => {
+    let ignore = false;
+
+    setIsLoadingCategories(true);
+    setCategoryLoadError("");
+
+    fetchSearchCategoryOptionsByMode(mode)
+      .then((nextCategories) => {
+        if (!ignore) {
+          setCategories(nextCategories);
+        }
+      })
+      .catch((error) => {
+        if (!ignore) {
+          setCategories([]);
+          setCategoryLoadError(
+            getErrorMessage(error, "검색 카테고리를 불러오지 못했습니다."),
+          );
+        }
+      })
+      .finally(() => {
+        if (!ignore) {
+          setIsLoadingCategories(false);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [mode]);
 
   return (
     <motion.div
@@ -105,23 +101,49 @@ export default function SearchScreen({
           <span className="text-gray-400 text-sm">검색어를 입력해 주세요.</span>
         </div>
 
-        {/* Category Section */}
         <div className="space-y-4">
           <h3 className="font-bold text-gray-900 text-lg">카테고리</h3>
-          <div className="grid grid-cols-4 gap-3">
-            {categories.map((cat) => (
-              <button
-                key={cat.name}
-                onClick={() => onSearch(cat.name)}
-                className="flex flex-col items-center justify-center p-3 rounded-2xl bg-gray-50 hover:bg-gray-100 transition-all active:scale-95"
-              >
-                <span className="text-2xl mb-2">{cat.icon}</span>
-                <span className="text-[10px] font-bold text-gray-700 text-center leading-tight">
-                  {cat.name}
-                </span>
-              </button>
-            ))}
-          </div>
+
+          {isLoadingCategories ? (
+            <div className="grid grid-cols-4 gap-3">
+              {Array.from({ length: 8 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="h-[76px] rounded-2xl bg-gray-50 animate-pulse"
+                />
+              ))}
+            </div>
+          ) : categoryLoadError ? (
+            <div className="rounded-2xl bg-red-50 px-4 py-3 text-sm font-medium text-red-500">
+              {categoryLoadError}
+            </div>
+          ) : (
+            <div className="grid grid-cols-4 gap-3">
+              {categories.map((category) => (
+                <button
+                  key={`${category.fromApi ? "api" : "mock"}-${category.categoryId}`}
+                  type="button"
+                  onClick={() =>
+                    onCategorySelect({
+                      id: category.categoryId,
+                      name: category.name,
+                    })
+                  }
+                  disabled={!category.enabled}
+                  className={`flex flex-col items-center justify-center py-2.5 rounded-xl border transition-all duration-200 ${
+                    category.enabled
+                      ? "bg-gray-50 border-transparent text-gray-500 hover:bg-gray-100"
+                      : "bg-gray-50 border-transparent text-gray-500 opacity-45 cursor-not-allowed"
+                  }`}
+                >
+                  <span className="text-xl mb-1">{category.icon}</span>
+                  <span className="text-[9px] font-bold text-gray-600">
+                    {category.name}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </motion.div>

--- a/src/app/(main)/search/page.tsx
+++ b/src/app/(main)/search/page.tsx
@@ -10,7 +10,11 @@ export default function SearchPage() {
   return (
     <SearchScreen
       onBack={() => router.back()}
-      onSearch={() => router.push("/products")}
+      onCategorySelect={(category) =>
+        router.push(
+          `/products?categoryId=${category.id}&category=${encodeURIComponent(category.name)}`,
+        )
+      }
       onSearchDetailClick={() => router.push("/search/detail")}
       onRecentClick={() => router.push("/products")}
       themeColor="#98E446"

--- a/src/app/auctions/page.tsx
+++ b/src/app/auctions/page.tsx
@@ -1,20 +1,37 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import AuctionListScreen from "./index";
 
-export default function AuctionsPage() {
+function AuctionsPageContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const categoryIdParam = Number(searchParams.get("categoryId"));
+  const categoryId =
+    Number.isFinite(categoryIdParam) && categoryIdParam > 0
+      ? categoryIdParam
+      : null;
+  const categoryName = searchParams.get("category");
 
   return (
     <AuctionListScreen
       listType="all"
-      categoryName={null}
+      categoryId={categoryId}
+      categoryName={categoryName}
       onBack={() => router.back()}
       onProductClick={(id: number) => router.push(`/auctions/${id}`)}
       onSearchClick={() => router.push("/search")}
       themeColor="#F64257"
     />
+  );
+}
+
+export default function AuctionsPage() {
+  return (
+    <Suspense fallback={null}>
+      <AuctionsPageContent />
+    </Suspense>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -123,6 +123,7 @@ type RouteState = {
   themeMode?: ThemeMode;
   productListType?: "all" | "closing_soon" | "recent";
   category?: string | null;
+  categoryId?: number | null;
 };
 
 const getFiniteId = (value: number | null | undefined) =>
@@ -140,6 +141,7 @@ const buildUrl = (
     themeMode,
     productListType,
     category,
+    categoryId,
     bidAmount,
   }: {
     tab: Tab;
@@ -149,6 +151,7 @@ const buildUrl = (
     themeMode: ThemeMode;
     productListType: "all" | "closing_soon" | "recent";
     category: string | null;
+    categoryId: number | null;
     bidAmount?: number;
   },
 ) => {
@@ -158,6 +161,9 @@ const buildUrl = (
 
   if (category) {
     params.set("category", category);
+  }
+  if (categoryId) {
+    params.set("categoryId", String(categoryId));
   }
 
   switch (screen) {
@@ -334,6 +340,7 @@ const routeStateFromUrl = (url: URL): RouteState | null => {
           ? (searchParams.get("type") as "closing_soon" | "recent")
           : "all",
       category: searchParams.get("category"),
+      categoryId: getFiniteId(Number(searchParams.get("categoryId"))),
     };
   }
   if (/^\/products\/\d+\/report$/.test(pathname)) {
@@ -364,6 +371,7 @@ const routeStateFromUrl = (url: URL): RouteState | null => {
           ? (searchParams.get("type") as "closing_soon" | "recent")
           : "all",
       category: searchParams.get("category"),
+      categoryId: getFiniteId(Number(searchParams.get("categoryId"))),
     };
   }
   if (/^\/auctions\/\d+\/bidding-status$/.test(pathname)) {
@@ -413,6 +421,9 @@ export default function App() {
     "all" | "closing_soon" | "recent"
   >("all");
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(
+    null,
+  );
   const [isEditingProfile, setIsEditingProfile] = useState(false);
   const [userLocationForm, setUserLocationForm] = useState<LocationFormValues>(
     createDefaultLocationForm(),
@@ -473,6 +484,9 @@ export default function App() {
     if (routeState.category !== undefined) {
       setSelectedCategory(routeState.category);
     }
+    if (routeState.categoryId !== undefined) {
+      setSelectedCategoryId(routeState.categoryId);
+    }
   }, []);
 
   useEffect(() => {
@@ -514,6 +528,7 @@ export default function App() {
       themeMode,
       productListType,
       category: selectedCategory,
+      categoryId: selectedCategoryId,
       bidAmount: bidData?.bidAmount,
     });
     const currentUrl = `${window.location.pathname}${window.location.search}`;
@@ -535,6 +550,7 @@ export default function App() {
     currentTab,
     productListType,
     selectedCategory,
+    selectedCategoryId,
     selectedChatDraftProductId,
     selectedChatId,
     selectedProductId,
@@ -911,7 +927,13 @@ export default function App() {
                 onProductClick={navigateToCatalogItem}
                 onProductListClick={(type, category) => {
                   setProductListType(type);
-                  setSelectedCategory(category || null);
+                  if (typeof category === "object" && category !== null) {
+                    setSelectedCategory(category.name);
+                    setSelectedCategoryId(category.id);
+                  } else {
+                    setSelectedCategory(category || null);
+                    setSelectedCategoryId(null);
+                  }
                   navigateTo("product_list");
                 }}
                 onNotificationClick={() => navigateTo("notifications")}
@@ -933,6 +955,7 @@ export default function App() {
                 onCategoryResetClick={() => navigateTo("category_reset")}
                 onSearchClick={() => {
                   setSelectedCategory(null);
+                  setSelectedCategoryId(null);
                   navigateTo("search_detail");
                 }}
                 onProfileEditClick={() => {
@@ -1008,19 +1031,26 @@ export default function App() {
                 onSearch={(keyword) => {
                   setProductListType("all");
                   setSelectedCategory(keyword);
+                  setSelectedCategoryId(null);
                   navigateTo("product_list");
                 }}
                 themeColor={themeColor}
-                initialCategory={selectedCategory}
+                initialCategory={
+                  selectedCategory && selectedCategoryId
+                    ? { id: selectedCategoryId, name: selectedCategory }
+                    : null
+                }
               />
             )}
             {currentScreen === "product_list" && (
               <ProductListScreen
                 key="product_list"
                 listType={productListType}
+                categoryId={selectedCategoryId}
                 categoryName={selectedCategory}
                 onBack={() => {
                   setSelectedCategory(null);
+                  setSelectedCategoryId(null);
                   navigateTo("main");
                 }}
                 onProductClick={navigateToCatalogItem}

--- a/src/app/products/index.tsx
+++ b/src/app/products/index.tsx
@@ -12,12 +12,17 @@ import {
 import { getErrorMessage } from "@/services/apiError";
 import { fetchHotRegularProducts } from "@/services/product/hotList/service";
 import { fetchPopularRegularProducts } from "@/services/product/popular/service";
+import {
+  fetchAuctionsByCategory,
+  fetchProductsByCategory,
+} from "@/services/product/search/service";
 import { fetchRegularWishlist } from "@/services/wishlist/service";
 
 type ProductListType = "all" | "closing_soon" | "recent";
 
 export default function ProductListScreen({
   listType,
+  categoryId,
   categoryName,
   onBack,
   onProductClick,
@@ -26,6 +31,7 @@ export default function ProductListScreen({
   mode,
 }: {
   listType: ProductListType;
+  categoryId?: number | null;
   categoryName: string | null;
   onBack: () => void;
   onProductClick: (id: number) => void;
@@ -54,14 +60,17 @@ export default function ProductListScreen({
 
   useEffect(() => {
     let ignore = false;
+    const shouldFetchCategoryList =
+      typeof categoryId === "number" && categoryId > 0;
     const shouldFetchApiList =
+      !shouldFetchCategoryList &&
       !categoryName &&
       ((mode === "regular" &&
         (listType === "all" || listType === "closing_soon")) ||
         (mode === "auction" &&
           (listType === "all" || listType === "closing_soon")));
 
-    if (!shouldFetchApiList) {
+    if (!shouldFetchCategoryList && !shouldFetchApiList) {
       setProducts([]);
       setErrorMessage("");
       return () => {
@@ -72,8 +81,11 @@ export default function ProductListScreen({
     setIsLoading(true);
     setErrorMessage("");
 
-    const request =
-      mode === "regular" && listType === "all"
+    const request = shouldFetchCategoryList
+      ? mode === "auction"
+        ? fetchAuctionsByCategory(categoryId, 0, 20)
+        : fetchProductsByCategory(categoryId, 0, 20)
+      : mode === "regular" && listType === "all"
         ? fetchPopularRegularProducts(10)
         : mode === "regular"
           ? fetchHotRegularProducts(8)
@@ -85,10 +97,12 @@ export default function ProductListScreen({
       .then((nextProducts) => {
         if (!ignore) {
           setProducts(
-            nextProducts.slice(
-              0,
-              mode === "regular" && listType === "all" ? 10 : 8,
-            ),
+            shouldFetchCategoryList
+              ? nextProducts
+              : nextProducts.slice(
+                  0,
+                  mode === "regular" && listType === "all" ? 10 : 8,
+                ),
           );
         }
       })
@@ -98,13 +112,17 @@ export default function ProductListScreen({
           setErrorMessage(
             getErrorMessage(
               error,
-              mode === "regular" && listType === "all"
-                ? "실시간 인기 상품을 불러오지 못했습니다."
-                : mode === "regular"
-                  ? "핫한 상품을 불러오지 못했습니다."
-                  : listType === "all"
-                    ? "실시간 인기 경매를 불러오지 못했습니다."
-                    : "마감 임박 경매를 불러오지 못했습니다.",
+              shouldFetchCategoryList
+                ? mode === "auction"
+                  ? "카테고리 경매를 불러오지 못했습니다."
+                  : "카테고리 상품을 불러오지 못했습니다."
+                : mode === "regular" && listType === "all"
+                  ? "실시간 인기 상품을 불러오지 못했습니다."
+                  : mode === "regular"
+                    ? "핫한 상품을 불러오지 못했습니다."
+                    : listType === "all"
+                      ? "실시간 인기 경매를 불러오지 못했습니다."
+                      : "마감 임박 경매를 불러오지 못했습니다.",
             ),
           );
         }
@@ -118,7 +136,7 @@ export default function ProductListScreen({
     return () => {
       ignore = true;
     };
-  }, [categoryName, listType, mode]);
+  }, [categoryId, categoryName, listType, mode]);
 
   useEffect(() => {
     if (mode !== "regular") {

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -1,21 +1,38 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import ProductListScreen from "./index";
 
-export default function ProductsPage() {
+function ProductsPageContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const categoryIdParam = Number(searchParams.get("categoryId"));
+  const categoryId =
+    Number.isFinite(categoryIdParam) && categoryIdParam > 0
+      ? categoryIdParam
+      : null;
+  const categoryName = searchParams.get("category");
 
   return (
     <ProductListScreen
       listType="all"
-      categoryName={null}
+      categoryId={categoryId}
+      categoryName={categoryName}
       onBack={() => router.back()}
       onProductClick={(id) => router.push(`/products/${id}`)}
       onSearchClick={() => router.push("/search")}
       themeColor="#98E446"
       mode="regular"
     />
+  );
+}
+
+export default function ProductsPage() {
+  return (
+    <Suspense fallback={null}>
+      <ProductsPageContent />
+    </Suspense>
   );
 }

--- a/src/services/auction/list/types.ts
+++ b/src/services/auction/list/types.ts
@@ -43,6 +43,6 @@ export interface AuctionListItemViewModel {
   auctionStatus: AuctionStatus;
   auctionStatusLabel: string;
   popularScore: number;
-  rank: number;
+  rank?: number;
   createdAt: string;
 }

--- a/src/services/product/search/api.ts
+++ b/src/services/product/search/api.ts
@@ -1,0 +1,127 @@
+import { ApiRequestError, getApiErrorMessage } from "@/services/apiError";
+import {
+  getAuthorizationHeaders,
+  handleUnauthorizedAccess,
+} from "@/services/auth/service";
+import type {
+  ProductSearchListResponse,
+  SearchCategoryOptionResponse,
+} from "@/services/product/search/types";
+import type { AuctionListResponse } from "@/services/auction/list/types";
+
+const PRODUCT_SEARCH_API_BASE = "/api/v1/products/search";
+const AUCTION_SEARCH_API_BASE = "/api/v1/auctions/search";
+
+async function throwProductSearchApiError(
+  response: Response,
+  fallbackMessage: string,
+) {
+  if (response.status === 401) {
+    handleUnauthorizedAccess();
+  }
+
+  throw new ApiRequestError(
+    await getApiErrorMessage(response, fallbackMessage),
+    response.status,
+  );
+}
+
+export async function getSearchCategories(): Promise<
+  SearchCategoryOptionResponse[]
+> {
+  const response = await fetch(`${PRODUCT_SEARCH_API_BASE}/categories`, {
+    method: "GET",
+    headers: getAuthorizationHeaders(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    await throwProductSearchApiError(
+      response,
+      "검색 카테고리를 불러오지 못했습니다.",
+    );
+  }
+
+  return response.json();
+}
+
+export async function getAuctionSearchCategories(): Promise<
+  SearchCategoryOptionResponse[]
+> {
+  const response = await fetch(`${AUCTION_SEARCH_API_BASE}/categories`, {
+    method: "GET",
+    headers: getAuthorizationHeaders(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    await throwProductSearchApiError(
+      response,
+      "경매 검색 카테고리를 불러오지 못했습니다.",
+    );
+  }
+
+  return response.json();
+}
+
+export async function searchProductsByCategory({
+  categoryId,
+  page = 0,
+  size = 20,
+}: {
+  categoryId: number;
+  page?: number;
+  size?: number;
+}): Promise<ProductSearchListResponse> {
+  const params = new URLSearchParams({
+    categoryId: String(categoryId),
+    page: String(page),
+    size: String(size),
+  });
+
+  const response = await fetch(`${PRODUCT_SEARCH_API_BASE}?${params}`, {
+    method: "GET",
+    headers: getAuthorizationHeaders(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    await throwProductSearchApiError(
+      response,
+      "카테고리 상품을 불러오지 못했습니다.",
+    );
+  }
+
+  return response.json();
+}
+
+export async function searchAuctionsByCategory({
+  categoryId,
+  page = 0,
+  size = 20,
+}: {
+  categoryId: number;
+  page?: number;
+  size?: number;
+}): Promise<AuctionListResponse> {
+  const params = new URLSearchParams({
+    categoryId: String(categoryId),
+    page: String(page),
+    size: String(size),
+  });
+
+  const response = await fetch(`${AUCTION_SEARCH_API_BASE}?${params}`, {
+    method: "GET",
+    headers: getAuthorizationHeaders(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    await throwProductSearchApiError(
+      response,
+      "카테고리 경매를 불러오지 못했습니다.",
+    );
+  }
+
+  return response.json();
+}

--- a/src/services/product/search/service.ts
+++ b/src/services/product/search/service.ts
@@ -1,0 +1,203 @@
+import * as productSearchApi from "@/services/product/search/api";
+import type { AuctionListItemViewModel } from "@/services/auction/list/types";
+import type {
+  ProductSearchItemResponse,
+  ProductSearchItemViewModel,
+  SearchCategoryViewModel,
+  SearchCategoryOptionResponse,
+} from "@/services/product/search/types";
+
+const DEFAULT_CATEGORY_LABEL = "카테고리 없음";
+const DEFAULT_LOCATION_LABEL = "지역 정보 없음";
+const FALLBACK_CATEGORIES: SearchCategoryViewModel[] = [
+  { categoryId: -1, name: "디지털기기", icon: "💻", enabled: false, fromApi: false },
+  { categoryId: -2, name: "생활가전", icon: "🔌", enabled: false, fromApi: false },
+  { categoryId: -3, name: "가구/인테리어", icon: "🛋️", enabled: false, fromApi: false },
+  { categoryId: -4, name: "유아동", icon: "🧸", enabled: false, fromApi: false },
+  { categoryId: -5, name: "생활/가공식품", icon: "🥫", enabled: false, fromApi: false },
+  { categoryId: -6, name: "유아도서", icon: "📚", enabled: false, fromApi: false },
+  { categoryId: -7, name: "스포츠/레저", icon: "⚽", enabled: false, fromApi: false },
+  { categoryId: -8, name: "여성잡화", icon: "👜", enabled: false, fromApi: false },
+  { categoryId: -9, name: "여성의류", icon: "👗", enabled: false, fromApi: false },
+  { categoryId: -10, name: "남성패션/잡화", icon: "👕", enabled: false, fromApi: false },
+  { categoryId: -11, name: "게임/취미", icon: "🎮", enabled: false, fromApi: false },
+  { categoryId: -12, name: "뷰티/미용", icon: "💄", enabled: false, fromApi: false },
+  { categoryId: -13, name: "반려동물용품", icon: "🐾", enabled: false, fromApi: false },
+  { categoryId: -14, name: "도서/티켓/음반", icon: "📚", enabled: false, fromApi: false },
+  { categoryId: -15, name: "식물", icon: "🌿", enabled: false, fromApi: false },
+  { categoryId: -16, name: "기타", icon: "✨", enabled: false, fromApi: false },
+];
+
+const CATEGORY_ICON_RULES = [
+  { keywords: ["전자", "디지털"], icon: "💻" },
+  { keywords: ["의류"], icon: "👗" },
+  { keywords: ["도서"], icon: "📚" },
+];
+
+function formatPrice(price: number) {
+  return `${Number(price || 0).toLocaleString()}원`;
+}
+
+function normalizeName(name: string) {
+  return name.trim().replace(/\s+/g, "");
+}
+
+function getIcon(name: string) {
+  const normalizedName = normalizeName(name);
+  const matchedRule = CATEGORY_ICON_RULES.find((rule) =>
+    rule.keywords.some((keyword) => normalizedName.includes(keyword)),
+  );
+
+  if (matchedRule) {
+    return matchedRule.icon;
+  }
+
+  const matchedFallback = FALLBACK_CATEGORIES.find(
+    (category) => normalizeName(category.name) === normalizedName,
+  );
+
+  return matchedFallback?.icon ?? "✨";
+}
+
+function toSearchCategoryViewModel(
+  category: SearchCategoryOptionResponse,
+): SearchCategoryViewModel {
+  return {
+    categoryId: category.id,
+    name: category.nameKo,
+    icon: getIcon(category.nameKo),
+    enabled: true,
+    fromApi: true,
+  };
+}
+
+function toProductSearchItemViewModel(
+  item: ProductSearchItemResponse,
+): ProductSearchItemViewModel {
+  return {
+    productId: item.productId,
+    name: item.name,
+    thumbnailUrl: item.thumbnailUrl,
+    priceLabel: formatPrice(item.price),
+    location: item.location ?? DEFAULT_LOCATION_LABEL,
+    categoryId: item.categoryId,
+    categoryName: item.categoryName ?? DEFAULT_CATEGORY_LABEL,
+    viewCount: item.viewCount,
+    favoriteCount: item.favoriteCount,
+    createdAt: item.createdAt,
+  };
+}
+
+export async function fetchSearchCategoryOptions(): Promise<
+  SearchCategoryViewModel[]
+> {
+  return fetchSearchCategoryOptionsByMode("regular");
+}
+
+export async function fetchSearchCategoryOptionsByMode(
+  mode: "regular" | "auction",
+): Promise<SearchCategoryViewModel[]> {
+  const apiCategories =
+    mode === "auction"
+      ? await productSearchApi.getAuctionSearchCategories()
+      : await productSearchApi.getSearchCategories();
+  const apiViewModels = apiCategories
+    .filter((category) => category.depth === 1)
+    .map(toSearchCategoryViewModel);
+  const apiNameSet = new Set(
+    apiViewModels.map((category) => normalizeName(category.name)),
+  );
+  const missingFallbacks = FALLBACK_CATEGORIES.filter(
+    (category) => !apiNameSet.has(normalizeName(category.name)),
+  );
+
+  return [...apiViewModels, ...missingFallbacks];
+}
+
+export async function fetchProductsByCategory(
+  categoryId: number,
+  page = 0,
+  size = 20,
+): Promise<ProductSearchItemViewModel[]> {
+  const response = await productSearchApi.searchProductsByCategory({
+    categoryId,
+    page,
+    size,
+  });
+  return response.content.map(toProductSearchItemViewModel);
+}
+
+function formatAuctionStatus(status: AuctionListItemViewModel["auctionStatus"]) {
+  switch (status) {
+    case "ONGOING":
+      return "진행중";
+    case "ENDED":
+      return "종료";
+    case "NO_BID":
+      return "유찰";
+    case "SUCCESSFUL_BID":
+      return "낙찰";
+    case "DRAFT":
+    default:
+      return "준비중";
+  }
+}
+
+function formatEndAt(endAt: string) {
+  const endTime = new Date(endAt).getTime();
+  if (!Number.isFinite(endTime)) {
+    return "마감 시간 없음";
+  }
+
+  const diffMs = endTime - Date.now();
+  if (diffMs <= 0) {
+    return "마감";
+  }
+
+  const totalMinutes = Math.floor(diffMs / 60000);
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
+
+  if (days > 0) {
+    return `${days}일 ${hours}시간 남음`;
+  }
+  if (hours > 0) {
+    return `${hours}시간 ${minutes}분 남음`;
+  }
+  return `${Math.max(1, minutes)}분 남음`;
+}
+
+export async function fetchAuctionsByCategory(
+  categoryId: number,
+  page = 0,
+  size = 20,
+): Promise<AuctionListItemViewModel[]> {
+  const response = await productSearchApi.searchAuctionsByCategory({
+    categoryId,
+    page,
+    size,
+  });
+
+  return response.content.map((item) => {
+    const currentPriceLabel = formatPrice(item.currentPrice);
+    return {
+      productId: item.productId,
+      auctionId: item.auctionId,
+      name: item.title,
+      thumbnailUrl: item.thumbnailUrl,
+      priceLabel: currentPriceLabel,
+      startPriceLabel: formatPrice(item.startPrice),
+      currentPriceLabel,
+      location: item.location ?? DEFAULT_LOCATION_LABEL,
+      categoryName: item.categoryName ?? DEFAULT_CATEGORY_LABEL,
+      bidCount: item.bidCount,
+      endAt: item.endAt,
+      endAtLabel: formatEndAt(item.endAt),
+      auctionStatus: item.auctionStatus,
+      auctionStatusLabel: formatAuctionStatus(item.auctionStatus),
+      popularScore: item.popularScore,
+      createdAt: item.createdAt,
+    };
+  });
+}

--- a/src/services/product/search/types.ts
+++ b/src/services/product/search/types.ts
@@ -1,0 +1,51 @@
+export interface SearchCategoryOptionResponse {
+  id: number;
+  nameKo: string;
+  nameEn: string;
+  depth: number;
+  parentId: number | null;
+  enabled: boolean;
+  children: SearchCategoryOptionResponse[];
+}
+
+export interface ProductSearchItemResponse {
+  productId: number;
+  name: string;
+  thumbnailUrl: string | null;
+  price: number;
+  location: string | null;
+  categoryId: number;
+  categoryName: string | null;
+  viewCount: number;
+  favoriteCount: number;
+  createdAt: string;
+}
+
+export interface ProductSearchListResponse {
+  content: ProductSearchItemResponse[];
+  page: number;
+  size: number;
+  totalElements: number;
+  hasNext: boolean;
+}
+
+export interface ProductSearchItemViewModel {
+  productId: number;
+  name: string;
+  thumbnailUrl: string | null;
+  priceLabel: string;
+  location: string;
+  categoryId: number;
+  categoryName: string;
+  viewCount: number;
+  favoriteCount: number;
+  createdAt: string;
+}
+
+export interface SearchCategoryViewModel {
+  categoryId: number;
+  name: string;
+  icon: string;
+  enabled: boolean;
+  fromApi: boolean;
+}


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
- 카테고리 기반 검색
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
- 상품/경매 목록 화면에서 카테고리 검색 결과 조회

검색창: 카테고리 기반이기에 대분류 기준 존재하는 카테고리들만 활성화되어있음

<img width="455" height="714" alt="스크린샷 2026-05-17 오후 1 20 31" src="https://github.com/user-attachments/assets/9901aefa-e0ef-4d9a-a093-8fb15743ef26" />

  - 일반 상품 검색 결과는 일반 상품 카드로 표시
  - 경매 검색 결과는 경매 카드로 표시

일반 상품 결과
<img width="475" height="443" alt="스크린샷 2026-05-17 오후 1 21 13" src="https://github.com/user-attachments/assets/3b867db5-6d94-4666-bb85-ef8ca61b1dab" />
<img width="467" height="420" alt="스크린샷 2026-05-17 오후 1 21 20" src="https://github.com/user-attachments/assets/2b321472-9ab8-4b1f-9577-19c5119da8bf" />
<img width="476" height="246" alt="스크린샷 2026-05-17 오후 1 20 37" src="https://github.com/user-attachments/assets/f5c9b4a9-74fd-4547-b390-14761f53e71a" />

경매 검색 결과
<img width="702" height="513" alt="스크린샷 2026-05-17 오후 2 51 18" src="https://github.com/user-attachments/assets/cf00427d-2423-4b69-b579-2435e6ab8e9f" />
<img width="691" height="473" alt="스크린샷 2026-05-17 오후 2 51 30" src="https://github.com/user-attachments/assets/7905543c-7904-4950-83c8-b3068e0b91fa" />

- 검색 결과 화면에서 돋보기 클릭 시 검색 상세 화면에 카테고리 블록 표시
  - 카테고리 블록은 사용자가 검색 결과에서 돋보기 진입 시에만 표시
  - 초기 탐색 카테고리 화면에서는 선택/체크 스타일 미표시
<img width="708" height="484" alt="스크린샷 2026-05-17 오후 3 13 23" src="https://github.com/user-attachments/assets/54bf078b-b41a-4e36-8a6e-d779daabd896" />

- 경매 카테고리 검색 결과에서는 순위 배지 제거
  - 검색 결과의 rank는 인기/마감임박 순위가 아니므로 표시하지 않음
  - 기존 실시간 인기/마감임박 경매 목록의 순위 표시는 유지

- `useSearchParams` 사용 페이지에 Suspense 경계 추가
  - `/products`
  - `/auctions`
---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #90 
