### PR TITLE
feat: 유찰경매 그대로올리기, 수정, 종료,문구

### DIFF
--- a/src/app/(main)/mypage/sales-management/index.tsx
+++ b/src/app/(main)/mypage/sales-management/index.tsx
@@ -134,6 +134,11 @@ export default function SalesManagementScreen({
   };
 
   const handleEditClick = async (product: SalesManagementItemViewModel) => {
+    if (product.type === "auction" && product.status === "NO_BID") {
+      router.push(`/auctions/${product.auctionId ?? product.productId}?reauctionPrompt=1`);
+      return;
+    }
+
     if (!product.editable || editingProductId) {
       return;
     }
@@ -161,6 +166,11 @@ export default function SalesManagementScreen({
 
   const handleItemClick = (product: SalesManagementItemViewModel) => {
     if (product.type === "auction") {
+      if (product.status === "NO_BID") {
+        router.push(`/auctions/${product.auctionId ?? product.productId}?reauctionPrompt=1`);
+        return;
+      }
+
       router.push(`/auctions/${product.auctionId ?? product.productId}`);
       return;
     }
@@ -330,7 +340,11 @@ export default function SalesManagementScreen({
                   disabled={!item.editable || editingProductId === item.id}
                   className="h-14 bg-gray-50 rounded-xl text-sm font-bold transition-colors disabled:text-gray-300 enabled:hover:bg-gray-100"
                 >
-                  {editingProductId === item.id ? "불러오는 중" : "수정"}
+                  {editingProductId === item.id
+                    ? "불러오는 중"
+                    : item.type === "auction" && item.status === "NO_BID"
+                      ? "재경매"
+                      : "수정"}
                 </button>
                 <button
                   type="button"

--- a/src/app/auctions/[auctionId]/page.tsx
+++ b/src/app/auctions/[auctionId]/page.tsx
@@ -137,7 +137,7 @@ export default function AuctionDetailPage() {
       await declineReauction(auctionId);
       setShowReauctionPrompt(false);
       showToast("재경매 대기를 종료했어요.");
-      router.replace("/mypage/sales-management");
+      router.replace("/");
     } catch (error) {
       console.error("Failed to decline reauction:", error);
       setReauctionError("재등록 안 하기에 실패했습니다.");

--- a/src/app/auctions/[auctionId]/page.tsx
+++ b/src/app/auctions/[auctionId]/page.tsx
@@ -9,6 +9,13 @@ import AuctionDetailScreen from "./index";
 import { findExistingChatRoomByProductId } from "@/services/chats/service";
 import { fetchAuctionDetail } from "@/services/auction/detail/service";
 import { EventStreamProvider } from "@/services/events/EventStreamProvider";
+import {
+  createDraftFromReauctionPreview,
+  declineReauction,
+  getReauctionPreview,
+  reauctionAuction,
+} from "@/services/auction/register/service";
+import type { ReauctionPreviewResponse } from "@/services/auction/register/types";
 
 type BidCompleteData = {
   bidAmount: number;
@@ -23,13 +30,51 @@ export default function AuctionDetailPage() {
   const [showReauctionPrompt, setShowReauctionPrompt] = useState(
     () => searchParams.get("reauctionPrompt") === "1",
   );
+  const [reauctionPreview, setReauctionPreview] =
+    useState<ReauctionPreviewResponse | null>(null);
+  const [reauctionError, setReauctionError] = useState("");
+  const [isReauctionLoading, setIsReauctionLoading] = useState(false);
+  const [reauctionAction, setReauctionAction] = useState<
+    "same" | "decline" | null
+  >(null);
   const [toast, setToast] = useState({ message: "", visible: false });
+  const isFromReauction = searchParams.get("fromReauction") === "1";
 
   useEffect(() => {
     if (searchParams.get("reauctionPrompt") === "1") {
       setShowReauctionPrompt(true);
     }
   }, [searchParams]);
+
+  useEffect(() => {
+    if (!showReauctionPrompt) {
+      return;
+    }
+
+    let isMounted = true;
+    setIsReauctionLoading(true);
+    setReauctionError("");
+    getReauctionPreview(auctionId)
+      .then((preview) => {
+        if (isMounted) {
+          setReauctionPreview(preview);
+        }
+      })
+      .catch(() => {
+        if (isMounted) {
+          setReauctionError("재경매 가능 기간이 지났거나 정보를 불러오지 못했습니다.");
+        }
+      })
+      .finally(() => {
+        if (isMounted) {
+          setIsReauctionLoading(false);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [auctionId, showReauctionPrompt]);
 
   const showToast = (message: string) => {
     setToast({ message, visible: true });
@@ -60,12 +105,58 @@ export default function AuctionDetailPage() {
     }
   };
 
+  const handleReauctionSame = async () => {
+    if (!reauctionPreview || reauctionAction) {
+      return;
+    }
+
+    try {
+      setReauctionAction("same");
+      const draft = createDraftFromReauctionPreview(reauctionPreview);
+      const result = await reauctionAuction(auctionId, draft, {
+        preserveSourceAuctionPeriod: true,
+      });
+      router.replace(`/auctions/${result.auctionId}?fromReauction=1`);
+    } catch (error) {
+      console.error("Failed to reauction:", error);
+      setReauctionError("재경매 등록에 실패했습니다.");
+      setReauctionAction(null);
+    }
+  };
+
+  const handleDeclineReauction = async () => {
+    if (reauctionAction) {
+      return;
+    }
+    if (!window.confirm("재등록하지 않으면 이 경매는 종료 처리돼요.")) {
+      return;
+    }
+
+    try {
+      setReauctionAction("decline");
+      await declineReauction(auctionId);
+      setShowReauctionPrompt(false);
+      showToast("재경매 대기를 종료했어요.");
+      router.replace("/mypage/sales-management");
+    } catch (error) {
+      console.error("Failed to decline reauction:", error);
+      setReauctionError("재등록 안 하기에 실패했습니다.");
+      setReauctionAction(null);
+    }
+  };
+
   return (
     <>
       <EventStreamProvider enabled>
         <AuctionDetailScreen
           productId={auctionId}
-          onBack={() => router.back()}
+          onBack={() => {
+            if (isFromReauction) {
+              router.replace("/");
+              return;
+            }
+            router.back();
+          }}
           onBidStatusClick={() =>
             router.push(`/auctions/${auctionId}/bidding-status`)
           }
@@ -104,10 +195,16 @@ export default function AuctionDetailPage() {
                       유찰된 경매를 다시 올려볼까요?
                     </h2>
                     <p className="text-base font-bold leading-relaxed text-gray-500">
-                      지금 선택하면 게시글을 수정하거나 그대로 다시 준비할 수 있어요.
+                      3일 안에 선택하지 않으면 재경매 대기가 자동 종료돼요.
                     </p>
                   </div>
                 </div>
+
+                {reauctionError && (
+                  <div className="rounded-xl bg-red-50 px-4 py-3 text-sm font-bold text-red-500">
+                    {reauctionError}
+                  </div>
+                )}
 
                 <button
                   type="button"
@@ -116,15 +213,36 @@ export default function AuctionDetailPage() {
                 >
                   <div className="flex items-center gap-4">
                     <div className="flex h-20 w-20 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-white text-xs font-bold text-gray-500">
-                      유찰
+                      {reauctionPreview?.images?.[0]?.imageUrl ? (
+                        <img
+                          src={reauctionPreview.images[0].imageUrl}
+                          alt={reauctionPreview.name}
+                          className="h-full w-full object-cover"
+                        />
+                      ) : (
+                        "유찰"
+                      )}
                     </div>
                     <div className="min-w-0">
                       <p className="truncate text-lg font-bold text-[#17181d]">
-                        유찰된 경매 #{auctionId}
+                        {isReauctionLoading
+                          ? "재경매 정보 확인 중"
+                          : reauctionPreview?.name ?? `유찰된 경매 #${auctionId}`}
                       </p>
                       <p className="mt-1 text-xl font-black text-[#17181d]">
                         재경매 대기
                       </p>
+                      {reauctionPreview?.reauctionExpiresAt && (
+                        <p className="mt-1 text-xs font-bold text-gray-400">
+                          {new Intl.DateTimeFormat("ko-KR", {
+                            month: "2-digit",
+                            day: "2-digit",
+                            hour: "2-digit",
+                            minute: "2-digit",
+                          }).format(new Date(reauctionPreview.reauctionExpiresAt))}
+                          까지 가능
+                        </p>
+                      )}
                     </div>
                   </div>
                 </button>
@@ -133,22 +251,27 @@ export default function AuctionDetailPage() {
               <div className="mt-3 space-y-3">
                 <div className="grid grid-cols-1 gap-3">
                   <button
-                    onClick={() => {}}
+                    onClick={handleReauctionSame}
+                    disabled={!reauctionPreview || reauctionAction !== null}
                     className="h-14 rounded-2xl bg-gray-100 text-sm font-black text-[#17181d] transition-colors hover:bg-gray-200"
                   >
-                    그대로 올리기
+                    {reauctionAction === "same" ? "등록 중" : "그대로 올리기"}
                   </button>
                   <button
-                    onClick={() => {}}
+                    onClick={() =>
+                      router.push(`/auctions/register?reauctionSourceId=${auctionId}`)
+                    }
+                    disabled={!reauctionPreview || reauctionAction !== null}
                     className="h-14 rounded-2xl bg-[#F64257] text-sm font-black text-white transition-opacity hover:opacity-90"
                   >
                     게시글 수정하기
                   </button>
                   <button
-                    onClick={() => {}}
+                    onClick={handleDeclineReauction}
+                    disabled={reauctionAction !== null}
                     className="h-14 rounded-2xl bg-gray-100 text-sm font-black text-gray-500 transition-colors hover:bg-gray-200"
                   >
-                    재등록 안 하기
+                    {reauctionAction === "decline" ? "처리 중" : "재등록 안 하기"}
                   </button>
                 </div>
               </div>

--- a/src/app/auctions/register/page.tsx
+++ b/src/app/auctions/register/page.tsx
@@ -1,7 +1,113 @@
 "use client";
 
+import { Suspense, useEffect, useState, type ReactNode } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
 import AuctionRegisterScreen from "../../products/register/AuctionRegisterScreen";
+import {
+  createDraftFromReauctionPreview,
+  getReauctionPreview,
+} from "@/services/auction/register/service";
+import type { AuctionRegisterDraft } from "@/services/auction/register/types";
+
+function AuctionRegisterPageContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const reauctionSourceAuctionId = Number(searchParams.get("reauctionSourceId"));
+  const [initialData, setInitialData] = useState<AuctionRegisterDraft | null>(
+    null,
+  );
+  const [errorMessage, setErrorMessage] = useState("");
+
+  useEffect(() => {
+    if (!reauctionSourceAuctionId) {
+      return;
+    }
+
+    let isMounted = true;
+    getReauctionPreview(reauctionSourceAuctionId)
+      .then((preview) => {
+        if (isMounted) {
+          setInitialData(createDraftFromReauctionPreview(preview));
+        }
+      })
+      .catch(() => {
+        if (isMounted) {
+          setErrorMessage("재경매 정보를 불러오지 못했습니다.");
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [reauctionSourceAuctionId]);
+
+  if (reauctionSourceAuctionId && errorMessage) {
+    return (
+      <AuctionRegisterRouteShell>
+        <div className="flex h-full items-center justify-center bg-white px-6 text-center text-sm font-bold text-gray-500">
+          {errorMessage}
+        </div>
+      </AuctionRegisterRouteShell>
+    );
+  }
+
+  if (reauctionSourceAuctionId && !initialData) {
+    return (
+      <AuctionRegisterRouteShell>
+        <div className="flex h-full items-center justify-center bg-white text-sm font-bold text-gray-400">
+          재경매 정보를 불러오는 중입니다
+        </div>
+      </AuctionRegisterRouteShell>
+    );
+  }
+
+  return (
+    <AuctionRegisterRouteShell>
+      <AuctionRegisterScreen
+        initialData={initialData ?? undefined}
+        submitMode={reauctionSourceAuctionId ? "create" : undefined}
+        reauctionSourceAuctionId={
+          reauctionSourceAuctionId || undefined
+        }
+        onComplete={(result) => {
+          const auctionId =
+            typeof result === "object" && result !== null && "auctionId" in result
+              ? Number(result.auctionId)
+              : 0;
+          router.replace(
+            auctionId
+              ? `/auctions/${auctionId}?fromReauction=1`
+              : "/mypage/sales-management",
+          );
+        }}
+      />
+    </AuctionRegisterRouteShell>
+  );
+}
+
+function AuctionRegisterRouteShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen justify-center bg-white font-sans text-[#141414]">
+      <div className="h-screen w-full max-w-[430px] overflow-hidden bg-white">
+        {children}
+      </div>
+    </div>
+  );
+}
 
 export default function AuctionRegisterPage() {
-  return <AuctionRegisterScreen />;
+  return (
+    <Suspense
+      fallback={
+        <AuctionRegisterRouteShell>
+          <div className="flex h-full items-center justify-center bg-white text-sm font-bold text-gray-400">
+            경매 등록 화면을 불러오는 중입니다
+          </div>
+        </AuctionRegisterRouteShell>
+      }
+    >
+      <AuctionRegisterPageContent />
+    </Suspense>
+  );
 }

--- a/src/app/auctions/register/page.tsx
+++ b/src/app/auctions/register/page.tsx
@@ -71,10 +71,7 @@ function AuctionRegisterPageContent() {
           reauctionSourceAuctionId || undefined
         }
         onComplete={(result) => {
-          const auctionId =
-            typeof result === "object" && result !== null && "auctionId" in result
-              ? Number(result.auctionId)
-              : 0;
+          const auctionId = getCreatedAuctionRouteId(result);
           router.replace(
             auctionId
               ? `/auctions/${auctionId}?fromReauction=1`
@@ -84,6 +81,22 @@ function AuctionRegisterPageContent() {
       />
     </AuctionRegisterRouteShell>
   );
+}
+
+function getCreatedAuctionRouteId(result: unknown) {
+  if (typeof result !== "object" || result === null) {
+    return 0;
+  }
+
+  if ("auctionId" in result) {
+    return Number(result.auctionId) || 0;
+  }
+
+  if ("productId" in result) {
+    return Number(result.productId) || 0;
+  }
+
+  return 0;
 }
 
 function AuctionRegisterRouteShell({ children }: { children: ReactNode }) {

--- a/src/app/products/register/AuctionRegisterScreen.tsx
+++ b/src/app/products/register/AuctionRegisterScreen.tsx
@@ -8,6 +8,7 @@ import {
   getAuctionCategories,
   recommendAuctionPrice,
   registerAuction,
+  reauctionAuction,
   saveAuctionDraft,
   updateAuction,
   uploadAuctionImage,
@@ -24,11 +25,15 @@ import {
 type RegisterScreenProps = ComponentProps<typeof RegisterScreen>;
 
 export default function AuctionRegisterScreen(
-  props: Omit<RegisterScreenProps, "getCategories" | "servicesByType">,
+  props: Omit<RegisterScreenProps, "getCategories" | "servicesByType"> & {
+    reauctionSourceAuctionId?: number;
+  },
 ) {
+  const { reauctionSourceAuctionId, ...screenProps } = props;
+
   return (
     <RegisterScreen
-      {...props}
+      {...screenProps}
       getCategories={getAuctionCategories}
       mode="auction"
       servicesByType={{
@@ -47,7 +52,9 @@ export default function AuctionRegisterScreen(
           deleteImage: deleteAuctionImage,
           saveDraft: saveAuctionDraft,
           recommendPrice: recommendAuctionPrice,
-          register: registerAuction,
+          register: reauctionSourceAuctionId
+            ? (draft) => reauctionAuction(reauctionSourceAuctionId, draft)
+            : registerAuction,
           update: (draft, initialData) =>
             updateAuction(initialData.auctionId, draft),
         },

--- a/src/app/products/register/RegisterScreen.tsx
+++ b/src/app/products/register/RegisterScreen.tsx
@@ -26,10 +26,11 @@ import { fetchMyLocationForm } from "@/services/mypage/service";
 
 export interface RegisterScreenProps {
   onBack?: () => void;
-  onComplete?: () => void;
+  onComplete?: (result?: unknown) => void;
   themeColor?: string;
   mode?: SaleType;
   initialData?: any;
+  submitMode?: "create" | "edit";
   getCategories: () => Promise<ProductCategory[]>;
   servicesByType: Record<SaleType, RegisterScreenServices>;
 }
@@ -141,6 +142,7 @@ export default function RegisterScreen({
   onComplete,
   mode = "regular",
   initialData,
+  submitMode,
   getCategories,
   servicesByType,
 }: RegisterScreenProps) {
@@ -184,7 +186,7 @@ export default function RegisterScreen({
       ...defaultAuction,
       ...initialData?.auction,
       startPrice: initialPriceValue,
-      bidUnit: calculateBidUnit(initialPriceValue),
+      bidUnit: initialData?.auction?.bidUnit ?? calculateBidUnit(initialPriceValue),
       durationDays,
     };
   });
@@ -200,7 +202,8 @@ export default function RegisterScreen({
   const hasLoadedDraftRef = useRef(false);
 
   const themeColor = saleType === "regular" ? "#98E446" : "#F64257";
-  const isEditMode = !!initialData;
+  const isEditMode = submitMode ? submitMode === "edit" : !!initialData;
+  const isPrefillCreateMode = submitMode === "create" && !!initialData;
   const auctionFieldContent = getAuctionFieldContent(saleType);
   const handleBack = onBack ?? (() => router.back());
   const handleComplete = onComplete ?? (() => router.push("/"));
@@ -246,13 +249,13 @@ export default function RegisterScreen({
   const currentServices = servicesByType[saleType];
 
   useEffect(() => {
-    if (!isEditMode) {
+    if (!isEditMode && !isPrefillCreateMode) {
       const savedDraft = localStorage.getItem("product_draft");
       if (savedDraft) {
         setShowLoadDraftModal(true);
       }
     }
-  }, [isEditMode]);
+  }, [isEditMode, isPrefillCreateMode]);
 
   useEffect(() => {
     if (isEditMode) {
@@ -429,13 +432,16 @@ export default function RegisterScreen({
           return;
         }
 
-        await currentServices.update(draft, initialData);
+        const result = await currentServices.update(draft, initialData);
+        localStorage.removeItem("product_draft");
+        handleComplete(result);
+        return;
       } else {
-        await currentServices.register(draft);
+        const result = await currentServices.register(draft);
+        localStorage.removeItem("product_draft");
+        handleComplete(result);
+        return;
       }
-
-      localStorage.removeItem("product_draft");
-      handleComplete();
     } catch (error) {
       console.error("Failed to submit product", error);
       showErrorMessage(
@@ -530,7 +536,7 @@ export default function RegisterScreen({
       return;
     }
 
-    if (targetImage.imageId > 0 && !isEditMode) {
+    if (targetImage.imageId > 0 && !isEditMode && !isPrefillCreateMode) {
       setDeletingImageIds((currentIds) => [...currentIds, targetImage.imageId]);
 
       try {
@@ -553,7 +559,7 @@ export default function RegisterScreen({
         })),
     );
 
-    if (targetImage.imageId > 0 && !isEditMode) {
+    if (targetImage.imageId > 0 && !isEditMode && !isPrefillCreateMode) {
       setDeletingImageIds((currentIds) =>
         currentIds.filter((imageId) => imageId !== targetImage.imageId),
       );

--- a/src/services/auction/register/api.ts
+++ b/src/services/auction/register/api.ts
@@ -12,6 +12,8 @@ import {
   RecommendCategoryResponse,
   RecommendPriceRequest,
   RecommendPriceResponse,
+  ReauctionPreviewResponse,
+  ReauctionResponse,
   SaveAuctionDraftRequest,
   SaveAuctionDraftResponse,
   UpdateAuctionRequest,
@@ -194,4 +196,60 @@ export async function patchAuction(
   }
 
   return response.json();
+}
+
+export async function getReauctionPreview(
+  auctionId: number,
+): Promise<ReauctionPreviewResponse> {
+  const response = await fetch(
+    `${AUCTIONS_API_BASE}/${auctionId}/reauction-preview`,
+    {
+      method: "GET",
+      headers: getAuthorizationHeaders(),
+      cache: "no-store",
+    },
+  );
+
+  if (!response.ok) {
+    await throwProtectedApiError(
+      response,
+      "재경매 정보를 불러오지 못했습니다.",
+    );
+  }
+
+  return response.json();
+}
+
+export async function postReauction(
+  auctionId: number,
+  payload: CreateAuctionRequest,
+): Promise<ReauctionResponse> {
+  const response = await fetch(`${AUCTIONS_API_BASE}/${auctionId}/reauction`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...getAuthorizationHeaders(),
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    await throwProtectedApiError(response, "재경매 등록에 실패했습니다.");
+  }
+
+  return response.json();
+}
+
+export async function patchDeclineReauction(auctionId: number): Promise<void> {
+  const response = await fetch(
+    `${AUCTIONS_API_BASE}/${auctionId}/reauction/decline`,
+    {
+      method: "PATCH",
+      headers: getAuthorizationHeaders(),
+    },
+  );
+
+  if (!response.ok) {
+    await throwProtectedApiError(response, "재등록 안 하기에 실패했습니다.");
+  }
 }

--- a/src/services/auction/register/service.ts
+++ b/src/services/auction/register/service.ts
@@ -7,6 +7,8 @@ import type {
   CreateAuctionRequest,
   ProductImagePayload,
   ProductSaleType,
+  ReauctionPreviewResponse,
+  ReauctionResponse,
   RecommendCategoryRequest,
   RecommendPriceRequest,
   SaleType,
@@ -127,7 +129,7 @@ export function createDraft(
       ...createDefaultAuctionForm(),
       ...draft.auction,
       startPrice,
-      bidUnit: calculateBidUnit(startPrice),
+      bidUnit: draft.auction?.bidUnit ?? calculateBidUnit(startPrice),
       durationDays:
         draft.auction?.durationDays ?? createDefaultAuctionForm().durationDays,
     },
@@ -165,6 +167,7 @@ export function toProductImagePayload(
 // Number 변환과 nullable 처리는 여기서 수행한다.
 export function buildCreateAuctionRequest(
   draft: AuctionRegisterDraft,
+  options?: { preserveSourceAuctionPeriod?: boolean },
 ): CreateAuctionRequest {
   return {
     name: draft.name,
@@ -181,7 +184,9 @@ export function buildCreateAuctionRequest(
     minimumBidAmount:
       draft.saleType === "auction" ? Number(draft.auction.bidUnit || 0) : null,
     auctionDurationDays:
-      draft.saleType === "auction" ? draft.auction.durationDays : null,
+      draft.saleType === "auction" && !options?.preserveSourceAuctionPeriod
+        ? draft.auction.durationDays
+        : null,
     allowOffer: draft.allowOffer,
     images: normalizeImagePayload(draft.images),
     location: draft.location,
@@ -283,6 +288,51 @@ export async function updateAuction(
   draft: AuctionRegisterDraft,
 ) {
   return auctionApi.patchAuction(auctionId, buildUpdateAuctionRequest(draft));
+}
+
+export async function getReauctionPreview(auctionId: number) {
+  return auctionApi.getReauctionPreview(auctionId);
+}
+
+export async function reauctionAuction(
+  auctionId: number,
+  draft: AuctionRegisterDraft,
+  options?: { preserveSourceAuctionPeriod?: boolean },
+): Promise<ReauctionResponse> {
+  return auctionApi.postReauction(
+    auctionId,
+    buildCreateAuctionRequest(draft, options),
+  );
+}
+
+export async function declineReauction(auctionId: number) {
+  return auctionApi.patchDeclineReauction(auctionId);
+}
+
+export function createDraftFromReauctionPreview(
+  preview: ReauctionPreviewResponse,
+): AuctionRegisterDraft {
+  const startPrice = String(preview.startPrice ?? "");
+  const bidUnit = String(
+    preview.minimumBidAmount ?? calculateBidUnit(startPrice),
+  );
+
+  return createDraft({
+    saleType: "auction",
+    name: preview.name,
+    description: preview.description,
+    categoryId: preview.categoryId,
+    categoryName: preview.categoryName ?? "",
+    price: startPrice,
+    startPrice,
+    location: preview.location,
+    images: preview.images,
+    auction: {
+      startPrice,
+      bidUnit,
+      durationDays: preview.auctionDurationDays || 3,
+    },
+  });
 }
 
 // 공용 등록 화면에서 사용하는 상품 등록용 함수명.

--- a/src/services/auction/register/types.ts
+++ b/src/services/auction/register/types.ts
@@ -90,6 +90,30 @@ export interface AuctionUpdateRequest {
   images: ProductImagePayload[];
 }
 
+export interface ReauctionPreviewResponse {
+  productId: number;
+  auctionId: number;
+  name: string;
+  description: string;
+  categoryId: number;
+  categoryName: string | null;
+  location: string;
+  images: ProductImagePayload[];
+  startPrice: number;
+  minimumBidAmount: number | null;
+  auctionDurationDays: number;
+  auctionStatus: "NO_BID";
+  noBidAt: string | null;
+  reauctionExpiresAt: string;
+  remainingSeconds: number;
+}
+
+export interface ReauctionResponse {
+  sourceAuctionId: number;
+  productId: number;
+  auctionId: number;
+}
+
 // 등록 성공 직후 필요한 최소 응답.
 // 상세 페이지 렌더링 데이터는 별도 상세 조회 응답으로 분리한다.
 export interface AuctionCreateResponse {

--- a/src/services/sales-management/service.ts
+++ b/src/services/sales-management/service.ts
@@ -46,7 +46,7 @@ function getAuctionStatusLabel(status: string) {
   }
 
   if (status === "NO_BID") {
-    return "유찰";
+    return "재경매 대기";
   }
 
   return "경매 종료";


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
- 재경매 그대로올리기, 수정, 종료, 3일 기간 부여 문구 추가
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
## 작업 내용

- 유찰 경매 재등록 플로우를 추가했습니다.
  - 경매 상세에서 `reauctionPrompt=1` 진입 시 재경매 선택 화면을 표시합니다.
  - 재경매 미리보기 API를 호출해 기존 상품 정보, 이미지, 가격, 재경매 가능 만료 시각을 보여줍니다.
  - `그대로 올리기`, `게시글 수정하기`, `재등록 안 하기` 액션을 연결했습니다.

- 재경매 API 연동을 추가했습니다.
  - `GET /auctions/{auctionId}/reauction-preview`
  - `POST /auctions/{auctionId}/reauction`
  - `PATCH /auctions/{auctionId}/reauction/decline`
  
재경매 
<img width="343" height="464" alt="스크린샷 2026-05-18 오후 10 04 47" src="https://github.com/user-attachments/assets/3e90f106-c3ff-4908-9354-c178d14ba97b" />

- `그대로 올리기` 동작을 분리했습니다.
  - 원본 경매 기간을 유지하기 위해 `auctionDurationDays`를 보내지 않는 옵션을 추가했습니다.
  - 재경매 성공 후 새 경매 상세로 이동하고, 해당 상세에서 뒤로가면 홈(`/`)으로 이동합니다.

말그대로 '그대로 올리기'
<img width="1417" height="390" alt="스크린샷 2026-05-18 오후 10 05 01" src="https://github.com/user-attachments/assets/46319482-ec0d-41ef-b2c3-d3f9d51da947" />

- `게시글 수정하기` 플로우를 추가했습니다.
  - `/auctions/register?reauctionSourceId={auctionId}`로 진입합니다.
  - 재경매 미리보기 데이터를 등록 폼 초기값으로 주입합니다.
  - 기존 이미지, 제목, 설명, 카테고리, 위치, 시작가, 최소 입찰 단위, 경매 기간을 폼에 반영합니다.
  - 수정 후 등록하면 재경매 API로 새 경매를 생성합니다.

게시글 수정 클릭시 등록페이지
<img width="1427" height="670" alt="스크린샷 2026-05-18 오후 10 05 41" src="https://github.com/user-attachments/assets/75862e57-8796-490e-a140-76d8abeb49dd" />

1분테스트로 수정
<img width="1429" height="350" alt="스크린샷 2026-05-18 오후 10 05 54" src="https://github.com/user-attachments/assets/710b64a6-3499-4e4d-b120-9353f4bbe893" />

'재등록 안하기'하면 없어짐

- 등록 폼 공통 로직을 보완했습니다.
  - 초기 데이터가 있어도 `submitMode="create"`일 때는 수정 모드가 아니라 신규 등록으로 처리되도록 분리했습니다.
  - 재등록 프리필 모드에서는 기존 이미지를 삭제 API로 지우지 않도록 처리했습니다.
  - 기존 최소 입찰 단위가 시작가 1% 기본값으로 덮이지 않도록 수정했습니다.
  - 등록/수정 완료 결과를 `onComplete(result)`로 받을 수 있게 했습니다.

- 판매관리 화면에서 유찰 경매 상태를 재경매 대기로 표시하고 재경매 플로우로 이동하도록 변경했습니다.
  - `NO_BID` 상태 라벨: `재경매 대기`
  - 버튼 문구: `재경매`
  - 항목 클릭 및 버튼 클릭 시 재경매 선택 화면으로 이동

- 재경매 등록 라우트 화면 폭을 일반 앱 화면과 맞췄습니다.
  - `/auctions/register`에 모바일 폭 셸을 적용해 화면이 과도하게 넓게 보이지 않도록 했습니다.

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #96 
