### PR TITLE
[refactor] 자세히 보기 페이지

### DIFF
--- a/src/app/(main)/mypage/purchase-history/[purchaseId]/receipt/page.tsx
+++ b/src/app/(main)/mypage/purchase-history/[purchaseId]/receipt/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import React from "react";
+import { useParams } from "next/navigation";
+import TransactionReceipt from "../../../../../../components/transaction-receipt/TransactionReceipt";
+
+export default function PurchaseReceiptPage() {
+  const params = useParams();
+  const purchaseId = Number(params?.purchaseId ?? NaN);
+  if (Number.isNaN(purchaseId)) return <div>유효하지 않은 ID</div>;
+  return (
+    <TransactionReceipt mode="purchase" id={purchaseId} themeColor="#98E446" />
+  );
+}

--- a/src/app/(main)/mypage/purchase-history/[purchaseId]/receipt/page.tsx
+++ b/src/app/(main)/mypage/purchase-history/[purchaseId]/receipt/page.tsx
@@ -1,14 +1,20 @@
 "use client";
 
 import React from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import TransactionReceipt from "../../../../../../components/transaction-receipt/TransactionReceipt";
 
 export default function PurchaseReceiptPage() {
   const params = useParams();
+  const router = useRouter();
   const purchaseId = Number(params?.purchaseId ?? NaN);
   if (Number.isNaN(purchaseId)) return <div>유효하지 않은 ID</div>;
   return (
-    <TransactionReceipt mode="purchase" id={purchaseId} themeColor="#98E446" />
+    <TransactionReceipt
+      mode="purchase"
+      id={purchaseId}
+      themeColor="#98E446"
+      onBack={() => router.push("/mypage/purchase-history")}
+    />
   );
 }

