### PR TITLE
[feat] 최근본상품 기능 구현

### DIFF
--- a/src/app/products/index.tsx
+++ b/src/app/products/index.tsx
@@ -14,7 +14,8 @@ import { fetchHotRegularProducts } from "@/services/product/hotList/service";
 import { fetchPopularRegularProducts } from "@/services/product/popular/service";
 import { fetchIntegratedSearchResults } from "@/services/product/search/service";
 import type { UnifiedSearchResultType } from "@/services/product/search/types";
-import { fetchRegularWishlist } from "@/services/wishlist/service";
+import { fetchRecentProducts } from "@/services/recent-products/service";
+import { fetchMyWishlist } from "@/services/wishlist/service";
 
 type ProductListType = "all" | "closing_soon" | "recent";
 
@@ -48,18 +49,21 @@ export default function ProductListScreen({
     searchKeyword
       ? `"${searchKeyword}" 검색 결과`
       : categoryName ||
-    (mode === "auction" && listType === "all"
-      ? "실시간 인기 경매"
-      : mode === "auction" && listType === "closing_soon"
-        ? "마감 임박 경매"
-        : mode === "regular" && listType === "all"
-          ? "실시간 인기 상품"
-          : mode === "regular" && listType === "closing_soon"
-            ? "핫한 상품"
-            : "상품 목록");
+        (listType === "recent"
+          ? "최근 본 상품"
+          : mode === "auction" && listType === "all"
+            ? "실시간 인기 경매"
+            : mode === "auction" && listType === "closing_soon"
+              ? "마감 임박 경매"
+              : mode === "regular" && listType === "all"
+                ? "실시간 인기 상품"
+                : mode === "regular" && listType === "closing_soon"
+                  ? "핫한 상품"
+                  : "상품 목록");
   const [products, setProducts] = useState<any[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+  const [wishlistErrorMessage, setWishlistErrorMessage] = useState("");
   const [likedProductIds, setLikedProductIds] = useState<Set<number>>(
     () => new Set(),
   );
@@ -70,16 +74,27 @@ export default function ProductListScreen({
     const shouldFetchKeywordList = Boolean(normalizedKeyword);
     const shouldFetchCategoryList =
       !shouldFetchKeywordList && typeof categoryId === "number" && categoryId > 0;
+    const shouldFetchRecentList =
+      !shouldFetchKeywordList &&
+      !shouldFetchCategoryList &&
+      !categoryName &&
+      listType === "recent";
     const shouldFetchApiList =
       !shouldFetchKeywordList &&
       !shouldFetchCategoryList &&
+      !shouldFetchRecentList &&
       !categoryName &&
       ((mode === "regular" &&
         (listType === "all" || listType === "closing_soon")) ||
         (mode === "auction" &&
           (listType === "all" || listType === "closing_soon")));
 
-    if (!shouldFetchKeywordList && !shouldFetchCategoryList && !shouldFetchApiList) {
+    if (
+      !shouldFetchKeywordList &&
+      !shouldFetchCategoryList &&
+      !shouldFetchRecentList &&
+      !shouldFetchApiList
+    ) {
       setProducts([]);
       setErrorMessage("");
       return () => {
@@ -89,6 +104,7 @@ export default function ProductListScreen({
 
     setIsLoading(true);
     setErrorMessage("");
+    setWishlistErrorMessage("");
 
     const request = shouldFetchKeywordList
       ? fetchIntegratedSearchResults({
@@ -104,6 +120,8 @@ export default function ProductListScreen({
             page: 0,
             size: 20,
           })
+      : shouldFetchRecentList
+        ? fetchRecentProducts(20)
       : mode === "regular" && listType === "all"
         ? fetchPopularRegularProducts(10)
         : mode === "regular"
@@ -116,7 +134,7 @@ export default function ProductListScreen({
       .then((nextProducts) => {
         if (!ignore) {
           setProducts(
-            shouldFetchKeywordList || shouldFetchCategoryList
+            shouldFetchKeywordList || shouldFetchCategoryList || shouldFetchRecentList
               ? nextProducts
               : nextProducts.slice(
                   0,
@@ -135,6 +153,8 @@ export default function ProductListScreen({
                 ? "검색 결과를 불러오지 못했습니다."
                 : shouldFetchCategoryList
                 ? "카테고리 검색 결과를 불러오지 못했습니다."
+                : shouldFetchRecentList
+                  ? "최근 본 상품을 불러오지 못했습니다."
                 : mode === "regular" && listType === "all"
                   ? "실시간 인기 상품을 불러오지 못했습니다."
                   : mode === "regular"
@@ -158,14 +178,14 @@ export default function ProductListScreen({
   }, [categoryId, categoryName, listType, mode, searchKeyword, searchResultType]);
 
   useEffect(() => {
-    if (mode !== "regular" && !categoryId && !searchKeyword) {
+    if (mode !== "regular" && !categoryId && !searchKeyword && listType !== "recent") {
       setLikedProductIds(new Set());
       return;
     }
 
     let ignore = false;
 
-    fetchRegularWishlist()
+    fetchMyWishlist()
       .then((items) => {
         if (!ignore) {
           setLikedProductIds(new Set(items.map((item) => item.productId)));
@@ -180,7 +200,7 @@ export default function ProductListScreen({
     return () => {
       ignore = true;
     };
-  }, [categoryId, mode, searchKeyword]);
+  }, [categoryId, listType, mode, searchKeyword]);
 
   const handleWishlistChange = (
     productId: number,
@@ -204,6 +224,13 @@ export default function ProductListScreen({
         item.productId === productId ? { ...item, favoriteCount } : item,
       ),
     );
+  };
+
+  const showWishlistError = (message: string) => {
+    setWishlistErrorMessage(message);
+    window.setTimeout(() => {
+      setWishlistErrorMessage("");
+    }, 3000);
   };
 
   const handleProductClick = (product: any) => {
@@ -249,6 +276,11 @@ export default function ProductListScreen({
       </div>
 
       <div className="flex-1 overflow-y-auto no-scrollbar p-4 space-y-4">
+        {wishlistErrorMessage && (
+          <div className="rounded-2xl bg-red-50 px-4 py-3 text-sm font-medium text-red-500">
+            {wishlistErrorMessage}
+          </div>
+        )}
         {isLoading ? (
           <EmptyState message={`${title}을 불러오는 중입니다`} />
         ) : errorMessage ? (
@@ -268,11 +300,13 @@ export default function ProductListScreen({
               }
               themeColor={themeColor}
               onProductClick={() => handleProductClick(product)}
-              initialLiked={
-                product.saleType !== "AUCTION" &&
-                likedProductIds.has(product.productId)
-              }
+              initialLiked={likedProductIds.has(product.productId)}
               onWishlistChange={handleWishlistChange}
+              onWishlistError={showWishlistError}
+              showWishlistButton={
+                product.saleType === "AUCTION" ||
+                (!searchKeyword && mode === "auction" && product.auctionId != null)
+              }
             />
           ))
         ) : (
@@ -280,6 +314,8 @@ export default function ProductListScreen({
             message={
               categoryName
                 ? "검색 결과가 없습니다"
+                : listType === "recent"
+                  ? "최근 본 상품이 없습니다"
                 : mode === "regular"
                   ? "표시할 일반 상품이 없습니다"
                   : "등록된 경매 상품이 없습니다"

--- a/src/components/product/ProductListItem.tsx
+++ b/src/components/product/ProductListItem.tsx
@@ -24,6 +24,8 @@ export default function ProductListItem({
   initialLiked = false,
   onUnlike,
   onWishlistChange,
+  onWishlistError,
+  showWishlistButton = false,
 }: {
   i?: number;
   product?: {
@@ -55,6 +57,8 @@ export default function ProductListItem({
   initialLiked?: boolean;
   onUnlike?: () => void;
   onWishlistChange?: (productId: number, liked: boolean, favoriteCount: number) => void;
+  onWishlistError?: (message: string) => void;
+  showWishlistButton?: boolean;
   key?: string | number;
 }) {
   const useData = product !== undefined && product !== null;
@@ -95,6 +99,65 @@ export default function ProductListItem({
     }
   }, [useData, product?.favoriteCount]);
 
+  const handleLikeClick = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+
+    if (isWishlistSubmitting) {
+      return;
+    }
+
+    if (isLiked && onUnlike) {
+      setShowConfirm(true);
+      return;
+    }
+
+    if (!useData) {
+      setIsLiked(!isLiked);
+      setDisplayFavoriteCount((currentCount) =>
+        isLiked ? Math.max(0, currentCount - 1) : currentCount + 1,
+      );
+      return;
+    }
+
+    if (product?.canFavorite === false && !isLiked) {
+      return;
+    }
+
+    setIsWishlistSubmitting(true);
+
+    const previousLiked = isLiked;
+    const previousFavoriteCount = displayFavoriteCount;
+    const optimisticLiked = !isLiked;
+    const optimisticFavoriteCount = optimisticLiked
+      ? displayFavoriteCount + 1
+      : Math.max(0, displayFavoriteCount - 1);
+
+    setIsLiked(optimisticLiked);
+    setDisplayFavoriteCount(optimisticFavoriteCount);
+    onWishlistChange?.(productId, optimisticLiked, optimisticFavoriteCount);
+
+    try {
+      const result = isLiked
+        ? await removeRegularWishlist(productId)
+        : await addRegularWishlist(productId);
+
+      setIsLiked(result.liked);
+      setDisplayFavoriteCount(result.favoriteCount);
+      onWishlistChange?.(productId, result.liked, result.favoriteCount);
+    } catch (error) {
+      setIsLiked(previousLiked);
+      setDisplayFavoriteCount(previousFavoriteCount);
+      onWishlistChange?.(productId, previousLiked, previousFavoriteCount);
+      onWishlistError?.(
+        error instanceof Error && error.message.trim()
+          ? error.message
+          : "찜 처리에 실패했습니다.",
+      );
+    } finally {
+      setIsWishlistSubmitting(false);
+    }
+  };
+
   if (mode === "auction") {
     const currentPriceLabel = useData
       ? (product!.currentPriceLabel ?? priceLabel)
@@ -129,18 +192,41 @@ export default function ProductListItem({
         <div className="flex-1 min-w-0 space-y-1.5">
           <div className="flex justify-between items-start gap-2">
             <h4 className="font-bold text-sm truncate text-gray-800">{name}</h4>
-            {showRankLabel && (
-              <div
-                className={`shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-bold ${
-                  isTopRank
-                    ? "bg-red-50 text-red-500"
-                    : "bg-gray-50 text-gray-500"
-                }`}
-              >
-                {rank}위
-              </div>
-            )}
+            <div className="flex shrink-0 items-center gap-1">
+              {showRankLabel && (
+                <div
+                  className={`rounded-full px-1.5 py-0.5 text-[10px] font-bold ${
+                    isTopRank
+                      ? "bg-red-50 text-red-500"
+                      : "bg-gray-50 text-gray-500"
+                  }`}
+                >
+                  {rank}위
+                </div>
+              )}
+              {showWishlistButton && (
+                <button
+                  onClick={handleLikeClick}
+                  disabled={isWishlistSubmitting}
+                  className="p-1 disabled:opacity-50"
+                  aria-label="찜하기"
+                >
+                  <Heart
+                    size={16}
+                    fill={isLiked ? "#FF3B30" : "none"}
+                    color={isLiked ? "#FF3B30" : "#D1D5DB"}
+                  />
+                </button>
+              )}
+            </div>
           </div>
+
+          {showWishlistButton && (
+            <div className="flex items-center space-x-1 text-[10px] text-gray-400 font-medium">
+              <Heart size={10} />
+              <span>{displayFavoriteCount}</span>
+            </div>
+          )}
 
           <p className="text-xs text-gray-500 font-medium">
             현재 입찰가{" "}
@@ -174,47 +260,6 @@ export default function ProductListItem({
       </div>
     );
   }
-
-  const handleLikeClick = async (e: React.MouseEvent) => {
-    e.stopPropagation();
-
-    if (isWishlistSubmitting) {
-      return;
-    }
-
-    if (isLiked && onUnlike) {
-      setShowConfirm(true);
-      return;
-    }
-
-    if (!useData) {
-      setIsLiked(!isLiked);
-      setDisplayFavoriteCount((currentCount) =>
-        isLiked ? Math.max(0, currentCount - 1) : currentCount + 1,
-      );
-      return;
-    }
-
-    if (product?.canFavorite === false && !isLiked) {
-      return;
-    }
-
-    setIsWishlistSubmitting(true);
-
-    try {
-      const result = isLiked
-        ? await removeRegularWishlist(productId)
-        : await addRegularWishlist(productId);
-
-      setIsLiked(result.liked);
-      setDisplayFavoriteCount(result.favoriteCount);
-      onWishlistChange?.(productId, result.liked, result.favoriteCount);
-    } catch {
-      // Keep the card stable when the backend rejects the toggle.
-    } finally {
-      setIsWishlistSubmitting(false);
-    }
-  };
 
   return (
     <>

--- a/src/components/product/ProductListItem.tsx
+++ b/src/components/product/ProductListItem.tsx
@@ -49,6 +49,7 @@ export default function ProductListItem({
     popularScore?: number;
     rank?: number;
     createdAt?: string;
+    recentViewedLabel?: string;
     canFavorite?: boolean;
   };
   mode: "regular" | "auction";
@@ -77,6 +78,7 @@ export default function ProductListItem({
   const chatCount = useData ? (product!.chatCount ?? 0) : 0;
   const bidCount = useData ? (product!.bidCount ?? 0) : 0;
   const rank = useData ? (product!.rank ?? null) : null;
+  const recentViewedLabel = useData ? product!.recentViewedLabel : undefined;
   const isTopRank = rank === 1;
   const showRankLabel = rank != null && rank >= 1 && rank <= 3;
 
@@ -240,6 +242,12 @@ export default function ProductListItem({
             {product?.location ?? "지역 정보 없음"}
           </p>
 
+          {recentViewedLabel && (
+            <p className="text-[10px] font-medium text-gray-400">
+              {recentViewedLabel}
+            </p>
+          )}
+
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-gray-400 font-medium">
             <div className="flex items-center space-x-1 whitespace-nowrap">
               <Gavel size={10} />
@@ -304,6 +312,12 @@ export default function ProductListItem({
               {priceLabel}
             </span>
           </p>
+
+          {recentViewedLabel && (
+            <p className="text-[10px] font-medium text-gray-400">
+              {recentViewedLabel}
+            </p>
+          )}
 
           <div className="flex items-center space-x-3 text-[10px] text-gray-400 font-medium">
             <div className="flex items-center space-x-1">

--- a/src/services/recent-products/api.ts
+++ b/src/services/recent-products/api.ts
@@ -1,0 +1,45 @@
+import { ApiRequestError, getApiErrorMessage } from "@/services/apiError";
+import {
+  getAuthorizationHeaders,
+  handleUnauthorizedAccess,
+} from "@/services/auth/service";
+import type { RecentProductListResponse } from "@/services/recent-products/types";
+
+const RECENT_PRODUCTS_API_BASE = "/api/v1/users/me/recent-products";
+
+async function throwRecentProductsApiError(
+  response: Response,
+  fallbackMessage: string,
+) {
+  if (response.status === 401) {
+    handleUnauthorizedAccess();
+  }
+
+  throw new ApiRequestError(
+    await getApiErrorMessage(response, fallbackMessage),
+    response.status,
+  );
+}
+
+export async function getRecentProducts(
+  size = 20,
+): Promise<RecentProductListResponse> {
+  const params = new URLSearchParams({
+    size: String(size),
+  });
+
+  const response = await fetch(`${RECENT_PRODUCTS_API_BASE}?${params}`, {
+    method: "GET",
+    headers: getAuthorizationHeaders(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    await throwRecentProductsApiError(
+      response,
+      "최근 본 상품을 불러오지 못했습니다.",
+    );
+  }
+
+  return response.json();
+}

--- a/src/services/recent-products/service.ts
+++ b/src/services/recent-products/service.ts
@@ -6,9 +6,36 @@ import type {
 
 const DEFAULT_CATEGORY_LABEL = "카테고리 없음";
 const DEFAULT_LOCATION_LABEL = "지역 정보 없음";
+const RECENT_PRODUCT_TTL_MS = 24 * 60 * 60 * 1000;
 
 function formatPrice(price: number | null | undefined) {
   return `${Number(price || 0).toLocaleString()}원`;
+}
+
+function getViewedAtMs(viewedAt: string) {
+  const viewedAtMs = new Date(viewedAt).getTime();
+  return Number.isFinite(viewedAtMs) ? viewedAtMs : Date.now();
+}
+
+function isExpired(item: RecentProductItemResponse) {
+  return Date.now() - getViewedAtMs(item.viewedAt) >= RECENT_PRODUCT_TTL_MS;
+}
+
+function formatRecentViewedLabel(viewedAt: string) {
+  const diffMinutes = Math.max(
+    0,
+    Math.floor((Date.now() - getViewedAtMs(viewedAt)) / 60000),
+  );
+
+  if (diffMinutes < 1) {
+    return "방금 봄";
+  }
+  if (diffMinutes < 60) {
+    return `${diffMinutes}분 전 봄`;
+  }
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  return `${diffHours}시간 전 봄`;
 }
 
 function toRecentProductItemViewModel(
@@ -32,6 +59,7 @@ function toRecentProductItemViewModel(
     favoriteCount: 0,
     createdAt: item.viewedAt,
     viewedAt: item.viewedAt,
+    recentViewedLabel: formatRecentViewedLabel(item.viewedAt),
     auctionStatusLabel: isAuction ? "경매" : undefined,
   };
 }
@@ -41,5 +69,7 @@ export async function fetchRecentProducts(
 ): Promise<RecentProductItemViewModel[]> {
   const response = await recentProductsApi.getRecentProducts(size);
 
-  return response.content.map(toRecentProductItemViewModel);
+  return response.content
+    .filter((item) => !isExpired(item))
+    .map(toRecentProductItemViewModel);
 }

--- a/src/services/recent-products/service.ts
+++ b/src/services/recent-products/service.ts
@@ -1,0 +1,45 @@
+import * as recentProductsApi from "@/services/recent-products/api";
+import type {
+  RecentProductItemResponse,
+  RecentProductItemViewModel,
+} from "@/services/recent-products/types";
+
+const DEFAULT_CATEGORY_LABEL = "카테고리 없음";
+const DEFAULT_LOCATION_LABEL = "지역 정보 없음";
+
+function formatPrice(price: number | null | undefined) {
+  return `${Number(price || 0).toLocaleString()}원`;
+}
+
+function toRecentProductItemViewModel(
+  item: RecentProductItemResponse,
+): RecentProductItemViewModel {
+  const isAuction = item.type === "AUCTION";
+  const price = isAuction ? item.currentPrice : item.price;
+  const priceLabel = formatPrice(price);
+
+  return {
+    saleType: item.type,
+    productId: item.productId,
+    auctionId: item.auctionId,
+    name: item.name,
+    thumbnailUrl: item.thumbnailUrl,
+    priceLabel,
+    currentPriceLabel: isAuction ? priceLabel : undefined,
+    categoryName: item.categoryName ?? DEFAULT_CATEGORY_LABEL,
+    location: item.location ?? DEFAULT_LOCATION_LABEL,
+    viewCount: 0,
+    favoriteCount: 0,
+    createdAt: item.viewedAt,
+    viewedAt: item.viewedAt,
+    auctionStatusLabel: isAuction ? "경매" : undefined,
+  };
+}
+
+export async function fetchRecentProducts(
+  size = 20,
+): Promise<RecentProductItemViewModel[]> {
+  const response = await recentProductsApi.getRecentProducts(size);
+
+  return response.content.map(toRecentProductItemViewModel);
+}

--- a/src/services/recent-products/types.ts
+++ b/src/services/recent-products/types.ts
@@ -32,5 +32,6 @@ export interface RecentProductItemViewModel {
   favoriteCount: number;
   createdAt: string;
   viewedAt: string;
+  recentViewedLabel: string;
   auctionStatusLabel?: string;
 }

--- a/src/services/recent-products/types.ts
+++ b/src/services/recent-products/types.ts
@@ -1,0 +1,36 @@
+export type RecentProductType = "REGULAR" | "AUCTION";
+
+export interface RecentProductItemResponse {
+  type: RecentProductType;
+  productId: number;
+  auctionId: number | null;
+  name: string;
+  thumbnailUrl: string | null;
+  price: number | null;
+  currentPrice: number | null;
+  location: string | null;
+  categoryName: string | null;
+  viewedAt: string;
+}
+
+export interface RecentProductListResponse {
+  content: RecentProductItemResponse[];
+  size: number;
+}
+
+export interface RecentProductItemViewModel {
+  saleType: RecentProductType;
+  productId: number;
+  auctionId: number | null;
+  name: string;
+  thumbnailUrl: string | null;
+  priceLabel: string;
+  currentPriceLabel?: string;
+  categoryName: string;
+  location: string;
+  viewCount: number;
+  favoriteCount: number;
+  createdAt: string;
+  viewedAt: string;
+  auctionStatusLabel?: string;
+}


### PR DESCRIPTION
### 🚀 Summary

최근 본 상품 기능 및 경매 상품 목록 찜 기능 추가
탐색 화면에서 최근 본 상품 목록을 확인할 수 있도록 백엔드 API와 프론트 화면 흐름을 연결
상품 목록 페이지의 경매 상품 카드에서도 하트 찜 토글이 가능하도록 개선
---

### ✨ Description

최근 본 상품 조회 흐름
사용자가 일반 상품/경매 상품 상세페이지 진입
→ 백엔드에서 최근 본 상품으로 기록
→ 탐색 화면의 최근 본 상품 클릭
→ service.ts가 최근 본 상품 목록 조회
→ api.ts가 서버 호출
→ 일반 상품과 경매 상품을 하나의 목록에서 함께 렌더링

경매 상품 찜 흐름
상품 목록 페이지에서 경매 상품 카드의 하트 클릭
→ 기존 찜 API 호출
→ 찜 상태와 찜 개수 즉시 반영
→ API 실패 시 이전 상태로 복구하고 실패 메시지 표시

주요 코드

products/index.tsx
/products, /auctions 목록 화면에 있음
최근 본 상품 목록 조회 흐름 추가
type=recent일 때 최근 본 상품 API 호출
일반/경매 상품을 통합 목록으로 표시
경매 상품 클릭 시 경매 상세 페이지 이동
일반 상품 클릭 시 일반 상품 상세 페이지 이동
경매 상품 카드 찜 상태/찜 개수 갱신 처리
찜 실패 시 오류 메시지 표시

ProductListItem.tsx
상품 목록 카드 컴포넌트
경매 카드에도 하트 버튼 표시 가능하도록 showWishlistButton 옵션 추가
하트 클릭 시 카드 클릭 이벤트와 겹치지 않도록 처리
찜 상태를 먼저 화면에 반영하고, 실패 시 이전 상태로 복구
일반 상품 카드 기존 찜 기능 유지
홈 화면에서는 기존처럼 경매 카드 하트 미표시

types.ts
RecentProductItemResponse - 최근 본 상품 응답 타입
RecentProductListResponse - 최근 본 상품 목록 응답 타입
RecentProductItemViewModel - 최근 본 상품 화면 표시용 모델
RecentProductType - REGULAR/AUCTION 타입 정의

api.ts
getRecentProducts - 최근 본 상품 목록 조회
GET /api/v1/users/me/recent-products?size=20 호출

service.ts
fetchRecentProducts - 최근 본 상품 응답을 화면용 데이터로 변환
일반 상품/경매 상품 가격 표시값 분기 처리
경매 상품은 현재가 기준으로 표시

사진
<img width="534" height="536" alt="화면 캡처 2026-05-21 215412" src="https://github.com/user-attachments/assets/2dfe83ed-789e-4ef2-80fb-c7342ce5de5d" />

<img width="537" height="473" alt="최근본목록" src="https://github.com/user-attachments/assets/4198a188-14af-47a8-9c48-fa442f41e362" />

---



### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #106 
