### PR TITLE
[feat] 카테고리 ai 추천 활성화

### DIFF
--- a/src/app/(main)/mypage/sales-management/index.tsx
+++ b/src/app/(main)/mypage/sales-management/index.tsx
@@ -19,6 +19,7 @@ import RegisterScreen from "../../../products/register/RegisterScreen";
 import {
   deleteAuctionImage,
   getAuctionCategories,
+  recommendAuctionCategory,
   recommendAuctionPrice,
   saveAuctionDraft,
   uploadAuctionImage,
@@ -26,6 +27,7 @@ import {
 import {
   deleteRegularProductImage,
   getRegularProductCategories,
+  recommendRegularProductCategory,
   recommendRegularProductPrice,
   saveRegularProductDraft,
   uploadRegularProductImage,
@@ -200,6 +202,7 @@ export default function SalesManagementScreen({
             uploadImage: uploadRegularProductImage,
             deleteImage: deleteRegularProductImage,
             saveDraft: saveRegularProductDraft,
+            recommendCategory: recommendRegularProductCategory,
             recommendPrice: ({ name, description }) =>
               recommendRegularProductPrice({ name, description }),
             register: (draft) =>
@@ -218,6 +221,7 @@ export default function SalesManagementScreen({
             uploadImage: uploadAuctionImage,
             deleteImage: deleteAuctionImage,
             saveDraft: saveAuctionDraft,
+            recommendCategory: recommendAuctionCategory,
             recommendPrice: recommendAuctionPrice,
             register: (draft) =>
               updateAuctionSalesManagementProduct(

--- a/src/app/products/register/AuctionRegisterScreen.tsx
+++ b/src/app/products/register/AuctionRegisterScreen.tsx
@@ -6,6 +6,7 @@ import RegisterScreen from "./RegisterScreen";
 import {
   deleteAuctionImage,
   getAuctionCategories,
+  recommendAuctionCategory,
   recommendAuctionPrice,
   registerAuction,
   reauctionAuction,
@@ -16,6 +17,7 @@ import {
 import {
   deleteRegularProductImage,
   getRegularProductCategories,
+  recommendRegularProductCategory,
   recommendRegularProductPrice,
   registerRegularProduct,
   saveRegularProductDraft,
@@ -42,6 +44,7 @@ export default function AuctionRegisterScreen(
           uploadImage: uploadRegularProductImage,
           deleteImage: deleteRegularProductImage,
           saveDraft: saveRegularProductDraft,
+          recommendCategory: recommendRegularProductCategory,
           recommendPrice: ({ name, description }) =>
             recommendRegularProductPrice({ name, description }),
           register: registerRegularProduct,
@@ -51,6 +54,7 @@ export default function AuctionRegisterScreen(
           uploadImage: uploadAuctionImage,
           deleteImage: deleteAuctionImage,
           saveDraft: saveAuctionDraft,
+          recommendCategory: recommendAuctionCategory,
           recommendPrice: recommendAuctionPrice,
           register: reauctionSourceAuctionId
             ? (draft) => reauctionAuction(reauctionSourceAuctionId, draft)

--- a/src/app/products/register/RegisterScreen.tsx
+++ b/src/app/products/register/RegisterScreen.tsx
@@ -52,6 +52,15 @@ export interface RegisterScreenServices {
     recommendedPrice: number;
     startPrice?: number | null;
   }>;
+  recommendCategory: (draft: {
+    name: string;
+    description: string;
+    images: ProductImagePayload[];
+    topCategoryId: number;
+  }) => Promise<{
+    categoryId: number;
+    categoryPathIds?: number[];
+  }>;
   register: (draft: AuctionRegisterDraft) => Promise<unknown>;
 }
 
@@ -194,6 +203,7 @@ export default function RegisterScreen({
   const [deletingImageIds, setDeletingImageIds] = useState<number[]>([]);
   const [isSavingDraft, setIsSavingDraft] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isRecommendingCategory, setIsRecommendingCategory] = useState(false);
   const [isLoadingCategories, setIsLoadingCategories] = useState(true);
   const [categoryLoadError, setCategoryLoadError] = useState<string | null>(
     null,
@@ -497,6 +507,55 @@ export default function RegisterScreen({
     }
   };
 
+  const handleRecommendCategory = async () => {
+    if (!selectedPrimaryCategoryId) {
+      showErrorMessage("대분류를 먼저 선택해 주세요.");
+      return;
+    }
+
+    if (!name.trim()) {
+      showErrorMessage("상품명을 입력해 주세요.");
+      return;
+    }
+
+    if (!description.trim()) {
+      showErrorMessage("상품 설명을 입력해 주세요.");
+      return;
+    }
+
+    setIsRecommendingCategory(true);
+    try {
+      const recommendation = await currentServices.recommendCategory({
+        name,
+        description,
+        images: getEffectiveImages(),
+        topCategoryId: selectedPrimaryCategoryId,
+      });
+      const recommendedLeafCategoryId =
+        recommendation.categoryPathIds?.at(-1) ?? recommendation.categoryId;
+      const matchedPath = findCategoryPathByLeafId(
+        categories,
+        recommendedLeafCategoryId,
+      );
+
+      if (!matchedPath) {
+        showErrorMessage("추천된 카테고리를 현재 목록에서 찾지 못했습니다.");
+        return;
+      }
+
+      setSelectedPrimaryCategoryId(matchedPath.primary.id);
+      setSelectedSecondaryCategoryId(matchedPath.secondary.id);
+      setSelectedTertiaryCategoryId(matchedPath.tertiary.id);
+      setPendingCategoryId(null);
+      setShowCategoryError(false);
+    } catch (error) {
+      console.error("Failed to recommend category", error);
+      showErrorMessage("카테고리 추천에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+    } finally {
+      setIsRecommendingCategory(false);
+    }
+  };
+
   const handleLoadDraft = () => {
     try {
       const savedDraft = localStorage.getItem("product_draft");
@@ -647,6 +706,7 @@ export default function RegisterScreen({
       deletingImageIds={deletingImageIds}
       isSavingDraft={isSavingDraft}
       isSubmitting={isSubmitting}
+      isRecommendingCategory={isRecommendingCategory}
       isLoadingCategories={isLoadingCategories}
       categoryLoadError={categoryLoadError}
       showCategoryError={shouldShowCategoryError}
@@ -665,6 +725,7 @@ export default function RegisterScreen({
       onImageButtonClick={handleImageButtonClick}
       onImageUpload={handleImageUpload}
       onRemoveImage={handleRemoveImage}
+      onRecommendCategory={handleRecommendCategory}
       onRecommendPrice={handleRecommendPrice}
       onSaveDraft={handleSaveDraft}
       onDiscardDraft={handleDiscardDraft}

--- a/src/app/products/register/RegularRegisterScreen.tsx
+++ b/src/app/products/register/RegularRegisterScreen.tsx
@@ -6,6 +6,7 @@ import RegisterScreen from "./RegisterScreen";
 import {
   deleteAuctionImage,
   getAuctionCategories,
+  recommendAuctionCategory,
   recommendAuctionPrice,
   registerAuction,
   saveAuctionDraft,
@@ -15,6 +16,7 @@ import {
 import {
   deleteRegularProductImage,
   getRegularProductCategories,
+  recommendRegularProductCategory,
   recommendRegularProductPrice,
   registerRegularProduct,
   saveRegularProductDraft,
@@ -29,7 +31,7 @@ export default function RegularRegisterScreen(
   return (
     <RegisterScreen
       {...props}
-      getCategories={getAuctionCategories}
+      getCategories={getRegularProductCategories}
       mode="regular"
       servicesByType={{
         regular: {
@@ -37,6 +39,7 @@ export default function RegularRegisterScreen(
           uploadImage: uploadRegularProductImage,
           deleteImage: deleteRegularProductImage,
           saveDraft: saveRegularProductDraft,
+          recommendCategory: recommendRegularProductCategory,
           recommendPrice: ({ name, description }) =>
             recommendRegularProductPrice({ name, description }),
           register: registerRegularProduct,
@@ -46,6 +49,7 @@ export default function RegularRegisterScreen(
           uploadImage: uploadAuctionImage,
           deleteImage: deleteAuctionImage,
           saveDraft: saveAuctionDraft,
+          recommendCategory: recommendAuctionCategory,
           recommendPrice: recommendAuctionPrice,
           register: registerAuction,
           update: (draft, initialData) =>

--- a/src/app/products/register/index.tsx
+++ b/src/app/products/register/index.tsx
@@ -50,6 +50,7 @@ export interface RegisterScreenViewProps {
   deletingImageIds: number[];
   isSavingDraft: boolean;
   isSubmitting: boolean;
+  isRecommendingCategory: boolean;
   isLoadingCategories: boolean;
   categoryLoadError: string | null;
   showCategoryError: boolean;
@@ -69,6 +70,7 @@ export interface RegisterScreenViewProps {
   onImageButtonClick: () => void;
   onImageUpload: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onRemoveImage: (sortOrder: number) => void;
+  onRecommendCategory: () => void;
   onRecommendPrice: () => void;
   onSaveDraft: () => void;
   onDiscardDraft: () => void;
@@ -100,6 +102,7 @@ export default function RegisterScreenView({
   deletingImageIds,
   isSavingDraft,
   isSubmitting,
+  isRecommendingCategory,
   isLoadingCategories,
   categoryLoadError,
   showCategoryError,
@@ -119,6 +122,7 @@ export default function RegisterScreenView({
   onImageButtonClick,
   onImageUpload,
   onRemoveImage,
+  onRecommendCategory,
   onRecommendPrice,
   onSaveDraft,
   onDiscardDraft,
@@ -135,6 +139,8 @@ export default function RegisterScreenView({
     secondaryCategories.find(
       (category) => category.id === selectedSecondaryCategoryId,
     )?.children ?? [];
+  const isCategoryRecommendationDisabled =
+    isLoadingCategories || isRecommendingCategory || !selectedPrimaryCategoryId;
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-white">
@@ -228,11 +234,22 @@ export default function RegisterScreenView({
                 <h3 className="font-bold text-base">카테고리</h3>
                 <button
                   type="button"
-                  disabled
-                  aria-disabled="true"
-                  className="text-[10px] flex items-center text-gray-300 cursor-not-allowed"
+                  onClick={onRecommendCategory}
+                  disabled={isCategoryRecommendationDisabled}
+                  aria-disabled={isCategoryRecommendationDisabled}
+                  className={`text-[10px] flex items-center ${
+                    isCategoryRecommendationDisabled
+                      ? "text-gray-300 cursor-not-allowed"
+                      : "font-bold"
+                  }`}
+                  style={
+                    isCategoryRecommendationDisabled
+                      ? undefined
+                      : { color: themeColor }
+                  }
                 >
-                  <Sparkles size={10} className="mr-1" /> AI 추천
+                  <Sparkles size={10} className="mr-1" />
+                  {isRecommendingCategory ? "추천 중" : "AI 추천"}
                 </button>
               </div>
               <div className="grid grid-cols-1 gap-3">
@@ -295,9 +312,11 @@ export default function RegisterScreenView({
                     카테고리 목록을 불러오는 중입니다.
                   </p>
                 )}
-                {!isLoadingCategories && !categoryLoadError && (
+                {!isLoadingCategories &&
+                  !categoryLoadError &&
+                  !selectedPrimaryCategoryId && (
                   <p className="text-xs text-gray-400">
-                    AI 추천 기능은 준비 중입니다.
+                    AI 추천을 사용하려면 1차 카테고리를 먼저 선택해 주세요.
                   </p>
                 )}
                 {categoryLoadError && (

--- a/src/services/auction/register/service.ts
+++ b/src/services/auction/register/service.ts
@@ -221,13 +221,17 @@ export function buildSaveAuctionDraftRequest(
   };
 }
 
-// 카테고리 AI 추천 요청은 현재 입력된 상품명/설명만 사용한다.
+// 카테고리 AI 추천 요청은 선택된 대분류 하위 후보와 상품 정보를 사용한다.
 export function buildRecommendCategoryRequest(
-  draft: Pick<AuctionRegisterDraft, "name" | "description">,
+  draft: Pick<AuctionRegisterDraft, "name" | "description" | "images"> & {
+    topCategoryId: number;
+  },
 ): RecommendCategoryRequest {
   return {
     name: draft.name.trim(),
     description: draft.description.trim(),
+    topCategoryId: draft.topCategoryId,
+    imageUrls: draft.images.map((image) => image.imageUrl),
   };
 }
 
@@ -264,7 +268,9 @@ export async function saveAuctionDraft(draft: AuctionRegisterDraft) {
 
 // 카테고리 추천 요청 위임.
 export async function recommendAuctionCategory(
-  draft: Pick<AuctionRegisterDraft, "name" | "description">,
+  draft: Pick<AuctionRegisterDraft, "name" | "description" | "images"> & {
+    topCategoryId: number;
+  },
 ) {
   return auctionApi.recommendAuctionCategory(
     buildRecommendCategoryRequest(draft),
@@ -354,7 +360,9 @@ export async function saveProductDraft(draft: AuctionRegisterDraft) {
 }
 
 export async function recommendProductCategory(
-  draft: Pick<AuctionRegisterDraft, "name" | "description">,
+  draft: Pick<AuctionRegisterDraft, "name" | "description" | "images"> & {
+    topCategoryId: number;
+  },
 ) {
   return recommendAuctionCategory(draft);
 }

--- a/src/services/auction/register/types.ts
+++ b/src/services/auction/register/types.ts
@@ -143,11 +143,17 @@ export interface SaveProductDraftResponse {
 export interface RecommendCategoryRequest {
   name: string;
   description: string;
+  topCategoryId: number;
+  imageUrls: string[];
 }
 
 export interface RecommendCategoryResponse {
   categoryId: number;
   categoryName: string;
+  categoryPathIds: number[];
+  categoryNames: string[];
+  confidence?: number | null;
+  reason?: string | null;
 }
 
 // 가격 추천 요청/응답.

--- a/src/services/product/register/service.ts
+++ b/src/services/product/register/service.ts
@@ -95,11 +95,16 @@ export function buildSaveRegularProductDraftRequest(
 }
 
 export function buildRecommendRegularProductCategoryRequest(
-  draft: Pick<RegularProductRegisterDraft, "name" | "description">,
+  draft: Pick<
+    RegularProductRegisterDraft,
+    "name" | "description" | "images"
+  > & { topCategoryId: number },
 ): RecommendRegularProductCategoryRequest {
   return {
     name: draft.name.trim(),
     description: draft.description.trim(),
+    topCategoryId: draft.topCategoryId,
+    imageUrls: draft.images.map((image) => image.imageUrl),
   };
 }
 
@@ -137,7 +142,10 @@ export async function saveRegularProductDraft(
 }
 
 export async function recommendRegularProductCategory(
-  draft: Pick<RegularProductRegisterDraft, "name" | "description">,
+  draft: Pick<
+    RegularProductRegisterDraft,
+    "name" | "description" | "images"
+  > & { topCategoryId: number },
 ) {
   return regularProductApi.recommendRegularProductCategory(
     buildRecommendRegularProductCategoryRequest(draft),

--- a/src/services/product/register/types.ts
+++ b/src/services/product/register/types.ts
@@ -74,11 +74,17 @@ export interface SaveRegularProductDraftResponse {
 export interface RecommendRegularProductCategoryRequest {
   name: string;
   description: string;
+  topCategoryId: number;
+  imageUrls: string[];
 }
 
 export interface RecommendRegularProductCategoryResponse {
   categoryId: number;
   categoryName: string;
+  categoryPathIds: number[];
+  categoryNames: string[];
+  confidence?: number | null;
+  reason?: string | null;
 }
 
 export interface RecommendRegularProductPriceRequest {


### PR DESCRIPTION
### 🚀 Summary

<!-- 작업 내용에 대한 간략한 설명을 써주세요. -->
- 카테고리 ai추천 활성화
---

### ✨ Description

<!-- 상세한 설명, 기능의 사용법, 주의 사항 실행 결과(이미지 첨부 가능) 등을 보여주세요. -->
#### 주요 변경사항

- 1차 카테고리 선택 전에는 AI 추천 버튼 비활성화
- 1차 카테고리 미선택 시 안내 문구 표시
  - `AI 추천을 사용하려면 1차 카테고리를 먼저 선택해 주세요.`

<img width="567" height="630" alt="스크린샷 2026-05-23 오전 12 03 52" src="https://github.com/user-attachments/assets/9c816ec7-8dc8-4a5e-a26b-5f441383ae07" />



- 1차 카테고리(대분류) 선택 후 ai추천 버튼 활성화
<img width="572" height="620" alt="스크린샷 2026-05-23 오전 12 04 01" src="https://github.com/user-attachments/assets/cda06052-3e8e-4224-9639-3bf5bfbd5833" />


- 추천 중 버튼 문구를 `추천 중`으로 표시
<img width="110" height="84" alt="스크린샷 2026-05-23 오전 12 04 08" src="https://github.com/user-attachments/assets/091f1ad8-edcd-4d01-8b2f-932063d07429" />

- 추천 응답의 `categoryPathIds` 또는 `categoryId`를 기준으로 1차/2차/3차 카테고리 select 자동 세팅
- 추천 완료

<img width="559" height="633" alt="스크린샷 2026-05-23 오전 12 06 00" src="https://github.com/user-attachments/assets/fd9b7b38-9393-4164-b07e-57c37bd0b09a" />

- 일반 상품 등록, 경매 등록, 판매관리 수정 화면의 `RegisterScreenServices`에 카테고리 추천 함수 연결
- 일반 상품/경매 카테고리 추천 요청/응답 타입 확장
  - `categoryPathIds`
  - `categoryNames`
  - `confidence`
  - `reason`

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #109 