--- a/src/app/(main)/mypage/purchase-history/index.tsx
+++ b/src/app/(main)/mypage/purchase-history/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import {
   ChevronLeft,
   Check,
@@ -46,6 +47,7 @@ export default function PurchaseHistoryScreen({
   key?: string;
 }) {
   console.log("[PH index] render");
+  const router = useRouter();
   const dedupeById = (items: any[]) =>
     Array.from(new Map(items.map((item) => [item.id, item])).values());
   const [selectedItem, setSelectedItem] = useState<any>(null);
@@ -443,7 +445,10 @@ export default function PurchaseHistoryScreen({
               {getPurchaseStatusGuide(purchase.status)}
             </p>
             <button
-              onClick={() => setSelectedItem({ ...purchase, history: [] })}
+              onClick={() => {
+                setSelectedItem(null);
+                router.push(`/mypage/purchase-history/${purchase.id}/receipt`);
+              }}
               className="w-full mt-4 py-2 bg-gray-50 hover:bg-gray-100 text-gray-600 text-sm font-medium rounded-lg transition-colors flex items-center justify-center space-x-1"
             >
               <span>자세히 보기</span>

--- a/src/app/(main)/mypage/sales-history/[purchaseId]/receipt/page.tsx
+++ b/src/app/(main)/mypage/sales-history/[purchaseId]/receipt/page.tsx
@@ -1,12 +1,20 @@
 "use client";
 
 import React from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import TransactionReceipt from "../../../../../../components/transaction-receipt/TransactionReceipt";
 
 export default function SalesReceiptPage() {
   const params = useParams();
+  const router = useRouter();
   const saleId = Number(params?.purchaseId ?? NaN);
   if (Number.isNaN(saleId)) return <div>유효하지 않은 ID</div>;
-  return <TransactionReceipt mode="sale" id={saleId} themeColor="#f97316" />;
+  return (
+    <TransactionReceipt
+      mode="sale"
+      id={saleId}
+      themeColor="#f97316"
+      onBack={() => router.push("/mypage/sales-history")}
+    />
+  );
 }

--- a/src/app/(main)/mypage/sales-history/[purchaseId]/receipt/page.tsx
+++ b/src/app/(main)/mypage/sales-history/[purchaseId]/receipt/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import React from "react";
+import { useParams } from "next/navigation";
+import TransactionReceipt from "../../../../../../components/transaction-receipt/TransactionReceipt";
+
+export default function SalesReceiptPage() {
+  const params = useParams();
+  const saleId = Number(params?.purchaseId ?? NaN);
+  if (Number.isNaN(saleId)) return <div>유효하지 않은 ID</div>;
+  return <TransactionReceipt mode="sale" id={saleId} themeColor="#f97316" />;
+}

--- a/src/app/(main)/mypage/sales-history/index.tsx
+++ b/src/app/(main)/mypage/sales-history/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState, useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
 import {
   ChevronLeft,
   Check,
@@ -46,6 +47,7 @@ export default function SalesHistoryScreen({
   key?: string;
 }) {
   console.log("[SH index] render");
+  const router = useRouter();
   const dedupeById = (items: any[]) =>
     Array.from(new Map(items.map((item) => [item.id, item])).values());
   const [selectedItem, setSelectedItem] = useState<any>(null);
@@ -430,7 +432,10 @@ export default function SalesHistoryScreen({
               {getSaleStatusGuide(sale.status)}
             </p>
             <button
-              onClick={() => setSelectedItem({ ...sale, history: [] })}
+              onClick={() => {
+                setSelectedItem(null);
+                router.push(`/mypage/sales-history/${sale.id}/receipt`);
+              }}
               className="w-full mt-4 py-2 bg-gray-50 hover:bg-gray-100 text-gray-600 text-sm font-medium rounded-lg transition-colors flex items-center justify-center space-x-1"
             >
               <span>자세히 보기</span>

--- a/src/components/transaction-receipt/TransactionReceipt.tsx
+++ b/src/components/transaction-receipt/TransactionReceipt.tsx
@@ -300,7 +300,7 @@ export default function TransactionReceipt({
                 거래일자:
               </span>
               <span style={{ fontSize: 15, color: "#111", lineHeight: 1.6 }}>
-                {formatDate(data.purchasedAt ?? data.createdAt ?? data.paidAt)}
+                {formatDate(data.purchasedAt ?? data.paidAt)}
               </span>
             </div>
             <div

--- a/src/components/transaction-receipt/TransactionReceipt.tsx
+++ b/src/components/transaction-receipt/TransactionReceipt.tsx
@@ -1,0 +1,419 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ChevronLeft } from "lucide-react";
+import {
+  getPurchaseReceipt,
+  getSalesReceipt,
+} from "../../services/mypage/transaction-receipt";
+import type { TransactionReceiptResponse } from "../../services/mypage/transaction-receipt";
+
+interface Props {
+  mode: "purchase" | "sale";
+  id: number;
+  onBack?: () => void;
+  themeColor?: string;
+}
+
+export default function TransactionReceipt({
+  mode,
+  id,
+  onBack,
+  themeColor,
+}: Props) {
+  const router = useRouter();
+  const [data, setData] = useState<TransactionReceiptResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<any>(null);
+
+  useEffect(() => {
+    let aborted = false;
+    setLoading(true);
+    setError(null);
+
+    const loader = async () => {
+      try {
+        const res =
+          mode === "purchase"
+            ? await getPurchaseReceipt(id)
+            : await getSalesReceipt(id);
+        if (!aborted) setData(res);
+      } catch (e: any) {
+        if (!aborted) setError(e);
+      } finally {
+        if (!aborted) setLoading(false);
+      }
+    };
+
+    loader();
+    return () => {
+      aborted = true;
+    };
+  }, [mode, id]);
+
+  const handleBack = () => {
+    if (onBack) return onBack();
+    router.back();
+  };
+
+  if (loading) return <div>로딩 중...</div>;
+  if (error)
+    return (
+      <div>
+        <div>오류가 발생했습니다.</div>
+        <div>{error?.message || "네트워크 오류"}</div>
+        <button onClick={handleBack}>뒤로가기</button>
+      </div>
+    );
+
+  if (!data) return <div>데이터가 없습니다.</div>;
+
+  const getStatusLabel = (status: string) => {
+    switch (status) {
+      case "PAID":
+        return "결제 완료";
+      case "SHIPPED":
+        return "배송 중";
+      case "COMPLETED":
+        return "거래 완료";
+      case "CANCELED":
+        return "취소";
+      case "PENDING":
+        return "대기 중";
+      default:
+        return status;
+    }
+  };
+
+  const getProductTypeLabel = (type: string) => {
+    switch (type) {
+      case "REGULAR":
+        return "일반 판매";
+      case "AUCTION":
+        return "경매";
+      default:
+        return type;
+    }
+  };
+
+  const formatPrice = (price: number | undefined) => {
+    if (price == null) return "-";
+    try {
+      return new Intl.NumberFormat("ko-KR").format(price) + "원";
+    } catch {
+      return String(price) + "원";
+    }
+  };
+
+  const getProductName = (d: any) => {
+    // common top-level fields
+    const topKeys = [
+      "productName",
+      "product_name",
+      "title",
+      "name",
+      "itemName",
+      "productTitle",
+      "label",
+    ];
+    for (const k of topKeys) {
+      if (
+        d &&
+        d[k] !== undefined &&
+        d[k] !== null &&
+        String(d[k]).trim() !== ""
+      )
+        return d[k];
+    }
+
+    // common nested containers
+    const nests = [
+      "product",
+      "item",
+      "productInfo",
+      "productDto",
+      "payload",
+      "data",
+    ];
+    for (const n of nests) {
+      const obj = d?.[n];
+      if (!obj) continue;
+      for (const k of topKeys) {
+        if (
+          obj &&
+          obj[k] !== undefined &&
+          obj[k] !== null &&
+          String(obj[k]).trim() !== ""
+        )
+          return obj[k];
+      }
+      // common fields
+      if (typeof obj === "string" && obj.trim() !== "") return obj;
+      if (obj?.title) return obj.title;
+      if (obj?.name) return obj.name;
+    }
+
+    // fallback: any string field that mentions product
+    for (const key of Object.keys(d || {})) {
+      if (
+        typeof d[key] === "string" &&
+        key.toLowerCase().includes("product") &&
+        d[key].trim() !== ""
+      )
+        return d[key];
+    }
+
+    return "-";
+  };
+
+  const getPriceDisplay = (d: any) => {
+    // check numeric fields first
+    if (typeof d.price === "number") return formatPrice(d.price);
+    if (typeof d.amount === "number") return formatPrice(d.amount);
+    // formatted string fields
+    if (typeof d.amountFormatted === "string" && d.amountFormatted.trim())
+      return d.amountFormatted;
+    if (typeof d.price === "string" && d.price.trim()) return d.price + "원";
+    // fallback
+    return "-";
+  };
+
+  const formatDate = (iso?: string | null) => {
+    if (!iso) return "-";
+    try {
+      const dt = new Date(iso);
+      return dt.toLocaleString("ko-KR");
+    } catch {
+      return iso;
+    }
+  };
+
+  return (
+    <div
+      style={{
+        background: "#f3f4f6",
+        padding: 20,
+        display: "flex",
+        justifyContent: "center",
+        minHeight: "100vh",
+        boxSizing: "border-box",
+      }}
+    >
+      <div style={{ width: "100%", maxWidth: 900 }}>
+        <header
+          style={{ display: "flex", alignItems: "center", marginBottom: 12 }}
+        >
+          <button
+            onClick={handleBack}
+            aria-label="뒤로가기"
+            style={{
+              padding: 8,
+              marginLeft: -8,
+              border: "none",
+              background: "transparent",
+              cursor: "pointer",
+            }}
+          >
+            <ChevronLeft size={24} />
+          </button>
+          <h2 style={{ marginLeft: 12, fontSize: 20 }}>
+            {mode === "purchase" ? "구매 영수증" : "판매 영수증"}
+          </h2>
+        </header>
+
+        <section
+          style={{
+            background: "#fff",
+            padding: 16,
+            borderRadius: 8,
+            marginBottom: 14,
+          }}
+        >
+          <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+            <img
+              src={data.productImageUrl ?? "/placeholder.png"}
+              alt={getProductName(data)}
+              style={{
+                width: 120,
+                height: 120,
+                objectFit: "cover",
+                borderRadius: 8,
+              }}
+            />
+            <div style={{ flex: 1 }}>
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                }}
+              >
+                <div>
+                  <div style={{ fontWeight: 700, fontSize: 20 }}>
+                    {getProductName(data)}
+                  </div>
+                  <div style={{ color: "#6b7280", marginTop: 8, fontSize: 14 }}>
+                    {getProductTypeLabel(data.productType)}
+                  </div>
+                </div>
+                <div style={{ fontWeight: 900, fontSize: 20 }}>
+                  {getPriceDisplay(data)}
+                </div>
+              </div>
+              <div style={{ marginTop: 10, fontSize: 15 }}>
+                판매자: {data.counterpartNickname ?? "-"}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* 거래 정보 카드는 요청에 따라 제거됨; 필요 시 추후 복원 가능 */}
+
+        <section style={{ background: "#fff", padding: 20, borderRadius: 8 }}>
+          <h3 style={{ fontSize: 18, marginBottom: 8 }}>진행 상태</h3>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 6,
+              fontSize: 16,
+            }}
+          >
+            <div
+              style={{
+                display: "block",
+                width: "100%",
+                padding: "12px 0",
+                borderBottom: "1px solid #e9ecef",
+              }}
+            >
+              <span
+                style={{
+                  fontWeight: 600,
+                  display: "inline-block",
+                  minWidth: 140,
+                  marginRight: 12,
+                  fontSize: 15,
+                }}
+              >
+                거래일자:
+              </span>
+              <span style={{ fontSize: 15, color: "#111", lineHeight: 1.6 }}>
+                {formatDate(data.purchasedAt ?? data.createdAt ?? data.paidAt)}
+              </span>
+            </div>
+            <div
+              style={{
+                display: "block",
+                width: "100%",
+                padding: "12px 0",
+                borderBottom: "1px solid #e9ecef",
+              }}
+            >
+              <span
+                style={{
+                  fontWeight: 600,
+                  display: "inline-block",
+                  minWidth: 140,
+                  marginRight: 12,
+                  fontSize: 15,
+                }}
+              >
+                결제일:
+              </span>
+              <span style={{ fontSize: 15, color: "#111", lineHeight: 1.6 }}>
+                {formatDate(data.paidAt)}
+              </span>
+            </div>
+            <div
+              style={{
+                display: "block",
+                width: "100%",
+                padding: "12px 0",
+                borderBottom: "1px solid #e9ecef",
+              }}
+            >
+              <span
+                style={{
+                  fontWeight: 600,
+                  display: "inline-block",
+                  minWidth: 140,
+                  marginRight: 12,
+                  fontSize: 15,
+                }}
+              >
+                결제 완료:
+              </span>
+              <span style={{ fontSize: 15, color: "#111", lineHeight: 1.6 }}>
+                {data.paidAt ? "완료" : "미완료"}
+              </span>
+            </div>
+            <div
+              style={{
+                display: "block",
+                width: "100%",
+                padding: "12px 0",
+                borderBottom: "1px solid #e9ecef",
+              }}
+            >
+              <span
+                style={{
+                  fontWeight: 600,
+                  display: "inline-block",
+                  minWidth: 140,
+                  marginRight: 12,
+                  fontSize: 15,
+                }}
+              >
+                판매자 발송:
+              </span>
+              <span style={{ fontSize: 15, color: "#111", lineHeight: 1.6 }}>
+                {data.sellerShipped ? "발송" : "미발송"}
+              </span>
+            </div>
+            <div
+              style={{
+                display: "block",
+                width: "100%",
+                padding: "12px 0",
+                borderBottom: "1px solid #e9ecef",
+              }}
+            >
+              <span
+                style={{
+                  fontWeight: 600,
+                  display: "inline-block",
+                  minWidth: 140,
+                  marginRight: 12,
+                  fontSize: 15,
+                }}
+              >
+                구매자 수령확인:
+              </span>
+              <span style={{ fontSize: 15, color: "#111", lineHeight: 1.6 }}>
+                {data.buyerConfirmed ? "확인" : "미확인"}
+              </span>
+            </div>
+            <div style={{ display: "block", width: "100%", padding: "12px 0" }}>
+              <span
+                style={{
+                  fontWeight: 600,
+                  display: "inline-block",
+                  minWidth: 140,
+                  marginRight: 12,
+                  fontSize: 15,
+                }}
+              >
+                거래 완료:
+              </span>
+              <span style={{ fontSize: 15, color: "#111", lineHeight: 1.6 }}>
+                {data.completedAt ? "완료" : "진행 중"}
+              </span>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/services/mypage/transaction-receipt/api.ts
+++ b/src/services/mypage/transaction-receipt/api.ts
@@ -1,0 +1,77 @@
+import { PURCHASE_RECEIPT_URL, SALES_RECEIPT_URL } from "./urls";
+import type { TransactionReceiptResponse } from "./types";
+import { ApiRequestError, getApiErrorMessage } from "@/services/apiError";
+import {
+  getAuthorizationHeaders,
+  handleUnauthorizedAccess,
+} from "@/services/auth/service";
+
+async function throwProtectedApiError(
+  response: Response,
+  fallbackMessage: string,
+) {
+  if (response.status === 401) {
+    handleUnauthorizedAccess();
+  }
+
+  throw new ApiRequestError(
+    await getApiErrorMessage(response, fallbackMessage),
+    response.status,
+  );
+}
+
+export async function getPurchaseReceipt(
+  purchaseId: number,
+  options?: { signal?: AbortSignal },
+): Promise<TransactionReceiptResponse> {
+  const response = await fetch(PURCHASE_RECEIPT_URL(purchaseId), {
+    method: "GET",
+    headers: {
+      ...getAuthorizationHeaders(),
+      "Content-Type": "application/json",
+    },
+    cache: "no-store",
+    signal: options?.signal,
+  });
+
+  if (!response.ok) {
+    await throwProtectedApiError(response, "영수증을 불러오지 못했습니다.");
+  }
+
+  return response.json();
+}
+
+export async function getSalesReceipt(
+  saleId: number,
+  options?: { signal?: AbortSignal },
+): Promise<TransactionReceiptResponse> {
+  // Try sales-specific URL first; if backend doesn't expose it, fall back to purchases URL.
+  let response = await fetch(SALES_RECEIPT_URL(saleId), {
+    method: "GET",
+    headers: {
+      ...getAuthorizationHeaders(),
+      "Content-Type": "application/json",
+    },
+    cache: "no-store",
+    signal: options?.signal,
+  });
+
+  if (response.status === 404) {
+    // fallback to purchases-based receipt endpoint
+    response = await fetch(PURCHASE_RECEIPT_URL(saleId), {
+      method: "GET",
+      headers: {
+        ...getAuthorizationHeaders(),
+        "Content-Type": "application/json",
+      },
+      cache: "no-store",
+      signal: options?.signal,
+    });
+  }
+
+  if (!response.ok) {
+    await throwProtectedApiError(response, "영수증을 불러오지 못했습니다.");
+  }
+
+  return response.json();
+}

--- a/src/services/mypage/transaction-receipt/index.ts
+++ b/src/services/mypage/transaction-receipt/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./urls";
+export * from "./api";

--- a/src/services/mypage/transaction-receipt/types.ts
+++ b/src/services/mypage/transaction-receipt/types.ts
@@ -24,6 +24,7 @@ export interface TransactionReceiptResponse {
   currency?: string;
   status: TransactionStatus;
   createdAt: string; // 주문 생성일
+  purchasedAt: string; // 구매 일자 (백엔드에서 제공)
   paidAt: string | null;
   shippedAt: string | null;
   completedAt: string | null;

--- a/src/services/mypage/transaction-receipt/types.ts
+++ b/src/services/mypage/transaction-receipt/types.ts
@@ -1,0 +1,40 @@
+export type TransactionStatus =
+  | "PAID"
+  | "SHIPPED"
+  | "COMPLETED"
+  | "CANCELED"
+  | "PENDING"
+  | string;
+
+export type ProductType = "REGULAR" | "AUCTION" | string;
+
+export interface Participant {
+  id: number;
+  nickname: string | null;
+}
+
+export interface TransactionReceiptResponse {
+  id: number;
+  transactionId: string;
+  productId: number;
+  productName: string;
+  productImageUrl?: string | null;
+  productType: ProductType;
+  price: number;
+  currency?: string;
+  status: TransactionStatus;
+  createdAt: string; // 주문 생성일
+  paidAt: string | null;
+  shippedAt: string | null;
+  completedAt: string | null;
+  canceledAt: string | null;
+  sellerShipped: boolean;
+  buyerConfirmed: boolean;
+  counterpartNickname: string | null; // 예: 판매자명(구매 영수증에서는 판매자)
+  seller: Participant;
+  buyer: Participant;
+  // 추가 정보 (결제수단 등) - optional
+  meta?: Record<string, unknown> | null;
+}
+
+export default TransactionReceiptResponse;

--- a/src/services/mypage/transaction-receipt/urls.ts
+++ b/src/services/mypage/transaction-receipt/urls.ts
@@ -1,0 +1,5 @@
+export const PURCHASE_RECEIPT_URL = (purchaseId: number) =>
+  `/api/v1/mypage/purchases/${purchaseId}/receipt`;
+// Backend currently exposes receipt via purchases endpoint for both purchase/sale contexts.
+export const SALES_RECEIPT_URL = (saleId: number) =>
+  `/api/v1/mypage/purchases/${saleId}/receipt`;


### PR DESCRIPTION
### 🚀 Summary

영수증(구매/판매) 화면 추가 및 관련 API/타입/라우트/UI 개선 작업을 머지하기 위한 PR입니다. 백엔드 응답 타입 반영, API 래퍼, 공통 영수증 컴포넌트, 새 라우트, 목록 네비게이션 변경, 인증/404 처리 및 UI 개선을 포함합니다.

---

### ✨ Description

- 목적: 마이페이지 내 영수증 뷰를 통합하고, 백엔드 응답 변화에 강건한 API/타입/컴포넌트를 제공하여 UX를 개선합니다.

- 주요 변경사항 요약:
  - 영수증 타입 및 API 추가/정비
  - 재사용 가능한 `TransactionReceipt` 컴포넌트 작성(구매/판매 공용)
  - 상세 페이지 라우트 추가 및 목록에서 새 페이지로 네비게이션 변경
  - 인증 헤더 적용, 401/404(판매용 미구현) 폴백 처리
  - UI: 이미지/폰트/간격 개선, 진행 상태 카드 항목을 한 줄씩 크게 표시, 최상위 컨테이너에 `minHeight:100vh` 적용

---

### 변경 파일(주요)
- 타입 / API / URL
  - `src/services/mypage/transaction-receipt/types.ts`
  - `src/services/mypage/transaction-receipt/urls.ts`
  - `src/services/mypage/transaction-receipt/api.ts`
  - `src/services/mypage/transaction-receipt/index.ts`
- UI / 컴포넌트 / 라우트
  - `src/components/transaction-receipt/TransactionReceipt.tsx`
  - `src/app/(main)/mypage/purchase-history/[purchaseId]/receipt/page.tsx`
  - `src/app/(main)/mypage/sales-history/[purchaseId]/receipt/page.tsx`
  - 목록 페이지들: `purchase-history` / `sales-history` (자세히 보기 버튼 네비게이션 변경)

---
<img width="2252" height="1121" alt="판매내역 자세히보기" src="https://github.com/user-attachments/assets/b28aa6ee-25c3-45c8-b3af-abd344551492" />

- 이미지, 상품명, 금액, 진행 상태(거래일자/결제일/결제완료/발송/수령확인/거래완료) 정상 표기
- 401 발생 시 기존 인증 흐름(로그아웃/리다이렉트) 동작 확인
- 판매 영수증 엔드포인트 미구현 시 sales→purchases 폴백 동작 확인

---
🎲 Issue Number
close #{Issue Number}

