### PR TITLE
[Fix] 채팅방 목업 및 이미지 로딩 이슈 해결 & 판매내역과 구매내역에 문구 추가 & 배지 색상 이슈

### DIFF
--- a/src/app/(main)/mypage/purchase-history/index.tsx
+++ b/src/app/(main)/mypage/purchase-history/index.tsx
@@ -81,6 +81,22 @@ export default function PurchaseHistoryScreen({
     return option ? option.label : code;
   };
 
+  const getPurchaseStatusGuide = (status: string) => {
+    if (status === "PAID") {
+      return "판매자가 아직 상품을 보내지 않았어요.";
+    }
+    if (status === "SHIPPED") {
+      return "상품이 배송 중입니다. 상품을 받은 이후 받았어요 버튼을 눌러주세요.";
+    }
+    if (status === "COMPLETED") {
+      return "거래가 완료되었습니다.";
+    }
+    if (status === "CANCELED") {
+      return "취소된 거래입니다.";
+    }
+    return "";
+  };
+
   function handleFilterToggle(statusCode: string) {
     setSelectedStatuses((prev) => {
       const newStatuses = prev.includes(statusCode)
@@ -423,6 +439,9 @@ export default function PurchaseHistoryScreen({
                 </span>
               </div>
             </div>
+            <p className="mt-3 rounded-lg bg-gray-50 px-3 py-2 text-xs leading-relaxed text-gray-500">
+              {getPurchaseStatusGuide(purchase.status)}
+            </p>
             <button
               onClick={() => setSelectedItem({ ...purchase, history: [] })}
               className="w-full mt-4 py-2 bg-gray-50 hover:bg-gray-100 text-gray-600 text-sm font-medium rounded-lg transition-colors flex items-center justify-center space-x-1"

--- a/src/app/(main)/mypage/sales-history/index.tsx
+++ b/src/app/(main)/mypage/sales-history/index.tsx
@@ -81,6 +81,22 @@ export default function SalesHistoryScreen({
     return option ? option.label : code;
   };
 
+  const getSaleStatusGuide = (status: string) => {
+    if (status === "PAID") {
+      return "결제가 완료되었습니다. 상품 전달 후 보냈어요를 눌러주세요.";
+    }
+    if (status === "SHIPPED") {
+      return "상품을 보냈어요. 구매자의 수령확정을 기다리고 있습니다.";
+    }
+    if (status === "COMPLETED") {
+      return "거래가 완료되었습니다.";
+    }
+    if (status === "CANCELED") {
+      return "취소된 거래입니다.";
+    }
+    return "";
+  };
+
   function handleFilterToggle(statusCode: string) {
     setSelectedStatuses((prev) => {
       const newStatuses = prev.includes(statusCode)
@@ -410,6 +426,9 @@ export default function SalesHistoryScreen({
                 <span className="font-bold mt-1">{sale.amountFormatted}</span>
               </div>
             </div>
+            <p className="mt-3 rounded-lg bg-gray-50 px-3 py-2 text-xs leading-relaxed text-gray-500">
+              {getSaleStatusGuide(sale.status)}
+            </p>
             <button
               onClick={() => setSelectedItem({ ...sale, history: [] })}
               className="w-full mt-4 py-2 bg-gray-50 hover:bg-gray-100 text-gray-600 text-sm font-medium rounded-lg transition-colors flex items-center justify-center space-x-1"

--- a/src/app/chats/[roomId]/index.tsx
+++ b/src/app/chats/[roomId]/index.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ChevronLeft, PackageCheck, PlusCircle, Send, Truck } from "lucide-react";
+import {
+  ChevronLeft,
+  PackageCheck,
+  PlusCircle,
+  Send,
+  Truck,
+} from "lucide-react";
 import { motion } from "motion/react";
 import { useRouter } from "next/navigation";
 
@@ -36,7 +42,6 @@ interface ChatRoomScreenProps {
   draftProductId?: number | null;
   purchaseId?: number | null;
   onBack?: () => void;
-  onProductClick?: (id: number) => void;
   themeColor: string;
 }
 
@@ -45,7 +50,6 @@ export default function ChatRoomScreen({
   draftProductId = null,
   purchaseId: _purchaseId = null,
   onBack,
-  onProductClick,
   themeColor,
 }: ChatRoomScreenProps) {
   const router = useRouter();
@@ -53,6 +57,7 @@ export default function ChatRoomScreen({
   const [isError, setIsError] = useState(false);
 
   const [roomName, setRoomName] = useState("");
+  const [chatType, setChatType] = useState<"GENERAL" | "AUCTION" | null>(null);
   const [productId, setProductId] = useState<number>(0);
   const [auctionId, setAuctionId] = useState<number | null>(null);
   const [productName, setProductName] = useState("");
@@ -66,7 +71,9 @@ export default function ChatRoomScreen({
   const [draftMessage, setDraftMessage] = useState("");
   const [isSending, setIsSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
-  const [tradeActionMessage, setTradeActionMessage] = useState<string | null>(null);
+  const [tradeActionMessage, setTradeActionMessage] = useState<string | null>(
+    null,
+  );
   const [tradeActionLoading, setTradeActionLoading] = useState<
     "SHIP" | "CONFIRM_RECEIPT" | null
   >(null);
@@ -107,6 +114,7 @@ export default function ChatRoomScreen({
       setIsLoading(false);
       setIsError(false);
       setRoomName("채팅방");
+      setChatType(null);
       setProductId(draftProductId ?? 0);
       setProductName(draftProductId ? `상품 #${draftProductId}` : "상품 정보");
       setProductImageUrl(null);
@@ -132,6 +140,7 @@ export default function ChatRoomScreen({
         if (!mounted) return;
 
         setRoomName(detail.room.opponentName);
+        setChatType(detail.room.chatType ?? null);
         setProductId(detail.room.productId);
         setAuctionId(detail.room.auctionId ?? null);
         setProductName(detail.room.productName);
@@ -277,12 +286,15 @@ export default function ChatRoomScreen({
     router.back();
   };
 
-  const handleProductClick = (id: number) => {
-    if (onProductClick) {
-      onProductClick(id);
+  const handleProductClick = () => {
+    if (chatType === "AUCTION" && auctionId) {
+      router.push(`/auctions/${auctionId}`);
       return;
     }
-    router.push(`/products/${id}`);
+
+    if (productId) {
+      router.push(`/products/${productId}`);
+    }
   };
 
   const getTradeActionErrorMessage = (code: string | null) => {
@@ -370,6 +382,7 @@ export default function ChatRoomScreen({
       if (roomId == null && draftProductId) {
         const room = await createChatRoom({ productId: draftProductId });
         roomId = room.roomId;
+        setChatType(room.chatType ?? null);
         setRoomName(
           room.participants.find((participant) => participant.role === "SELLER")
             ?.nickname ?? "채팅방",
@@ -443,12 +456,16 @@ export default function ChatRoomScreen({
     if (chatId == null || tradeActionLoading) return;
 
     if (type === "SHIP" && !actionButtons?.canShip) {
-      setTradeActionMessage("발송 처리 가능 시간이 지났거나 현재 발송 처리할 수 없는 상태입니다.");
+      setTradeActionMessage(
+        "발송 처리 가능 시간이 지났거나 현재 발송 처리할 수 없는 상태입니다.",
+      );
       return;
     }
 
     if (type === "CONFIRM_RECEIPT" && !actionButtons?.canConfirmReceipt) {
-      setTradeActionMessage("아직 판매자가 '보냈어요'를 누르기 전입니다. 발송 처리 후 수령확정할 수 있습니다.");
+      setTradeActionMessage(
+        "아직 판매자가 '보냈어요'를 누르기 전입니다. 발송 처리 후 수령확정할 수 있습니다.",
+      );
       return;
     }
 
@@ -505,7 +522,7 @@ export default function ChatRoomScreen({
 
       <div
         className="shrink-0 p-4 border-b border-gray-50 flex items-center space-x-4 bg-gray-50/50 cursor-pointer hover:bg-gray-100 transition-colors"
-        onClick={() => productId && handleProductClick(productId)}
+        onClick={handleProductClick}
       >
         <div className="w-12 h-12 rounded-lg overflow-hidden bg-gray-100 shrink-0">
           {productImageUrl ? (
@@ -544,7 +561,9 @@ export default function ChatRoomScreen({
             {actionButtons?.shipButtonType === "SHIP" && (
               <button
                 type="button"
-                aria-disabled={!actionButtons.canShip || tradeActionLoading !== null}
+                aria-disabled={
+                  !actionButtons.canShip || tradeActionLoading !== null
+                }
                 onClick={() => void handleTradeAction("SHIP")}
                 className={`inline-flex h-10 flex-1 items-center justify-center gap-2 rounded-lg px-3 text-xs font-bold ${
                   actionButtons.canShip && tradeActionLoading === null
@@ -560,17 +579,20 @@ export default function ChatRoomScreen({
               <button
                 type="button"
                 aria-disabled={
-                  !actionButtons.canConfirmReceipt || tradeActionLoading !== null
+                  !actionButtons.canConfirmReceipt ||
+                  tradeActionLoading !== null
                 }
                 onClick={() => void handleTradeAction("CONFIRM_RECEIPT")}
                 className="inline-flex h-10 flex-1 items-center justify-center gap-2 rounded-lg px-3 text-xs font-bold text-white"
                 style={{
                   backgroundColor:
-                    actionButtons.canConfirmReceipt && tradeActionLoading === null
+                    actionButtons.canConfirmReceipt &&
+                    tradeActionLoading === null
                       ? themeColor
                       : "#e5e7eb",
                   color:
-                    actionButtons.canConfirmReceipt && tradeActionLoading === null
+                    actionButtons.canConfirmReceipt &&
+                    tradeActionLoading === null
                       ? "#ffffff"
                       : "#6b7280",
                 }}
@@ -599,7 +621,9 @@ export default function ChatRoomScreen({
             <button
               onClick={() => void handlePurchaseTradeAction()}
               disabled={
-                purchaseActionLoading || !actionButton.enabled || !roomPurchaseId
+                purchaseActionLoading ||
+                !actionButton.enabled ||
+                !roomPurchaseId
               }
               className="w-full h-12 rounded-xl font-bold text-sm border border-gray-200 bg-black text-white disabled:bg-gray-200 disabled:text-gray-400 disabled:border-gray-200"
             >
@@ -660,7 +684,7 @@ export default function ChatRoomScreen({
       </div>
 
       {showReviewPrompt && (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center p-6">
+        <div className="fixed inset-0 z-100 flex items-center justify-center p-6">
           <div
             className="absolute inset-0 bg-black/40 backdrop-blur-sm"
             onClick={() => setShowReviewPrompt(false)}
@@ -738,7 +762,9 @@ export default function ChatRoomScreen({
         </button>
       </div>
       {sendError && (
-        <div className="shrink-0 px-4 pb-3 text-xs text-red-500">{sendError}</div>
+        <div className="shrink-0 px-4 pb-3 text-xs text-red-500">
+          {sendError}
+        </div>
       )}
     </motion.div>
   );

--- a/src/app/chats/[roomId]/page.tsx
+++ b/src/app/chats/[roomId]/page.tsx
@@ -1,26 +1,3 @@
-/*
-"use client";
-
-import { useParams, useRouter } from "next/navigation";
-
-import ChatRoomScreen from "./index";
-
-export default function ChatRoomPage() {
-  const params = useParams<{ roomId: string }>();
-  const router = useRouter();
-  const roomId = Number(params.roomId) || 1;
-
-  return (
-    <ChatRoomScreen
-      chatId={roomId}
-      onBack={() => router.back()}
-      onProductClick={(id) => router.push(`/products/${id}`)}
-      themeColor="#98E446"
-    />
-  );
-}
-*/
-
 import { notFound } from "next/navigation";
 import ChatRoomScreen from "./index";
 

--- a/src/app/chats/index.tsx
+++ b/src/app/chats/index.tsx
@@ -329,18 +329,12 @@ export default function ChatListScreen({
                       {chat.productName}
                     </span>
                     <span
-                      className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${
-                        chat.productTypeLabel === "Deal it!"
-                          ? "bg-red-50 text-red-500"
-                          : ""
-                      }`}
+                      className="text-[10px] font-bold px-1.5 py-0.5 rounded"
                       style={
-                        chat.productTypeLabel !== "Deal it!"
-                          ? {
-                              backgroundColor: `${themeColor}15`,
-                              color: themeColor,
-                            }
-                          : undefined
+                        chat.chatType === "AUCTION" ||
+                        chat.productTypeLabel === "Deal it!"
+                          ? { backgroundColor: "#FEF2F2", color: "#EF4444" }
+                          : { backgroundColor: "#F1FBE8", color: "#65C91F" }
                       }
                     >
                       {chat.productTypeLabel}

--- a/src/app/chats/new/page.tsx
+++ b/src/app/chats/new/page.tsx
@@ -17,7 +17,6 @@ function NewChatRoomPageContent() {
       chatId={null}
       draftProductId={parsedProductId}
       onBack={() => router.back()}
-      onProductClick={(id) => router.push(`/products/${id}`)}
       themeColor="#98E446"
     />
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1253,10 +1253,6 @@ export default function App() {
                 key="chat_room"
                 chatId={selectedChatId}
                 onBack={() => navigateTo("main")}
-                onProductClick={(id) => {
-                  setSelectedProductId(id);
-                  navigateTo("product_detail");
-                }}
                 themeColor={themeColor}
               />
             )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -242,7 +242,9 @@ const buildUrl = (
         ? `/auctions/${safeProductId}/winning-complete`
         : "/notifications";
     case "outbid_notification":
-      return safeProductId ? `/auctions/${safeProductId}/outbid` : "/notifications";
+      return safeProductId
+        ? `/auctions/${safeProductId}/outbid`
+        : "/notifications";
     case "search_detail":
       return "/search/detail";
     case "wishlist":
@@ -273,14 +275,17 @@ const buildUrl = (
       return "/mypage/review/write";
     case "chat_room":
       if (safeChatId) return `/chats/${safeChatId}`;
-      if (chatDraftProductId) return `/chats/new?productId=${chatDraftProductId}`;
+      if (chatDraftProductId)
+        return `/chats/new?productId=${chatDraftProductId}`;
       return "/chats";
     case "bid_placement_complete": {
       const query =
         typeof bidAmount === "number" && Number.isFinite(bidAmount)
           ? `?bidPrice=${bidAmount}`
           : "";
-      return safeProductId ? `/auctions/${safeProductId}/bid-complete${query}` : "/auctions";
+      return safeProductId
+        ? `/auctions/${safeProductId}/bid-complete${query}`
+        : "/auctions";
     }
     default:
       return "/";
@@ -307,7 +312,10 @@ const routeStateFromUrl = (url: URL): RouteState | null => {
   if (pathname === "/profile-setup") return { screen: "profile_setup" };
   if (pathname === "/category-selection") {
     return {
-      screen: searchParams.get("mode") === "edit" ? "category_reset" : "category_selection",
+      screen:
+        searchParams.get("mode") === "edit"
+          ? "category_reset"
+          : "category_selection",
     };
   }
   if (pathname === "/search") return { screen: "main", tab: "search" };
@@ -347,7 +355,8 @@ const routeStateFromUrl = (url: URL): RouteState | null => {
   if (pathname === "/mypage/my-bids") return { screen: "my_bids" };
   if (pathname === "/mypage/review") return { screen: "review" };
   if (pathname === "/mypage/review/write") return { screen: "write_review" };
-  if (pathname === "/products/register") return { screen: "main", tab: "register" };
+  if (pathname === "/products/register")
+    return { screen: "main", tab: "register" };
   if (pathname === "/products") {
     return {
       screen: "product_list",
@@ -376,10 +385,18 @@ const routeStateFromUrl = (url: URL): RouteState | null => {
     return { screen: "receipt", productId: readId(2), themeMode: "regular" };
   }
   if (/^\/products\/\d+\/regular-purchase$/.test(pathname)) {
-    return { screen: "regular_purchase", productId: readId(2), themeMode: "regular" };
+    return {
+      screen: "regular_purchase",
+      productId: readId(2),
+      themeMode: "regular",
+    };
   }
   if (/^\/products\/\d+$/.test(pathname)) {
-    return { screen: "product_detail", productId: readId(2), themeMode: "regular" };
+    return {
+      screen: "product_detail",
+      productId: readId(2),
+      themeMode: "regular",
+    };
   }
   if (pathname === "/auctions") {
     return {
@@ -397,7 +414,11 @@ const routeStateFromUrl = (url: URL): RouteState | null => {
     };
   }
   if (/^\/auctions\/\d+\/bidding-status$/.test(pathname)) {
-    return { screen: "bidding_status", productId: readId(2), themeMode: "auction" };
+    return {
+      screen: "bidding_status",
+      productId: readId(2),
+      themeMode: "auction",
+    };
   }
   if (/^\/auctions\/\d+\/bid-complete$/.test(pathname)) {
     return {
@@ -414,10 +435,18 @@ const routeStateFromUrl = (url: URL): RouteState | null => {
     };
   }
   if (/^\/auctions\/\d+\/outbid$/.test(pathname)) {
-    return { screen: "outbid_notification", productId: readId(2), themeMode: "auction" };
+    return {
+      screen: "outbid_notification",
+      productId: readId(2),
+      themeMode: "auction",
+    };
   }
   if (/^\/auctions\/\d+$/.test(pathname)) {
-    return { screen: "product_detail", productId: readId(2), themeMode: "auction" };
+    return {
+      screen: "product_detail",
+      productId: readId(2),
+      themeMode: "auction",
+    };
   }
 
   return null;
@@ -554,7 +583,7 @@ export default function App() {
       tab: currentTab,
       productId:
         currentScreen === "bid_placement_complete"
-          ? bidData?.productId ?? selectedProductId
+          ? (bidData?.productId ?? selectedProductId)
           : selectedProductId,
       chatId: selectedChatId,
       chatDraftProductId: selectedChatDraftProductId,
@@ -604,7 +633,9 @@ export default function App() {
   };
 
   const navigateToCatalogItem = (id: number) => {
-    router.push(themeMode === "auction" ? `/auctions/${id}` : `/products/${id}`);
+    router.push(
+      themeMode === "auction" ? `/auctions/${id}` : `/products/${id}`,
+    );
   };
 
   const openProductChat = async () => {

--- a/src/services/chats/service.ts
+++ b/src/services/chats/service.ts
@@ -39,6 +39,20 @@ import type {
  * 내부 유틸
  * ========================= */
 
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL?.replace(/\/$/, "") ?? "";
+
+function resolveChatProductImageUrl(
+  imageUrl: string | null | undefined,
+): string | null {
+  if (!imageUrl) return null;
+  // data:, blob:, http(s):// 은 그대로 사용
+  if (/^(data:|blob:|https?:\/\/)/.test(imageUrl)) return imageUrl;
+  // 상대 경로이면 API_BASE_URL을 붙임
+  if (imageUrl.startsWith("/")) return `${API_BASE_URL}${imageUrl}`;
+  return imageUrl;
+}
+
 function toProductTypeLabel(type: ChatRoomType): "Deal it!" | "일반 판매" {
   return type === "AUCTION" ? "Deal it!" : "일반 판매";
 }
@@ -125,7 +139,7 @@ function toRoomDetailVM(response: CreateChatRoomResponse): ChatRoomDetailVM {
     productId: response.product.productId,
     auctionId: response.product.auctionId ?? null,
     productName: response.product.name ?? `상품 #${response.product.productId}`,
-    productImageUrl: response.product.thumbnailUrl ?? null,
+    productImageUrl: resolveChatProductImageUrl(response.product.thumbnailUrl),
     productStatusLabel:
       response.chatType === "AUCTION" ? "Deal it! 거래" : "거래 중",
     chatType: response.chatType,

--- a/src/styles/badgeColors.ts
+++ b/src/styles/badgeColors.ts
@@ -1,0 +1,6 @@
+// Badge colors for chat product types
+export const badgeColors: Record<string, { bg: string; color: string }> = {
+  AUCTION: { bg: "#FEF2F2", color: "#EF4444" },
+  GENERAL: { bg: "#F1FBE8", color: "#65C91F" },
+  DEFAULT: { bg: "#F1FBE8", color: "#65C91F" },
+};


### PR DESCRIPTION
### 🚀 Summary

채팅방 상세 이동, 채팅 배지 색상, 이미지 URL 처리, 판매/구매내역 안내 문구를 정리했습니다.

- 채팅 목록 배지를 `chatType` 기준으로 분리해 경매/일반 판매 색상을 구분했습니다.
- 채팅방 상단 상품 이미지가 상대 경로로 내려오는 경우를 대비해 API base URL을 붙여 표시하도록 처리했습니다.
- 채팅방 상세보기 버튼이 현재 채팅방 상태(`chatType`, `productId`, `auctionId`) 기준으로 올바른 상세 페이지로 이동하도록 정리했습니다.
- 판매내역/구매내역 카드에 상태별 안내 문구를 추가했습니다.

---

### ✨ Description

#### 수정한 파일

- `src/app/chats/index.tsx`
- `src/services/chats/service.ts`
- `src/app/chats/[roomId]/index.tsx`
- `src/app/chats/[roomId]/page.tsx`
- `src/app/chats/new/page.tsx`
- `src/app/(main)/mypage/sales-history/index.tsx`
- `src/app/(main)/mypage/purchase-history/index.tsx`

#### 작업 내용

1. 채팅 목록 배지 색상 수정
	- 경매 채팅은 빨강, 일반 판매 채팅은 초록으로 고정했습니다.
	- 전역 `themeColor` 영향을 받지 않도록 분리했습니다.

2. 채팅방 상단 상품 이미지 처리 수정
	- `thumbnailUrl`이 `/uploads/...` 같은 상대 경로로 내려오는 경우를 대비해 `NEXT_PUBLIC_API_BASE_URL`을 붙여 표시하도록 처리했습니다.

3. 채팅방 상세보기 버튼 이동 로직 수정
	- `chatType`, `productId`, `auctionId` 기준으로 현재 채팅방의 원본 상품 상세로 이동하도록 정리했습니다.
	- 경매 채팅이면 `/auctions/{auctionId}`로, 일반 판매면 `/products/{productId}`로 이동합니다.

4. 판매내역 / 구매내역 안내 문구 추가
	- 상태 라벨 아래, 상세보기 버튼 위에 역할별 안내 문구를 추가했습니다.

#### 실행 결과
1. 경매 토글 배지 색상
<img width="706" height="1296" alt="경매상태에서배지색상" src="https://github.com/user-attachments/assets/4f2b5acf-a99d-4332-bee5-3b7cd9f6c100" />

2. 채팅방 상태
<img width="817" height="1284" alt="채팅방 목업제거ㅗ" src="https://github.com/user-attachments/assets/74ced9c8-2a7f-43f3-82b6-bd20c808b181" />

3. 판매내역 구매내역 문구 추가
<img width="2547" height="773" alt="구매자문구" src="https://github.com/user-attachments/assets/47eb5000-67f7-4b22-93ec-e52fd926a758" />

<img width="811" height="1299" alt="판매자문구" src="https://github.com/user-attachments/assets/0581e324-3127-4e17-b12e-fbe6fb6adca2" />


#### 확인 사항

- 채팅 목록에서 경매/일반 판매 배지 색상이 의도대로 나오는지 확인했습니다.
- 채팅방 상단 상품 이미지가 정상적으로 로드되는지 확인했습니다.
- 채팅방 상세보기 버튼이 올바른 상세 페이지로 이동하는지 확인했습니다.
- 판매내역 / 구매내역 카드의 상태 안내 문구가 정상 노출되는지 확인했습니다.

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{Issue Number}
