### PR TITLE
[fix] ui수정 및 경매 상세 탭 추가

### DIFF
--- a/src/app/(main)/home/page.tsx
+++ b/src/app/(main)/home/page.tsx
@@ -1,47 +1,93 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
-import HomeScreen from "./index";
+import MainLayout from "../index";
 import {
   readStoredThemeMode,
   writeStoredThemeMode,
   type ThemeMode,
 } from "@/services/themeMode";
+import type { Tab } from "@/types";
 
 export default function HomePage() {
   const router = useRouter();
-  const [mode, setMode] = useState<ThemeMode>(readStoredThemeMode);
+  const [mode, setMode] = useState<ThemeMode>("regular");
+
+  useEffect(() => {
+    setMode(readStoredThemeMode());
+  }, []);
 
   const handleModeChange = (nextMode: ThemeMode) => {
     setMode(nextMode);
     writeStoredThemeMode(nextMode);
   };
 
-  return (
-    <HomeScreen
-      onProductClick={(id) =>
-        router.push(mode === "auction" ? `/auctions/${id}` : `/products/${id}`)
-      }
-      onProductListClick={(type, category) => {
-        const params = new URLSearchParams();
-        params.set("type", type);
-        if (category) {
-          params.set("category", category);
-        }
+  const themeColor = mode === "regular" ? "#98E446" : "#F64257";
 
-        router.push(
-          `${mode === "auction" ? "/auctions" : "/products"}?${params.toString()}`,
-        );
-      }}
-      onNotificationClick={() => router.push("/notifications")}
-      onCategoryResetClick={() => {}}
-      onSearchClick={() => router.push("/search")}
-      onWishlistClick={() => router.push("/wishlist")}
-      mode={mode}
-      onModeChange={handleModeChange}
-      onTabChange={() => {}}
-    />
+  const handleTabChange = (tab: Tab) => {
+    switch (tab) {
+      case "home":
+        router.push("/home");
+        return;
+      case "search":
+        router.push("/search");
+        return;
+      case "register":
+        router.push("/products/register");
+        return;
+      case "chat":
+        router.push("/chats");
+        return;
+      case "mypage":
+        router.push("/mypage");
+        return;
+    }
+  };
+
+  return (
+    <div className="h-screen overflow-hidden bg-white font-sans text-[#141414]">
+      <MainLayout
+        activeTab="home"
+        onTabChange={handleTabChange}
+        onProductClick={(id) =>
+          router.push(mode === "auction" ? `/auctions/${id}` : `/products/${id}`)
+        }
+        onProductListClick={(type, category) => {
+          const params = new URLSearchParams();
+          params.set("type", type);
+          if (category) {
+            params.set(
+              "category",
+              typeof category === "object" ? category.name : category,
+            );
+          }
+
+          router.push(
+            `${mode === "auction" ? "/auctions" : "/products"}?${params.toString()}`,
+          );
+        }}
+        onNotificationClick={() => router.push("/notifications")}
+        onReviewClick={() => router.push("/mypage/review")}
+        onSalesManagementClick={() => router.push("/mypage/sales-management")}
+        onNotificationSettingsClick={() => router.push("/notifications/settings")}
+        onChatClick={(id) => router.push(`/chats/${id}`)}
+        onCategoryResetClick={() => router.push("/category-selection?mode=edit")}
+        onSearchClick={() => router.push("/search/detail")}
+        onProfileEditClick={() => router.push("/mypage/edit-profile")}
+        onLocationEditClick={() => router.push("/mypage/edit-profile/location")}
+        onWishlistClick={() => router.push("/wishlist")}
+        onAccountManagementClick={() => router.push("/mypage/account-management")}
+        onPurchaseHistoryClick={() => router.push("/mypage/purchase-history")}
+        onSalesHistoryClick={() => router.push("/mypage/sales-history")}
+        onBiddingClick={() => router.push("/mypage/my-bids")}
+        themeMode={mode}
+        onThemeChange={handleModeChange}
+        themeColor={themeColor}
+        userLocation="지역 정보 없음"
+        onLogout={() => router.push("/login")}
+      />
+    </div>
   );
 }

--- a/src/app/(main)/index.tsx
+++ b/src/app/(main)/index.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { 
   ChevronLeft, 
   Check, 
@@ -98,8 +98,11 @@ export default function MainLayout({
 }) {
   const { chatUnreadCount } = useEventStream();
   const [lastTab, setLastTab] = useState<Tab>(activeTab === 'register' ? 'home' : activeTab);
+  const [isBottomNavVisible, setIsBottomNavVisible] = useState(true);
+  const lastScrollTopRef = useRef(0);
   const RegisterComponent =
     themeMode === 'auction' ? AuctionRegisterScreen : RegularRegisterScreen;
+  const displayTab = activeTab === 'register' ? lastTab : activeTab;
   
   useEffect(() => {
     if (activeTab !== 'register') {
@@ -107,11 +110,43 @@ export default function MainLayout({
     }
   }, [activeTab]);
 
-  const displayTab = activeTab === 'register' ? lastTab : activeTab;
+  useEffect(() => {
+    setIsBottomNavVisible(true);
+    lastScrollTopRef.current = 0;
+
+    const handleScroll = (event: Event) => {
+      const target = event.target as HTMLElement | Document | null;
+      const scrollElement =
+        target instanceof Document
+          ? target.scrollingElement
+          : target instanceof HTMLElement
+            ? target
+            : null;
+
+      if (!scrollElement) {
+        return;
+      }
+
+      const nextScrollTop = scrollElement.scrollTop;
+      const previousScrollTop = lastScrollTopRef.current;
+      const delta = nextScrollTop - previousScrollTop;
+
+      if (nextScrollTop <= 12 || delta < -8) {
+        setIsBottomNavVisible(true);
+      } else if (delta > 8) {
+        setIsBottomNavVisible(false);
+      }
+
+      lastScrollTopRef.current = Math.max(0, nextScrollTop);
+    };
+
+    window.addEventListener('scroll', handleScroll, true);
+    return () => window.removeEventListener('scroll', handleScroll, true);
+  }, [displayTab]);
 
   return (
-    <div className="flex-1 flex flex-col h-full">
-      <div className="flex-1 flex flex-col overflow-hidden relative">
+    <div className="flex-1 flex flex-col h-full relative overflow-hidden">
+      <div className="flex-1 flex flex-col overflow-hidden relative pb-16">
         {displayTab === 'home' && (
           <HomeScreen 
             onProductClick={onProductClick} 
@@ -178,13 +213,17 @@ export default function MainLayout({
 
       {/* Bottom Tab Bar */}
       {activeTab !== 'register' && (
-        <div className="h-16 bg-white border-t border-gray-100 flex items-center justify-around px-4 shrink-0">
+        <motion.div
+          animate={{ y: isBottomNavVisible ? 0 : 76 }}
+          transition={{ duration: 0.22, ease: 'easeOut' }}
+          className="absolute bottom-0 left-0 right-0 z-40 h-16 bg-white border-t border-gray-100 flex items-center justify-around px-4 shadow-[0_-8px_20px_rgba(0,0,0,0.03)]"
+        >
           <TabButton active={activeTab === 'home'} icon={<Home size={24} />} label="홈" onClick={() => onTabChange('home')} activeColor={themeColor} />
           <TabButton active={activeTab === 'search'} icon={<ExploreIcon size={30} />} label="탐색" onClick={() => onTabChange('search')} activeColor={themeColor} />
           <TabButton active={(activeTab as any) === 'register'} icon={<PlusCircle size={24} />} label="등록" onClick={() => onTabChange('register')} activeColor={themeColor} />
           <TabButton active={activeTab === 'chat'} icon={<MessageCircle size={24} />} label="채팅" onClick={() => onTabChange('chat')} activeColor={themeColor} badgeCount={chatUnreadCount} />
           <TabButton active={activeTab === 'mypage'} icon={<User size={24} />} label="MY" onClick={() => onTabChange('mypage')} activeColor={themeColor} />
-        </div>
+        </motion.div>
       )}
     </div>
   );

--- a/src/app/auctions/[auctionId]/bidding-status/index.tsx
+++ b/src/app/auctions/[auctionId]/bidding-status/index.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { 
   ChevronLeft, 
+  ChevronDown,
   Check, 
   ChevronRight, 
   User, 
@@ -41,8 +42,17 @@ import {
   fetchAuctionDetail,
   getAuctionDisplayCurrentPrice,
 } from '@/services/auction/detail/service';
-import type { AuctionBidHistoryResponse, AuctionDetailResponse } from '@/services/auction/detail/types';
+import type { AuctionBidHistoryItem, AuctionBidHistoryResponse, AuctionDetailResponse } from '@/services/auction/detail/types';
 import { useEventStream } from '@/services/events/EventStreamProvider';
+
+type BidStatusTab = "history" | "ranking";
+
+type BidRankingItem = {
+  bidderId: number;
+  bidderNickname: string;
+  highestBid: AuctionBidHistoryItem;
+  bids: AuctionBidHistoryItem[];
+};
 
 function formatBidTime(value: string) {
   const date = new Date(value);
@@ -64,11 +74,28 @@ export default function BiddingStatusScreen({ auctionId, onBack, themeColor }: {
   const [bidHistory, setBidHistory] = useState<AuctionBidHistoryResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+  const [activeTab, setActiveTab] = useState<BidStatusTab>("history");
+  const [expandedBidderIds, setExpandedBidderIds] = useState<Set<number>>(
+    () => new Set(),
+  );
   const { latestAuctionEvent } = useEventStream();
   const bids = bidHistory?.bids ?? [];
+  const bidRankings = buildBidRankings(bids);
   const currentDisplayPrice = bidHistory?.currentPrice ?? getAuctionDisplayCurrentPrice(auctionDetail);
   const bidCount = bidHistory?.bidCount ?? auctionDetail?.bidCount ?? 0;
   const priceHelperText = bidCount > 0 ? "현재 최고 입찰가" : "입찰 기록 없음";
+
+  const toggleBidderExpanded = (bidderId: number) => {
+    setExpandedBidderIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(bidderId)) {
+        next.delete(bidderId);
+      } else {
+        next.add(bidderId);
+      }
+      return next;
+    });
+  };
 
   useEffect(() => {
     if (auctionId == null) {
@@ -157,7 +184,7 @@ export default function BiddingStatusScreen({ auctionId, onBack, themeColor }: {
         <h1 className="flex-1 text-center font-bold text-lg mr-10">입찰 현황</h1>
       </div>
 
-      <div className="flex-1 overflow-y-auto no-scrollbar">
+      <div className="flex-1 overflow-y-auto pb-28 no-scrollbar">
         {/* Summary Header */}
         <div className="p-6 bg-gray-50/50 border-b border-gray-50">
           <div className="flex items-center justify-between mb-4">
@@ -177,11 +204,26 @@ export default function BiddingStatusScreen({ auctionId, onBack, themeColor }: {
         {/* Bidding List */}
         <div className="p-6 space-y-6">
           <div className="flex items-center justify-between">
-            <h3 className="font-bold text-gray-900">입찰 기록</h3>
-            <span className="text-[10px] text-gray-400">최신순</span>
+            <div className="flex rounded-xl bg-gray-100 p-1">
+              <BidStatusTabButton
+                active={activeTab === "history"}
+                label="입찰 기록"
+                onClick={() => setActiveTab("history")}
+                activeColor={themeColor}
+              />
+              <BidStatusTabButton
+                active={activeTab === "ranking"}
+                label="입찰 순위"
+                onClick={() => setActiveTab("ranking")}
+                activeColor={themeColor}
+              />
+            </div>
+            <span className="text-[10px] text-gray-400">
+              {activeTab === "history" ? "최신순" : "최고가순"}
+            </span>
           </div>
 
-          {bids.length > 0 ? (
+          {activeTab === "history" && bids.length > 0 ? (
             <div className="space-y-4">
               {bids.map((bid, idx) => (
                 <div key={bid.bidId} className="relative">
@@ -217,23 +259,176 @@ export default function BiddingStatusScreen({ auctionId, onBack, themeColor }: {
                 </div>
               ))}
             </div>
+          ) : activeTab === "ranking" && bidRankings.length > 0 ? (
+            <div className="space-y-3">
+              {bidRankings.map((ranking, index) => {
+                const isExpanded = expandedBidderIds.has(ranking.bidderId);
+                const hasMultipleBids = ranking.bids.length > 1;
+
+                return (
+                  <div
+                    key={ranking.bidderId}
+                    className="rounded-2xl border border-gray-100 bg-white p-4 shadow-sm"
+                  >
+                    <div className="flex items-center gap-3">
+                      <div
+                        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-black text-white"
+                        style={{ backgroundColor: index === 0 ? themeColor : "#111827" }}
+                      >
+                        {index + 1}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="truncate text-sm font-black text-gray-950">
+                            {ranking.bidderNickname}
+                          </span>
+                          {index === 0 && (
+                            <span
+                              className="rounded-full px-2 py-0.5 text-[8px] font-black uppercase tracking-wider text-white"
+                              style={{ backgroundColor: themeColor }}
+                            >
+                              Highest
+                            </span>
+                          )}
+                        </div>
+                        <div className="mt-1 flex items-baseline gap-1">
+                          <span
+                            className="text-lg font-black"
+                            style={{ color: index === 0 ? themeColor : "#111827" }}
+                          >
+                            ₩{ranking.highestBid.bidPrice.toLocaleString()}
+                          </span>
+                          <span className="text-[10px] font-bold text-gray-400">
+                            최고 입찰가
+                          </span>
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => toggleBidderExpanded(ranking.bidderId)}
+                        disabled={!hasMultipleBids}
+                        className="flex h-9 w-9 items-center justify-center rounded-full bg-gray-50 text-gray-500 transition-colors hover:bg-gray-100 disabled:opacity-30"
+                        aria-label={`${ranking.bidderNickname} 입찰 내역 ${isExpanded ? "접기" : "펼치기"}`}
+                      >
+                        <ChevronDown
+                          size={18}
+                          className={`transition-transform ${isExpanded ? "rotate-180" : ""}`}
+                        />
+                      </button>
+                    </div>
+
+                    <AnimatePresence initial={false}>
+                      {isExpanded && (
+                        <motion.div
+                          initial={{ height: 0, opacity: 0 }}
+                          animate={{ height: "auto", opacity: 1 }}
+                          exit={{ height: 0, opacity: 0 }}
+                          transition={{ duration: 0.18 }}
+                          className="overflow-hidden"
+                        >
+                          <div className="mt-4 space-y-2 border-t border-gray-100 pt-3">
+                            {ranking.bids.map((bid) => (
+                              <div
+                                key={bid.bidId}
+                                className="flex items-center justify-between rounded-xl bg-gray-50 px-3 py-2"
+                              >
+                                <span className="text-xs font-bold text-gray-500">
+                                  {formatBidTime(bid.bidAt)}
+                                </span>
+                                <span
+                                  className="text-sm font-black"
+                                  style={{ color: bid.bidId === ranking.highestBid.bidId ? themeColor : "#6B7280" }}
+                                >
+                                  ₩{bid.bidPrice.toLocaleString()}
+                                </span>
+                              </div>
+                            ))}
+                          </div>
+                        </motion.div>
+                      )}
+                    </AnimatePresence>
+                  </div>
+                );
+              })}
+            </div>
           ) : (
             <div className="flex h-48 items-center justify-center rounded-2xl border border-dashed border-gray-200 text-sm font-medium text-gray-400">
-              입찰 기록이 없습니다
+              {activeTab === "history" ? "입찰 기록이 없습니다" : "입찰 순위가 없습니다"}
             </div>
           )}
         </div>
       </div>
 
       {/* Bottom Action */}
-      <div className="p-6 border-t border-gray-50">
+      <div className="absolute bottom-0 left-0 right-0 z-20 border-t border-gray-50 bg-white p-6">
         <button 
           onClick={onBack}
-          className="w-full h-14 bg-gray-900 text-white font-bold rounded-2xl hover:bg-black transition-colors"
+          className="w-full h-14 bg-gray-900 text-white font-bold rounded-2xl shadow-[0_8px_18px_rgba(15,23,42,0.18)] hover:bg-black transition-colors"
         >
           확인
         </button>
       </div>
     </motion.div>
   );
+}
+
+function BidStatusTabButton({
+  active,
+  label,
+  onClick,
+  activeColor,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+  activeColor: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="h-9 rounded-lg px-4 text-sm font-black transition-colors"
+      style={{
+        backgroundColor: active ? "#FFFFFF" : "transparent",
+        color: active ? activeColor : "#9CA3AF",
+        boxShadow: active ? "0 1px 4px rgba(0, 0, 0, 0.06)" : "none",
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function buildBidRankings(bids: AuctionBidHistoryItem[]): BidRankingItem[] {
+  const groupedBids = new Map<number, AuctionBidHistoryItem[]>();
+
+  bids.forEach((bid) => {
+    const bidderBids = groupedBids.get(bid.bidderId) ?? [];
+    bidderBids.push(bid);
+    groupedBids.set(bid.bidderId, bidderBids);
+  });
+
+  return Array.from(groupedBids.entries())
+    .map(([bidderId, bidderBids]) => {
+      const sortedBids = [...bidderBids].sort((a, b) => {
+        if (b.bidPrice !== a.bidPrice) {
+          return b.bidPrice - a.bidPrice;
+        }
+        return new Date(b.bidAt).getTime() - new Date(a.bidAt).getTime();
+      });
+
+      return {
+        bidderId,
+        bidderNickname: sortedBids[0]?.bidderNickname ?? `입찰자 #${bidderId}`,
+        highestBid: sortedBids[0],
+        bids: sortedBids,
+      };
+    })
+    .filter((ranking): ranking is BidRankingItem => ranking.highestBid != null)
+    .sort((a, b) => {
+      if (b.highestBid.bidPrice !== a.highestBid.bidPrice) {
+        return b.highestBid.bidPrice - a.highestBid.bidPrice;
+      }
+      return new Date(b.highestBid.bidAt).getTime() - new Date(a.highestBid.bidAt).getTime();
+    });
 }

--- a/src/app/auctions/[auctionId]/bidding-status/index.tsx
+++ b/src/app/auctions/[auctionId]/bidding-status/index.tsx
@@ -54,6 +54,8 @@ type BidRankingItem = {
   bids: AuctionBidHistoryItem[];
 };
 
+const EMPTY_BIDS: AuctionBidHistoryItem[] = [];
+
 function formatBidTime(value: string) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
@@ -79,8 +81,8 @@ export default function BiddingStatusScreen({ auctionId, onBack, themeColor }: {
     () => new Set(),
   );
   const { latestAuctionEvent } = useEventStream();
-  const bids = bidHistory?.bids ?? [];
-  const bidRankings = buildBidRankings(bids);
+  const bids = bidHistory?.bids ?? EMPTY_BIDS;
+  const bidRankings = React.useMemo(() => buildBidRankings(bids), [bids]);
   const currentDisplayPrice = bidHistory?.currentPrice ?? getAuctionDisplayCurrentPrice(auctionDetail);
   const bidCount = bidHistory?.bidCount ?? auctionDetail?.bidCount ?? 0;
   const priceHelperText = bidCount > 0 ? "현재 최고 입찰가" : "입찰 기록 없음";

--- a/src/app/auctions/[auctionId]/page.tsx
+++ b/src/app/auctions/[auctionId]/page.tsx
@@ -23,7 +23,10 @@ export default function AuctionDetailPage() {
   const [showReauctionPrompt, setShowReauctionPrompt] = useState(
     () => searchParams.get("reauctionPrompt") === "1",
   );
-  const [toast, setToast] = useState({ message: "", visible: false });
+  const [toast, setToast] = useState<{ message: string; visible: boolean }>({
+    message: "",
+    visible: false,
+  });
 
   useEffect(() => {
     if (searchParams.get("reauctionPrompt") === "1") {
@@ -63,98 +66,100 @@ export default function AuctionDetailPage() {
   return (
     <>
       <EventStreamProvider enabled>
-        <AuctionDetailScreen
-          productId={auctionId}
-          onBack={() => router.back()}
-          onBidStatusClick={() =>
-            router.push(`/auctions/${auctionId}/bidding-status`)
-          }
-          onChatClick={handleChatClick}
-          onReportClick={() => router.push(`/products/${auctionId}/report`)}
-          onPurchaseClick={() => router.push(`/products/${auctionId}/payment`)}
-          onBidComplete={(data: BidCompleteData) => {
-            router.replace(
-              `/auctions/${auctionId}/bid-complete?bidPrice=${data.bidAmount}`,
-            );
-          }}
-          themeColor="#F64257"
-          mode="auction"
-          showToast={showToast}
-        />
-        {showReauctionPrompt && (
-          <div className="fixed inset-0 z-[100] flex justify-center bg-white text-[#17181d]">
-            <div className="flex h-full w-full max-w-[430px] flex-col px-7 pb-8 pt-5">
-              <div className="flex h-14 items-center justify-between">
-                <button
-                  onClick={() => {
-                    router.back();
-                  }}
-                  className="-ml-2 flex h-11 w-11 items-center justify-center rounded-full text-[#17181d]"
-                  aria-label="뒤로가기"
-                >
-                  <ChevronLeft size={34} strokeWidth={2.4} />
-                </button>
-                <div className="h-11 w-11" />
-              </div>
-
-              <div className="mt-7 space-y-6">
-                <div className="space-y-3">
-                  <div className="space-y-2">
-                    <h2 className="whitespace-nowrap text-[clamp(22px,6vw,28px)] font-black leading-tight tracking-[-0.02em] text-[#17181d]">
-                      유찰된 경매를 다시 올려볼까요?
-                    </h2>
-                    <p className="text-base font-bold leading-relaxed text-gray-500">
-                      지금 선택하면 게시글을 수정하거나 그대로 다시 준비할 수 있어요.
-                    </p>
-                  </div>
+        <div className="relative h-screen overflow-hidden bg-white">
+          <AuctionDetailScreen
+            productId={auctionId}
+            onBack={() => router.back()}
+            onBidStatusClick={() =>
+              router.push(`/auctions/${auctionId}/bidding-status`)
+            }
+            onChatClick={handleChatClick}
+            onReportClick={() => router.push(`/products/${auctionId}/report`)}
+            onPurchaseClick={() => router.push(`/products/${auctionId}/payment`)}
+            onBidComplete={(data: BidCompleteData) => {
+              router.replace(
+                `/auctions/${auctionId}/bid-complete?bidPrice=${data.bidAmount}`,
+              );
+            }}
+            themeColor="#F64257"
+            mode="auction"
+            showToast={showToast}
+          />
+          {showReauctionPrompt && (
+            <div className="fixed inset-0 z-[100] flex justify-center bg-white text-[#17181d]">
+              <div className="flex h-full w-full max-w-[430px] flex-col px-7 pb-8 pt-5">
+                <div className="flex h-14 items-center justify-between">
+                  <button
+                    onClick={() => {
+                      router.back();
+                    }}
+                    className="-ml-2 flex h-11 w-11 items-center justify-center rounded-full text-[#17181d]"
+                    aria-label="뒤로가기"
+                  >
+                    <ChevronLeft size={34} strokeWidth={2.4} />
+                  </button>
+                  <div className="h-11 w-11" />
                 </div>
 
-                <button
-                  type="button"
-                  onClick={() => {}}
-                  className="w-full rounded-2xl bg-gray-100 p-4 text-left transition-colors hover:bg-gray-200"
-                >
-                  <div className="flex items-center gap-4">
-                    <div className="flex h-20 w-20 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-white text-xs font-bold text-gray-500">
-                      유찰
-                    </div>
-                    <div className="min-w-0">
-                      <p className="truncate text-lg font-bold text-[#17181d]">
-                        유찰된 경매 #{auctionId}
-                      </p>
-                      <p className="mt-1 text-xl font-black text-[#17181d]">
-                        재경매 대기
+                <div className="mt-7 space-y-6">
+                  <div className="space-y-3">
+                    <div className="space-y-2">
+                      <h2 className="whitespace-nowrap text-[clamp(22px,6vw,28px)] font-black leading-tight tracking-[-0.02em] text-[#17181d]">
+                        유찰된 경매를 다시 올려볼까요?
+                      </h2>
+                      <p className="text-base font-bold leading-relaxed text-gray-500">
+                        지금 선택하면 게시글을 수정하거나 그대로 다시 준비할 수 있어요.
                       </p>
                     </div>
                   </div>
-                </button>
-              </div>
 
-              <div className="mt-3 space-y-3">
-                <div className="grid grid-cols-1 gap-3">
                   <button
+                    type="button"
                     onClick={() => {}}
-                    className="h-14 rounded-2xl bg-gray-100 text-sm font-black text-[#17181d] transition-colors hover:bg-gray-200"
+                    className="w-full rounded-2xl bg-gray-100 p-4 text-left transition-colors hover:bg-gray-200"
                   >
-                    그대로 올리기
+                    <div className="flex items-center gap-4">
+                      <div className="flex h-20 w-20 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-white text-xs font-bold text-gray-500">
+                        유찰
+                      </div>
+                      <div className="min-w-0">
+                        <p className="truncate text-lg font-bold text-[#17181d]">
+                          유찰된 경매 #{auctionId}
+                        </p>
+                        <p className="mt-1 text-xl font-black text-[#17181d]">
+                          재경매 대기
+                        </p>
+                      </div>
+                    </div>
                   </button>
-                  <button
-                    onClick={() => {}}
-                    className="h-14 rounded-2xl bg-[#F64257] text-sm font-black text-white transition-opacity hover:opacity-90"
-                  >
-                    게시글 수정하기
-                  </button>
-                  <button
-                    onClick={() => {}}
-                    className="h-14 rounded-2xl bg-gray-100 text-sm font-black text-gray-500 transition-colors hover:bg-gray-200"
-                  >
-                    재등록 안 하기
-                  </button>
+                </div>
+
+                <div className="mt-3 space-y-3">
+                  <div className="grid grid-cols-1 gap-3">
+                    <button
+                      onClick={() => {}}
+                      className="h-14 rounded-2xl bg-gray-100 text-sm font-black text-[#17181d] transition-colors hover:bg-gray-200"
+                    >
+                      그대로 올리기
+                    </button>
+                    <button
+                      onClick={() => {}}
+                      className="h-14 rounded-2xl bg-[#F64257] text-sm font-black text-white transition-opacity hover:opacity-90"
+                    >
+                      게시글 수정하기
+                    </button>
+                    <button
+                      onClick={() => {}}
+                      className="h-14 rounded-2xl bg-gray-100 text-sm font-black text-gray-500 transition-colors hover:bg-gray-200"
+                    >
+                      재등록 안 하기
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </EventStreamProvider>
       <Toast message={toast.message} visible={toast.visible} />
     </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -438,7 +438,8 @@ export default function App() {
   const [selectedChatDraftProductId, setSelectedChatDraftProductId] = useState<
     number | null
   >(null);
-  const [themeMode, setThemeMode] = useState<ThemeMode>(readStoredThemeMode);
+  const [themeMode, setThemeMode] = useState<ThemeMode>("regular");
+  const [isThemeModeReady, setIsThemeModeReady] = useState(false);
   const [productListType, setProductListType] = useState<
     "all" | "closing_soon" | "recent"
   >("all");
@@ -528,7 +529,13 @@ export default function App() {
     if (routeState) {
       isApplyingPopState.current = true;
       applyRouteState(routeState);
+      if (!routeState.themeMode) {
+        setThemeMode(readStoredThemeMode());
+      }
+    } else {
+      setThemeMode(readStoredThemeMode());
     }
+    setIsThemeModeReady(true);
 
     const handlePopState = () => {
       const routeState = routeStateFromUrl(new URL(window.location.href));
@@ -546,8 +553,12 @@ export default function App() {
   }, [applyRouteState]);
 
   useEffect(() => {
+    if (!isThemeModeReady) {
+      return;
+    }
+
     writeStoredThemeMode(themeMode);
-  }, [themeMode]);
+  }, [isThemeModeReady, themeMode]);
 
   useEffect(() => {
     const nextUrl = buildUrl(currentScreen, {
@@ -693,8 +704,8 @@ export default function App() {
 
   return (
     <EventStreamProvider enabled={currentScreen !== "login"}>
-      <div className="min-h-screen bg-white flex justify-center px-4 font-sans text-[#141414]">
-        <div className="w-full max-w-180 mx-auto bg-white overflow-hidden relative flex flex-col shrink-0">
+      <div className="h-screen overflow-hidden bg-white flex justify-center px-4 font-sans text-[#141414]">
+        <div className="h-full w-full max-w-180 mx-auto bg-white overflow-hidden relative flex flex-col shrink-0">
           <AnimatePresence mode="wait">
             {currentScreen === "login" && (
               <LoginScreen
@@ -1289,6 +1300,19 @@ export default function App() {
                 onComplete={() => navigateTo("receipt")}
                 themeColor="#F64257"
               />
+            )}
+          </AnimatePresence>
+          <AnimatePresence>
+            {toast.visible && (
+              <motion.div
+                initial={{ opacity: 0, y: 18 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 18 }}
+                transition={{ duration: 0.18 }}
+                className="pointer-events-none absolute bottom-20 left-4 right-4 z-[120] rounded-xl bg-black/85 px-4 py-3 text-center text-sm font-bold text-white shadow-lg"
+              >
+                {toast.message}
+              </motion.div>
             )}
           </AnimatePresence>
         </div>

--- a/src/app/products/[productId]/page.tsx
+++ b/src/app/products/[productId]/page.tsx
@@ -20,7 +20,10 @@ export default function ProductDetailPage() {
   );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [toast, setToast] = useState({ message: "", visible: false });
+  const [toast, setToast] = useState<{ message: string; visible: boolean }>({
+    message: "",
+    visible: false,
+  });
 
   const showToast = (message: string) => {
     setToast({ message, visible: true });
@@ -111,27 +114,29 @@ export default function ProductDetailPage() {
   return (
     <>
       <EventStreamProvider enabled>
-        <ProductDetailScreen
-          productId={productId}
-          productData={productData}
-          onBack={() => router.back()}
-          onChatClick={handleChatClick}
-          onReportClick={() => router.push(`/products/${productId}/report`)}
-          onPurchaseClick={() =>
-            router.push(`/products/${productId}/regular-payment`)
-          }
-          onBidStatusClick={() =>
-            router.push(`/auctions/${productId}/bidding-status`)
-          }
-          onBidComplete={(data) =>
-            router.push(
-              `/auctions/${productId}/bid-complete?bidPrice=${data.bidAmount}`,
-            )
-          }
-          themeColor={productData.saleType === "AUCTION" ? "#F64257" : "#98E446"}
-          mode={productData.saleType === "AUCTION" ? "auction" : "regular"}
-          showToast={showToast}
-        />
+        <div className="relative h-screen overflow-hidden bg-white">
+          <ProductDetailScreen
+            productId={productId}
+            productData={productData}
+            onBack={() => router.back()}
+            onChatClick={handleChatClick}
+            onReportClick={() => router.push(`/products/${productId}/report`)}
+            onPurchaseClick={() =>
+              router.push(`/products/${productId}/regular-payment`)
+            }
+            onBidStatusClick={() =>
+              router.push(`/auctions/${productId}/bidding-status`)
+            }
+            onBidComplete={(data) =>
+              router.push(
+                `/auctions/${productId}/bid-complete?bidPrice=${data.bidAmount}`,
+              )
+            }
+            themeColor={productData.saleType === "AUCTION" ? "#F64257" : "#98E446"}
+            mode={productData.saleType === "AUCTION" ? "auction" : "regular"}
+            showToast={showToast}
+          />
+        </div>
       </EventStreamProvider>
       <Toast message={toast.message} visible={toast.visible} />
     </>

--- a/src/components/wallet/DealitMoneyPanel.tsx
+++ b/src/components/wallet/DealitMoneyPanel.tsx
@@ -2,7 +2,17 @@
 
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
-import { Landmark, Plus, ReceiptText, Wallet, X } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  Landmark,
+  Plus,
+  ReceiptText,
+  Wallet,
+  X,
+} from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
 
 import { getErrorMessage } from "@/services/apiError";
 import {
@@ -31,6 +41,8 @@ export default function DealitMoneyPanel() {
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isHistoryLoading, setIsHistoryLoading] = useState(false);
+  const [historyMonth, setHistoryMonth] = useState(() => createMonthState());
+  const [isMonthPickerOpen, setIsMonthPickerOpen] = useState(false);
 
   useEffect(() => {
     let ignore = false;
@@ -98,10 +110,21 @@ export default function DealitMoneyPanel() {
     setModal(nextModal);
   };
 
+  const openHistory = () => {
+    setErrorMessage("");
+    setHistoryMonth(createMonthState());
+    setModal("history");
+  };
+
   const closeModal = () => {
     setModal(null);
     setAmountInput("");
     setErrorMessage("");
+    setIsMonthPickerOpen(false);
+  };
+
+  const addQuickAmount = (amount: number) => {
+    setAmountInput(String(parseWalletAmount(amountInput) + amount));
   };
 
   const handleSubmitAmount = async () => {
@@ -168,7 +191,7 @@ export default function DealitMoneyPanel() {
         <MoneyActionButton
           icon={<ReceiptText size={18} />}
           label="내역"
-          onClick={() => setModal("history")}
+          onClick={openHistory}
         />
         <MoneyActionButton
           icon={<Landmark size={18} />}
@@ -177,8 +200,26 @@ export default function DealitMoneyPanel() {
         />
       </div>
 
-      {modal && (
-        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40 p-6 text-black backdrop-blur-sm">
+      {modal === "history" && (
+        <WalletHistoryScreen
+          ledgers={ledgers}
+          isLoading={isHistoryLoading}
+          selectedMonth={historyMonth}
+          isMonthPickerOpen={isMonthPickerOpen}
+          onClose={closeModal}
+          onPreviousMonth={() => setHistoryMonth(shiftMonth(historyMonth, -1))}
+          onNextMonth={() => setHistoryMonth(shiftMonth(historyMonth, 1))}
+          onOpenMonthPicker={() => setIsMonthPickerOpen(true)}
+          onCloseMonthPicker={() => setIsMonthPickerOpen(false)}
+          onSelectMonth={(nextMonth) => {
+            setHistoryMonth(nextMonth);
+            setIsMonthPickerOpen(false);
+          }}
+        />
+      )}
+
+      {modal && modal !== "history" && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-6 text-black backdrop-blur-sm">
           <div className="w-full rounded-2xl bg-white p-5 shadow-2xl">
             <div className="flex items-center justify-between">
               <h2 className="text-lg font-bold">{getModalTitle(modal)}</h2>
@@ -192,47 +233,49 @@ export default function DealitMoneyPanel() {
               </button>
             </div>
 
-            {modal === "history" ? (
-              <WalletHistoryContent
-                ledgers={ledgers}
-                isLoading={isHistoryLoading}
-              />
-            ) : (
-              <div className="mt-5 space-y-4">
-                <div className="grid grid-cols-2 gap-2">
-                  {QUICK_AMOUNTS.map((amount) => (
-                    <button
-                      key={amount}
-                      type="button"
-                      onClick={() => setAmountInput(String(amount))}
-                      className="h-11 rounded-lg bg-gray-100 text-sm font-bold hover:bg-gray-200"
-                    >
-                      {formatWon(amount)}
-                    </button>
-                  ))}
-                </div>
-                <input
-                  value={amountInput}
-                  onChange={(event) => setAmountInput(event.target.value)}
-                  inputMode="numeric"
-                  placeholder="금액 직접 입력"
-                  className="h-12 w-full rounded-lg border border-gray-200 px-4 text-base font-semibold outline-none focus:border-black"
-                />
-                {errorMessage && (
-                  <div className="rounded-lg bg-red-50 px-3 py-2 text-xs text-red-500">
-                    {errorMessage}
-                  </div>
-                )}
+            <div className="mt-5 space-y-4">
+              <div className="grid grid-cols-2 gap-2">
+                {QUICK_AMOUNTS.map((amount) => (
+                  <button
+                    key={amount}
+                    type="button"
+                    onClick={() => addQuickAmount(amount)}
+                    className="h-11 rounded-lg bg-gray-100 text-sm font-bold hover:bg-gray-200"
+                  >
+                    {formatWon(amount)}
+                  </button>
+                ))}
+              </div>
+              {modal === "withdraw" && (
                 <button
                   type="button"
-                  onClick={handleSubmitAmount}
-                  disabled={isSubmitting}
-                  className="h-12 w-full rounded-lg bg-black text-sm font-bold text-white disabled:bg-gray-300"
+                  onClick={() => setAmountInput(String(wallet?.balance ?? 0))}
+                  className="text-sm font-bold text-gray-700 underline underline-offset-4"
                 >
-                  {isSubmitting ? "처리 중" : getSubmitLabel(modal)}
+                  전액 입력
                 </button>
-              </div>
-            )}
+              )}
+              <input
+                value={amountInput}
+                onChange={(event) => setAmountInput(event.target.value)}
+                inputMode="numeric"
+                placeholder="금액 직접 입력"
+                className="h-12 w-full rounded-lg border border-gray-200 px-4 text-base font-semibold outline-none focus:border-black"
+              />
+              {errorMessage && (
+                <div className="rounded-lg bg-red-50 px-3 py-2 text-xs text-red-500">
+                  {errorMessage}
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={handleSubmitAmount}
+                disabled={isSubmitting}
+                className="h-12 w-full rounded-lg bg-black text-sm font-bold text-white disabled:bg-gray-300"
+              >
+                {isSubmitting ? "처리 중" : getSubmitLabel(modal)}
+              </button>
+            </div>
           </div>
         </div>
       )}
@@ -261,53 +304,263 @@ function MoneyActionButton({
   );
 }
 
-function WalletHistoryContent({
+type MonthState = {
+  year: number;
+  month: number;
+};
+
+function WalletHistoryScreen({
   ledgers,
   isLoading,
+  selectedMonth,
+  isMonthPickerOpen,
+  onClose,
+  onPreviousMonth,
+  onNextMonth,
+  onOpenMonthPicker,
+  onCloseMonthPicker,
+  onSelectMonth,
 }: {
   ledgers: WalletLedgerViewModel[];
   isLoading: boolean;
+  selectedMonth: MonthState;
+  isMonthPickerOpen: boolean;
+  onClose: () => void;
+  onPreviousMonth: () => void;
+  onNextMonth: () => void;
+  onOpenMonthPicker: () => void;
+  onCloseMonthPicker: () => void;
+  onSelectMonth: (month: MonthState) => void;
 }) {
-  if (isLoading) {
-    return <div className="py-12 text-center text-sm text-gray-400">불러오는 중</div>;
-  }
-
-  if (ledgers.length === 0) {
-    return (
-      <div className="py-12 text-center text-sm text-gray-400">
-        딜릿머니 내역이 없습니다.
-      </div>
-    );
-  }
+  const filteredLedgers = ledgers.filter((ledger) =>
+    isSameMonth(ledger.createdAt, selectedMonth),
+  );
 
   return (
-    <div className="mt-4 max-h-80 overflow-y-auto">
-      {ledgers.map((ledger) => (
-        <div
-          key={ledger.id}
-          className="flex items-center justify-between border-b border-gray-100 py-3 last:border-b-0"
-        >
-          <div className="min-w-0">
-            <div className="font-semibold">{ledger.typeLabel}</div>
-            <div className="mt-1 truncate text-xs text-gray-400">
-              {ledger.createdAtLabel || ledger.description}
-            </div>
-          </div>
-          <div className="text-right">
-            <div
-              className={`font-bold ${
-                ledger.isIncome ? "text-green-600" : "text-gray-900"
-              }`}
-            >
-              {ledger.amountLabel}
-            </div>
-            <div className="mt-1 text-xs text-gray-400">
-              잔액 {ledger.balanceAfterLabel}
-            </div>
-          </div>
+    <div className="fixed inset-0 z-50 bg-white text-black">
+      <div className="flex h-full flex-col px-5 pb-6 pt-7">
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-black tracking-normal">사용 내역</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full p-2 text-gray-400 hover:bg-gray-100"
+            aria-label="닫기"
+          >
+            <X size={22} />
+          </button>
         </div>
+
+        <div className="mt-8 flex items-center justify-between">
+          <button
+            type="button"
+            onClick={onPreviousMonth}
+            className="flex h-10 w-10 items-center justify-center rounded-full text-gray-500 hover:bg-gray-50"
+            aria-label="이전 달"
+          >
+            <ChevronLeft size={26} strokeWidth={1.9} />
+          </button>
+          <button
+            type="button"
+            onClick={onOpenMonthPicker}
+            className="flex items-center gap-1 rounded-full px-4 py-2 text-xl font-black tracking-normal hover:bg-gray-50"
+          >
+            {selectedMonth.month}월
+            <ChevronDown size={18} fill="currentColor" strokeWidth={2.4} />
+          </button>
+          <button
+            type="button"
+            onClick={onNextMonth}
+            className="flex h-10 w-10 items-center justify-center rounded-full text-gray-400 hover:bg-gray-50"
+            aria-label="다음 달"
+          >
+            <ChevronRight size={26} strokeWidth={1.9} />
+          </button>
+        </div>
+
+        <div className="mt-8 flex-1 overflow-y-auto">
+          {isLoading ? (
+            <div className="py-12 text-center text-sm text-gray-400">
+              불러오는 중
+            </div>
+          ) : filteredLedgers.length === 0 ? (
+            <div className="py-12 text-center text-sm text-gray-400">
+              사용 내역이 없습니다.
+            </div>
+          ) : (
+            filteredLedgers.map((ledger) => (
+              <div
+                key={ledger.id}
+                className="flex items-start justify-between border-b border-gray-100 py-4 last:border-b-0"
+              >
+                <div className="min-w-0 pr-4">
+                  <div className="text-base font-bold leading-tight text-gray-900">
+                    {ledger.typeLabel}
+                  </div>
+                  <div className="mt-1.5 text-sm font-semibold leading-tight text-gray-400">
+                    {ledger.createdAtLabel}
+                  </div>
+                </div>
+                <div
+                  className={`whitespace-nowrap pt-0.5 text-right text-base font-black ${
+                    ledger.isIncome ? "text-[#F64257]" : "text-gray-950"
+                  }`}
+                >
+                  {ledger.amountLabel}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      <AnimatePresence>
+        {isMonthPickerOpen && (
+          <MonthPickerSheet
+            selectedMonth={selectedMonth}
+            onClose={onCloseMonthPicker}
+            onConfirm={onSelectMonth}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function MonthPickerSheet({
+  selectedMonth,
+  onClose,
+  onConfirm,
+}: {
+  selectedMonth: MonthState;
+  onClose: () => void;
+  onConfirm: (month: MonthState) => void;
+}) {
+  const [draftMonth, setDraftMonth] = useState(selectedMonth);
+
+  useEffect(() => {
+    setDraftMonth(selectedMonth);
+  }, [selectedMonth]);
+
+  return (
+    <motion.div
+      className="fixed inset-0 z-10 flex items-end bg-black/35"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.18 }}
+    >
+      <button
+        type="button"
+        className="absolute inset-0"
+        aria-label="조회 기간 설정 닫기"
+        onClick={onClose}
+      />
+      <motion.div
+        className="relative w-full rounded-t-3xl bg-white px-5 pb-6 pt-8 shadow-2xl"
+        initial={{ y: "100%" }}
+        animate={{ y: 0 }}
+        exit={{ y: "100%" }}
+        transition={{ type: "spring", damping: 28, stiffness: 360, mass: 0.8 }}
+      >
+        <h3 className="text-xl font-black tracking-normal">
+          조회 기간 설정
+        </h3>
+        <p className="mt-2 text-sm font-semibold text-gray-500">
+          사용 내역을 월 별로 조회할 수 있어요.
+        </p>
+
+        <div className="mt-8 grid grid-cols-2 items-center gap-4 px-8 text-center">
+          <MonthPickerColumn
+            values={[
+              draftMonth.year - 1,
+              draftMonth.year,
+              draftMonth.year + 1,
+            ]}
+            selectedValue={draftMonth.year}
+            label={(value) => `${value}년`}
+            onSelect={(year) => setDraftMonth((prev) => ({ ...prev, year }))}
+          />
+          <MonthPickerColumn
+            values={[
+              normalizeMonth(draftMonth.month - 1),
+              draftMonth.month,
+              normalizeMonth(draftMonth.month + 1),
+            ]}
+            selectedValue={draftMonth.month}
+            label={(value) => `${value}월`}
+            onSelect={(month) => setDraftMonth((prev) => ({ ...prev, month }))}
+          />
+        </div>
+
+        <button
+          type="button"
+          onClick={() => onConfirm(draftMonth)}
+          className="mt-10 h-13 w-full rounded-xl bg-[#F64257] text-base font-black text-white shadow-sm"
+        >
+          확인
+        </button>
+      </motion.div>
+    </motion.div>
+  );
+}
+
+function MonthPickerColumn({
+  values,
+  selectedValue,
+  label,
+  onSelect,
+}: {
+  values: number[];
+  selectedValue: number;
+  label: (value: number) => string;
+  onSelect: (value: number) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      {values.map((value) => (
+        <button
+          key={value}
+          type="button"
+          onClick={() => onSelect(value)}
+          className={`block w-full rounded-xl py-2 text-lg font-black tracking-normal transition-colors ${
+            value === selectedValue ? "text-gray-950" : "text-gray-200"
+          }`}
+        >
+          {label(value)}
+        </button>
       ))}
     </div>
+  );
+}
+
+function createMonthState(date = new Date()): MonthState {
+  return {
+    year: date.getFullYear(),
+    month: date.getMonth() + 1,
+  };
+}
+
+function shiftMonth(monthState: MonthState, offset: number): MonthState {
+  const date = new Date(monthState.year, monthState.month - 1 + offset, 1);
+  return createMonthState(date);
+}
+
+function normalizeMonth(month: number) {
+  if (month < 1) {
+    return 12;
+  }
+  if (month > 12) {
+    return 1;
+  }
+  return month;
+}
+
+function isSameMonth(date: Date | null, monthState: MonthState) {
+  return (
+    date !== null &&
+    date.getFullYear() === monthState.year &&
+    date.getMonth() + 1 === monthState.month
   );
 }
 

--- a/src/services/wallet/service.ts
+++ b/src/services/wallet/service.ts
@@ -19,6 +19,7 @@ export interface WalletLedgerViewModel {
   amountLabel: string;
   balanceAfterLabel: string;
   description: string;
+  createdAt: Date | null;
   createdAtLabel: string;
   isIncome: boolean;
 }
@@ -53,6 +54,7 @@ export function toWalletLedgerViewModel(
     amountLabel: `${isIncome ? "+" : "-"}${formatWon(Math.abs(ledger.amount))}`,
     balanceAfterLabel: formatWon(ledger.balanceAfter),
     description: ledger.description,
+    createdAt: parseWalletDate(ledger.createdAt),
     createdAtLabel: formatWalletDate(ledger.createdAt),
     isIncome,
   };
@@ -62,8 +64,8 @@ export async function fetchWallet() {
   return toWalletViewModel(await walletApi.getWallet());
 }
 
-export async function fetchWalletLedgers() {
-  const response = await walletApi.getWalletLedgers();
+export async function fetchWalletLedgers(page = 0, size = 100) {
+  const response = await walletApi.getWalletLedgers(page, size);
   return response.content.map(toWalletLedgerViewModel);
 }
 
@@ -78,7 +80,7 @@ export async function withdrawDealitMoney(amount: number) {
 function getWalletLedgerTypeLabel(type: WalletLedgerType) {
   switch (type) {
     case "TEMP_CHARGE":
-      return "충전";
+      return "딜릿머니 충전";
     case "REFUND":
       return "환불";
     case "WITHDRAWAL":
@@ -95,19 +97,25 @@ function getWalletLedgerTypeLabel(type: WalletLedgerType) {
 }
 
 function formatWalletDate(value: string | null) {
-  if (!value) {
+  const date = parseWalletDate(value);
+  if (!date) {
     return "";
   }
 
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hour = String(date.getHours()).padStart(2, "0");
+  const minute = String(date.getMinutes()).padStart(2, "0");
+
+  return `${year}.${month}.${day} | ${hour}:${minute}`;
+}
+
+function parseWalletDate(value: string | null) {
+  if (!value) {
+    return null;
   }
 
-  return new Intl.DateTimeFormat("ko-KR", {
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(date);
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
 }


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
ui수정 및 경매 상세 탭 추가 했습니다.
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
1. `/home` 진입 및 새로고침 시 url미스매치 문제와 하단 네비게이션 누락 문제가 발생하지 않도록 테마 초기화와 라우트 렌더링 구조를 수정했습니다.
  2. 홈 상단바와 하단 네비게이션의 스크롤 동작을 개선해 상단바는 유지하고 하단 네비게이션은 스크롤 방향에 따라 숨김/노출되도록 변경했습니다.
<img width="697" height="809" alt="image" src="https://github.com/user-attachments/assets/1bdaf5df-f062-49b1-9099-bd08f2a02f30" />

  3. 딜릿머니 내역을 전체화면으로 제공하고 월별 조회 바텀시트를 추가했습니다.
<img width="697" height="789" alt="image" src="https://github.com/user-attachments/assets/de125c51-562c-42a0-9e57-5463bd550e09" />

<img width="697" height="391" alt="image" src="https://github.com/user-attachments/assets/0651b7a9-3da8-45c4-b7d5-ec4a10834145" />

  4. 딜릿머니 충전/환불 빠른 금액 버튼을 누적 입력 방식으로 변경하고 환불 화면에 `전액 입력` 버튼을 추가했습니다.
  5. 딜릿머니 내역의 `TEMP_CHARGE` 표시를 `딜릿머니 충전`으로 변경했습니다.
  6. 입찰 실패 메시지가 사용자에게 보이도록 상세 화면 토스트 처리를 보완했습니다.
  7. 입찰 현황 화면에 `입찰 기록` / `입찰 순위` 탭을 추가했습니다.
  8. 입찰 순위 탭에서 유저별 최고 입찰가만 기본 표시하고, 드롭다운으로 해당 유저의 전체 입찰 내역을 확인할 수 있도록 구현했습니다.
  9. 입찰 현황 화면의 `확인` 버튼을 하단 고정 버튼으로 변경하고 버튼 자체에 그림자를 적용했습니다.

<img width="708" height="818" alt="image" src="https://github.com/user-attachments/assets/f47573cd-b9c9-4372-a244-7203466c32db" />

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #97 
