### PR TITLE
[fix] 채팅 푸쉬 알림 부분 억제

### DIFF
--- a/src/services/notifications/ForegroundNotificationListener.tsx
+++ b/src/services/notifications/ForegroundNotificationListener.tsx
@@ -46,6 +46,22 @@ function openNotificationTarget(targetUrl: string) {
   window.location.assign(new URL(targetUrl, window.location.origin).href);
 }
 
+function shouldSuppressForegroundNotification(payload: {
+  data?: Record<string, string>;
+}) {
+  const data = payload.data || {};
+  if (data.type !== "CHAT_MESSAGE") {
+    return false;
+  }
+
+  const pathname = window.location.pathname;
+  if (pathname === "/chats") {
+    return true;
+  }
+
+  return Boolean(data.roomId && pathname === `/chats/${data.roomId}`);
+}
+
 export function ForegroundNotificationListener() {
   useEffect(() => {
     let unsubscribe: (() => void) | undefined;
@@ -83,6 +99,10 @@ export function ForegroundNotificationListener() {
 
     listenForegroundFcmMessages((payload) => {
       console.log("foreground FCM message received:", payload);
+
+      if (shouldSuppressForegroundNotification(payload)) {
+        return;
+      }
 
       if (Notification.permission !== "granted") {
         return;


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
채팅 화면 진입 상태에 따라 채팅 푸쉬 알림 표시를 제어하도록 개선했습니다.
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
 - 포그라운드 채팅 메시지 알림 표시 조건 추가
      - 현재 화면이 채팅 목록이면 알림 표시 안 함
      - 현재 화면이 같은 채팅방이면 알림 표시 안 함
      - 다른 화면에서는 기존처럼 알림 표시
      
  - 테스트
      - npm run build 통과
---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #102 
