### PR TITLE
refactor: 카테고리 검색 결과를 일반 상품/경매 통합 검색으로 변경

### DIFF
--- a/src/app/products/index.tsx
+++ b/src/app/products/index.tsx
@@ -12,11 +12,7 @@ import {
 import { getErrorMessage } from "@/services/apiError";
 import { fetchHotRegularProducts } from "@/services/product/hotList/service";
 import { fetchPopularRegularProducts } from "@/services/product/popular/service";
-import {
-  fetchIntegratedSearchResults,
-  fetchAuctionsByCategory,
-  fetchProductsByCategory,
-} from "@/services/product/search/service";
+import { fetchIntegratedSearchResults } from "@/services/product/search/service";
 import type { UnifiedSearchResultType } from "@/services/product/search/types";
 import { fetchRegularWishlist } from "@/services/wishlist/service";
 
@@ -103,9 +99,11 @@ export default function ProductListScreen({
           size: 20,
         })
       : shouldFetchCategoryList
-        ? mode === "auction"
-        ? fetchAuctionsByCategory(categoryId, 0, 20)
-        : fetchProductsByCategory(categoryId, 0, 20)
+        ? fetchIntegratedSearchResults({
+            categoryId,
+            page: 0,
+            size: 20,
+          })
       : mode === "regular" && listType === "all"
         ? fetchPopularRegularProducts(10)
         : mode === "regular"
@@ -136,9 +134,7 @@ export default function ProductListScreen({
               shouldFetchKeywordList
                 ? "검색 결과를 불러오지 못했습니다."
                 : shouldFetchCategoryList
-                ? mode === "auction"
-                  ? "카테고리 경매를 불러오지 못했습니다."
-                  : "카테고리 상품을 불러오지 못했습니다."
+                ? "카테고리 검색 결과를 불러오지 못했습니다."
                 : mode === "regular" && listType === "all"
                   ? "실시간 인기 상품을 불러오지 못했습니다."
                   : mode === "regular"
@@ -162,7 +158,7 @@ export default function ProductListScreen({
   }, [categoryId, categoryName, listType, mode, searchKeyword, searchResultType]);
 
   useEffect(() => {
-    if (mode !== "regular") {
+    if (mode !== "regular" && !categoryId && !searchKeyword) {
       setLikedProductIds(new Set());
       return;
     }
@@ -184,7 +180,7 @@ export default function ProductListScreen({
     return () => {
       ignore = true;
     };
-  }, [mode]);
+  }, [categoryId, mode, searchKeyword]);
 
   const handleWishlistChange = (
     productId: number,
@@ -262,7 +258,7 @@ export default function ProductListScreen({
         ) : products.length > 0 ? (
           products.map((product) => (
             <ProductListItem
-              key={`${mode}-${product.auctionId ?? product.productId}`}
+              key={`${product.saleType ?? mode}-${product.auctionId ?? product.productId}`}
               product={product}
               mode={
                 product.saleType === "AUCTION" ||
@@ -273,7 +269,8 @@ export default function ProductListScreen({
               themeColor={themeColor}
               onProductClick={() => handleProductClick(product)}
               initialLiked={
-                mode === "regular" && likedProductIds.has(product.productId)
+                product.saleType !== "AUCTION" &&
+                likedProductIds.has(product.productId)
               }
               onWishlistChange={handleWishlistChange}
             />

--- a/src/services/product/search/service.ts
+++ b/src/services/product/search/service.ts
@@ -135,12 +135,21 @@ export async function fetchSearchCategoryOptions(): Promise<
 }
 
 export async function fetchSearchCategoryOptionsByMode(
-  mode: "regular" | "auction",
+  _mode: "regular" | "auction",
 ): Promise<SearchCategoryViewModel[]> {
-  const apiCategories =
-    mode === "auction"
-      ? await productSearchApi.getAuctionSearchCategories()
-      : await productSearchApi.getSearchCategories();
+  const [regularCategories, auctionCategories] = await Promise.all([
+    productSearchApi.getSearchCategories(),
+    productSearchApi.getAuctionSearchCategories(),
+  ]);
+  const categoriesById = new Map<number, SearchCategoryOptionResponse>();
+
+  for (const category of [...regularCategories, ...auctionCategories]) {
+    categoriesById.set(category.id, category);
+  }
+
+  const apiCategories = Array.from(categoriesById.values()).sort(
+    (left, right) => left.id - right.id,
+  );
   const apiViewModels = apiCategories
     .filter((category) => category.depth === 1)
     .map(toSearchCategoryViewModel);


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
- 카테고리 선택 시 홈 토글 상태와 관계없이 일반 상품+경매상품
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
- 카테고리 검색 요청을 기존 타입별 API에서 통합검색 API로 변경했습니다.
  - 기존: `/api/v1/products/search`, `/api/v1/auctions/search`
  - 변경: `/api/v1/search?categoryId=...`
- 검색 카테고리 목록도 일반 상품/경매 카테고리 API 결과를 합쳐서 사용하도록 변경했습니다.
- 통합검색 결과의 `saleType` 기준으로 일반 상품/경매 카드 렌더링과 상세 페이지 이동이 분기되도록 유지했습니다.
- 경매 토글 상태에서 통합 카테고리 결과에 일반 상품이 포함되는 경우에도 일반 상품 찜 상태가 반영되도록 조정했습니다.

도서 카테고리 검색 예시
<img width="707" height="524" alt="스크린샷 2026-05-18 오전 11 00 06" src="https://github.com/user-attachments/assets/15de6b4a-bbc8-473d-8143-19ed4bc20e23" />

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #94 
