### PR TITLE
[refactor] 판매내역과구매내역 경매 상태추가

### DIFF
--- a/src/app/(main)/mypage/purchase-history/[purchaseId]/receipt/page.tsx
+++ b/src/app/(main)/mypage/purchase-history/[purchaseId]/receipt/page.tsx
@@ -1,20 +1,25 @@
 "use client";
 
 import React from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import TransactionReceipt from "../../../../../../components/transaction-receipt/TransactionReceipt";
+import RouteTabShell from "@/components/common/bottom-navigation/RouteTabShell";
 
 export default function PurchaseReceiptPage() {
   const params = useParams();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const purchaseId = Number(params?.purchaseId ?? NaN);
+  const returnUrl = searchParams.get("returnUrl") ?? "/mypage/purchase-history";
   if (Number.isNaN(purchaseId)) return <div>유효하지 않은 ID</div>;
   return (
-    <TransactionReceipt
-      mode="purchase"
-      id={purchaseId}
-      themeColor="#98E446"
-      onBack={() => router.push("/mypage/purchase-history")}
-    />
+    <RouteTabShell activeTab="mypage" activeColor="#98E446">
+      <TransactionReceipt
+        mode="purchase"
+        id={purchaseId}
+        themeColor="#98E446"
+        onBack={() => router.push(returnUrl)}
+      />
+    </RouteTabShell>
   );
 }

--- a/src/app/(main)/mypage/purchase-history/index.tsx
+++ b/src/app/(main)/mypage/purchase-history/index.tsx
@@ -60,6 +60,9 @@ export default function PurchaseHistoryScreen({
     "SHIPPED",
     "COMPLETED",
   ]);
+  const [productTypeFilter, setProductTypeFilter] = useState<
+    "ALL" | "REGULAR" | "AUCTION"
+  >("ALL");
   const nextPageRef = React.useRef<number>(0);
   const sentinelRef = React.useRef<HTMLDivElement | null>(null);
   const isLoadingRef = React.useRef<boolean>(false);
@@ -70,6 +73,13 @@ export default function PurchaseHistoryScreen({
     "SHIPPED",
     "COMPLETED",
   ]);
+
+  const buildReceiptUrl = (purchaseId: number) => {
+    const params = new URLSearchParams({
+      returnUrl: "/mypage/purchase-history",
+    });
+    return `/mypage/purchase-history/${purchaseId}/receipt?${params.toString()}`;
+  };
 
   const statusOptions = [
     { code: "PAID", label: "결제완료" },
@@ -379,20 +389,37 @@ export default function PurchaseHistoryScreen({
         <h1 className="text-lg font-bold ml-2">구매 내역</h1>
       </div>
 
-      <div className="px-4 py-3 bg-white border-b border-gray-100 shrink-0 flex gap-2 overflow-x-auto">
-        {statusOptions.map((status) => (
+      <div className="px-4 py-3 bg-white border-b border-gray-100 shrink-0 flex gap-2 items-center">
+        <div className="flex gap-2">
           <button
-            key={status.code}
-            onClick={() => handleFilterToggle(status.code)}
-            className={`px-3 py-1.5 rounded-full text-xs font-medium whitespace-nowrap transition-colors ${
-              selectedStatuses.includes(status.code)
+            onClick={() =>
+              setProductTypeFilter((prev) =>
+                prev === "REGULAR" ? "ALL" : "REGULAR",
+              )
+            }
+            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+              productTypeFilter === "REGULAR"
                 ? "bg-black text-white"
                 : "bg-gray-100 text-gray-600 hover:bg-gray-200"
             }`}
           >
-            {status.label}
+            일반
           </button>
-        ))}
+          <button
+            onClick={() =>
+              setProductTypeFilter((prev) =>
+                prev === "AUCTION" ? "ALL" : "AUCTION",
+              )
+            }
+            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+              productTypeFilter === "AUCTION"
+                ? "bg-black text-white"
+                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+            }`}
+          >
+            경매
+          </button>
+        </div>
       </div>
 
       <div className="flex-1 overflow-y-auto p-4 space-y-3">
@@ -410,52 +437,57 @@ export default function PurchaseHistoryScreen({
           </div>
         )}
 
-        {dedupeById(purchases).map((purchase) => (
-          <div
-            key={purchase.id}
-            className="bg-white p-4 rounded-xl shadow-sm border border-gray-100"
-          >
-            <div className="flex justify-between items-center mb-3 pb-3 border-b border-gray-50">
-              <span className="text-xs text-gray-400 font-mono">
-                {purchase.purchasedAtDisplay}
-              </span>
-              <span
-                className="text-xs font-medium"
-                style={{ color: themeColor }}
-              >
-                {getStatusLabel(purchase.status)}
-              </span>
-            </div>
-            <div className="flex space-x-4">
-              <img
-                src={purchase.imageUrl ?? undefined}
-                alt={purchase.title}
-                className="w-16 h-16 object-cover rounded-lg bg-gray-100"
-              />
-              <div className="flex-1 flex flex-col justify-center">
-                <span className="font-medium text-gray-800 line-clamp-1">
-                  {purchase.title}
+        {dedupeById(purchases)
+          .filter((purchase) => {
+            if (productTypeFilter === "ALL") return true;
+            return purchase.productType === productTypeFilter;
+          })
+          .map((purchase) => (
+            <div
+              key={purchase.id}
+              className="bg-white p-4 rounded-xl shadow-sm border border-gray-100"
+            >
+              <div className="flex justify-between items-center mb-3 pb-3 border-b border-gray-50">
+                <span className="text-xs text-gray-400 font-mono">
+                  {purchase.purchasedAtDisplay}
                 </span>
-                <span className="font-bold mt-1">
-                  {purchase.amountFormatted}
+                <span
+                  className="text-xs font-medium"
+                  style={{ color: themeColor }}
+                >
+                  {getStatusLabel(purchase.status)}
                 </span>
               </div>
+              <div className="flex space-x-4">
+                <img
+                  src={purchase.imageUrl ?? undefined}
+                  alt={purchase.title}
+                  className="w-16 h-16 object-cover rounded-lg bg-gray-100"
+                />
+                <div className="flex-1 flex flex-col justify-center">
+                  <span className="font-medium text-gray-800 line-clamp-1">
+                    {purchase.title}
+                  </span>
+                  <span className="font-bold mt-1">
+                    {purchase.amountFormatted}
+                  </span>
+                </div>
+              </div>
+              <p className="mt-3 rounded-lg bg-gray-50 px-3 py-2 text-xs leading-relaxed text-gray-500">
+                {getPurchaseStatusGuide(purchase.status)}
+              </p>
+              <button
+                onClick={() => {
+                  setSelectedItem(null);
+                  router.push(buildReceiptUrl(purchase.id));
+                }}
+                className="w-full mt-4 py-2 bg-gray-50 hover:bg-gray-100 text-gray-600 text-sm font-medium rounded-lg transition-colors flex items-center justify-center space-x-1"
+              >
+                <span>자세히 보기</span>
+                <ChevronRight size={16} />
+              </button>
             </div>
-            <p className="mt-3 rounded-lg bg-gray-50 px-3 py-2 text-xs leading-relaxed text-gray-500">
-              {getPurchaseStatusGuide(purchase.status)}
-            </p>
-            <button
-              onClick={() => {
-                setSelectedItem(null);
-                router.push(`/mypage/purchase-history/${purchase.id}/receipt`);
-              }}
-              className="w-full mt-4 py-2 bg-gray-50 hover:bg-gray-100 text-gray-600 text-sm font-medium rounded-lg transition-colors flex items-center justify-center space-x-1"
-            >
-              <span>자세히 보기</span>
-              <ChevronRight size={16} />
-            </button>
-          </div>
-        ))}
+          ))}
         {/* sentinel for IntersectionObserver */}
         <div ref={sentinelRef} />
       </div>

--- a/src/app/(main)/mypage/purchase-history/page.tsx
+++ b/src/app/(main)/mypage/purchase-history/page.tsx
@@ -3,11 +3,17 @@
 import { useRouter } from "next/navigation";
 
 import PurchaseHistoryScreen from "./index";
+import RouteTabShell from "@/components/common/bottom-navigation/RouteTabShell";
 
 export default function PurchaseHistoryPage() {
   const router = useRouter();
 
   return (
-    <PurchaseHistoryScreen onBack={() => router.back()} themeColor="#98E446" />
+    <RouteTabShell activeTab="mypage" activeColor="#98E446">
+      <PurchaseHistoryScreen
+        onBack={() => router.push("/mypage")}
+        themeColor="#98E446"
+      />
+    </RouteTabShell>
   );
 }

--- a/src/app/(main)/mypage/sales-history/[purchaseId]/receipt/page.tsx
+++ b/src/app/(main)/mypage/sales-history/[purchaseId]/receipt/page.tsx
@@ -1,20 +1,25 @@
 "use client";
 
 import React from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import TransactionReceipt from "../../../../../../components/transaction-receipt/TransactionReceipt";
+import RouteTabShell from "@/components/common/bottom-navigation/RouteTabShell";
 
 export default function SalesReceiptPage() {
   const params = useParams();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const saleId = Number(params?.purchaseId ?? NaN);
+  const returnUrl = searchParams.get("returnUrl") ?? "/mypage/sales-history";
   if (Number.isNaN(saleId)) return <div>유효하지 않은 ID</div>;
   return (
-    <TransactionReceipt
-      mode="sale"
-      id={saleId}
-      themeColor="#f97316"
-      onBack={() => router.push("/mypage/sales-history")}
-    />
+    <RouteTabShell activeTab="mypage" activeColor="#98E446">
+      <TransactionReceipt
+        mode="sale"
+        id={saleId}
+        themeColor="#f97316"
+        onBack={() => router.push(returnUrl)}
+      />
+    </RouteTabShell>
   );
 }

--- a/src/app/(main)/mypage/sales-history/index.tsx
+++ b/src/app/(main)/mypage/sales-history/index.tsx
@@ -60,6 +60,9 @@ export default function SalesHistoryScreen({
     "SHIPPED",
     "COMPLETED",
   ]);
+  const [productTypeFilter, setProductTypeFilter] = useState<
+    "ALL" | "REGULAR" | "AUCTION"
+  >("ALL");
   const nextPageRef = React.useRef<number>(0);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const isLoadingRef = useRef<boolean>(false);
@@ -70,6 +73,11 @@ export default function SalesHistoryScreen({
     "SHIPPED",
     "COMPLETED",
   ]);
+
+  const buildReceiptUrl = (saleId: number) => {
+    const params = new URLSearchParams({ returnUrl: "/mypage/sales-history" });
+    return `/mypage/sales-history/${saleId}/receipt?${params.toString()}`;
+  };
 
   const statusOptions = [
     { code: "PAID", label: "결제완료" },
@@ -368,20 +376,37 @@ export default function SalesHistoryScreen({
         <h1 className="text-lg font-bold ml-2">판매 내역</h1>
       </div>
 
-      <div className="px-4 py-3 bg-white border-b border-gray-100 shrink-0 flex gap-2 overflow-x-auto">
-        {statusOptions.map((status) => (
+      <div className="px-4 py-3 bg-white border-b border-gray-100 shrink-0 flex gap-2 items-center">
+        <div className="flex gap-2">
           <button
-            key={status.code}
-            onClick={() => handleFilterToggle(status.code)}
-            className={`px-3 py-1.5 rounded-full text-xs font-medium whitespace-nowrap transition-colors ${
-              selectedStatuses.includes(status.code)
+            onClick={() =>
+              setProductTypeFilter((prev) =>
+                prev === "REGULAR" ? "ALL" : "REGULAR",
+              )
+            }
+            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+              productTypeFilter === "REGULAR"
                 ? "bg-black text-white"
                 : "bg-gray-100 text-gray-600 hover:bg-gray-200"
             }`}
           >
-            {status.label}
+            일반
           </button>
-        ))}
+          <button
+            onClick={() =>
+              setProductTypeFilter((prev) =>
+                prev === "AUCTION" ? "ALL" : "AUCTION",
+              )
+            }
+            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+              productTypeFilter === "AUCTION"
+                ? "bg-black text-white"
+                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+            }`}
+          >
+            경매
+          </button>
+        </div>
       </div>
 
       <div className="flex-1 overflow-y-auto p-4 space-y-3">
@@ -399,50 +424,55 @@ export default function SalesHistoryScreen({
           </div>
         )}
 
-        {dedupeById(sales).map((sale) => (
-          <div
-            key={sale.id}
-            className="bg-white p-4 rounded-xl shadow-sm border border-gray-100"
-          >
-            <div className="flex justify-between items-center mb-3 pb-3 border-b border-gray-50">
-              <span className="text-xs text-gray-400 font-mono">
-                {sale.purchasedAtDisplay}
-              </span>
-              <span
-                className="text-xs font-medium"
-                style={{ color: themeColor }}
-              >
-                {getStatusLabel(sale.status)}
-              </span>
-            </div>
-            <div className="flex space-x-4">
-              <img
-                src={sale.imageUrl ?? undefined}
-                alt={sale.title}
-                className="w-16 h-16 object-cover rounded-lg bg-gray-100"
-              />
-              <div className="flex-1 flex flex-col justify-center">
-                <span className="font-medium text-gray-800 line-clamp-1">
-                  {sale.title}
-                </span>
-                <span className="font-bold mt-1">{sale.amountFormatted}</span>
-              </div>
-            </div>
-            <p className="mt-3 rounded-lg bg-gray-50 px-3 py-2 text-xs leading-relaxed text-gray-500">
-              {getSaleStatusGuide(sale.status)}
-            </p>
-            <button
-              onClick={() => {
-                setSelectedItem(null);
-                router.push(`/mypage/sales-history/${sale.id}/receipt`);
-              }}
-              className="w-full mt-4 py-2 bg-gray-50 hover:bg-gray-100 text-gray-600 text-sm font-medium rounded-lg transition-colors flex items-center justify-center space-x-1"
+        {dedupeById(sales)
+          .filter((sale) => {
+            if (productTypeFilter === "ALL") return true;
+            return sale.productType === productTypeFilter;
+          })
+          .map((sale) => (
+            <div
+              key={sale.id}
+              className="bg-white p-4 rounded-xl shadow-sm border border-gray-100"
             >
-              <span>자세히 보기</span>
-              <ChevronRight size={16} />
-            </button>
-          </div>
-        ))}
+              <div className="flex justify-between items-center mb-3 pb-3 border-b border-gray-50">
+                <span className="text-xs text-gray-400 font-mono">
+                  {sale.purchasedAtDisplay}
+                </span>
+                <span
+                  className="text-xs font-medium"
+                  style={{ color: themeColor }}
+                >
+                  {getStatusLabel(sale.status)}
+                </span>
+              </div>
+              <div className="flex space-x-4">
+                <img
+                  src={sale.imageUrl ?? undefined}
+                  alt={sale.title}
+                  className="w-16 h-16 object-cover rounded-lg bg-gray-100"
+                />
+                <div className="flex-1 flex flex-col justify-center">
+                  <span className="font-medium text-gray-800 line-clamp-1">
+                    {sale.title}
+                  </span>
+                  <span className="font-bold mt-1">{sale.amountFormatted}</span>
+                </div>
+              </div>
+              <p className="mt-3 rounded-lg bg-gray-50 px-3 py-2 text-xs leading-relaxed text-gray-500">
+                {getSaleStatusGuide(sale.status)}
+              </p>
+              <button
+                onClick={() => {
+                  setSelectedItem(null);
+                  router.push(buildReceiptUrl(sale.id));
+                }}
+                className="w-full mt-4 py-2 bg-gray-50 hover:bg-gray-100 text-gray-600 text-sm font-medium rounded-lg transition-colors flex items-center justify-center space-x-1"
+              >
+                <span>자세히 보기</span>
+                <ChevronRight size={16} />
+              </button>
+            </div>
+          ))}
         {/* sentinel for IntersectionObserver */}
         <div ref={sentinelRef} />
       </div>

--- a/src/app/(main)/mypage/sales-history/page.tsx
+++ b/src/app/(main)/mypage/sales-history/page.tsx
@@ -3,11 +3,17 @@
 import { useRouter } from "next/navigation";
 
 import SalesHistoryScreen from "./index";
+import RouteTabShell from "@/components/common/bottom-navigation/RouteTabShell";
 
 export default function SalesHistoryPage() {
   const router = useRouter();
 
   return (
-    <SalesHistoryScreen onBack={() => router.back()} themeColor="#98E446" />
+    <RouteTabShell activeTab="mypage" activeColor="#98E446">
+      <SalesHistoryScreen
+        onBack={() => router.push("/mypage")}
+        themeColor="#98E446"
+      />
+    </RouteTabShell>
   );
 }

--- a/src/components/common/bottom-navigation/RouteTabShell.tsx
+++ b/src/components/common/bottom-navigation/RouteTabShell.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import { Home, PlusCircle, MessageCircle, User } from "lucide-react";
+
+import TabButton from "./TabButton";
+import { ExploreIcon } from "../ExploreIcon";
+import { useEventStream } from "@/services/events/EventStreamProvider";
+import { readStoredThemeMode } from "@/services/themeMode";
+
+export default function RouteTabShell({
+  children,
+  activeTab = "mypage",
+  activeColor = "#98E446",
+}: {
+  children: ReactNode;
+  activeTab?: "home" | "search" | "register" | "chat" | "mypage";
+  activeColor?: string;
+}) {
+  const router = useRouter();
+  const { chatUnreadCount } = useEventStream();
+  const themeMode = readStoredThemeMode();
+
+  const goToRegister = () => {
+    router.push(
+      themeMode === "auction" ? "/auctions/register" : "/products/register",
+    );
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col bg-white">
+      <div className="flex-1">{children}</div>
+      <div className="h-16 bg-white border-t border-gray-100 flex items-center justify-around px-4 shrink-0">
+        <TabButton
+          active={activeTab === "home"}
+          icon={<Home size={24} />}
+          label="홈"
+          onClick={() => router.push("/home")}
+          activeColor={activeColor}
+        />
+        <TabButton
+          active={activeTab === "search"}
+          icon={<ExploreIcon size={30} />}
+          label="탐색"
+          onClick={() => router.push("/search")}
+          activeColor={activeColor}
+        />
+        <TabButton
+          active={activeTab === "register"}
+          icon={<PlusCircle size={24} />}
+          label="등록"
+          onClick={goToRegister}
+          activeColor={activeColor}
+        />
+        <TabButton
+          active={activeTab === "chat"}
+          icon={<MessageCircle size={24} />}
+          label="채팅"
+          onClick={() => router.push("/chats")}
+          activeColor={activeColor}
+          badgeCount={chatUnreadCount}
+        />
+        <TabButton
+          active={activeTab === "mypage"}
+          icon={<User size={24} />}
+          label="MY"
+          onClick={() => router.push("/mypage")}
+          activeColor={activeColor}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/transaction-receipt/TransactionReceipt.tsx
+++ b/src/components/transaction-receipt/TransactionReceipt.tsx
@@ -8,6 +8,10 @@ import {
   getSalesReceipt,
 } from "../../services/mypage/transaction-receipt";
 import type { TransactionReceiptResponse } from "../../services/mypage/transaction-receipt";
+import {
+  getMyReceivedReviews,
+  getMyWrittenReviews,
+} from "@/services/review/api";
 
 interface Props {
   mode: "purchase" | "sale";
@@ -26,6 +30,8 @@ export default function TransactionReceipt({
   const [data, setData] = useState<TransactionReceiptResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<any>(null);
+  const [writtenReviewExists, setWrittenReviewExists] = useState(false);
+  const [receivedReviewExists, setReceivedReviewExists] = useState(false);
 
   useEffect(() => {
     let aborted = false;
@@ -38,7 +44,64 @@ export default function TransactionReceipt({
           mode === "purchase"
             ? await getPurchaseReceipt(id)
             : await getSalesReceipt(id);
-        if (!aborted) setData(res);
+
+        if (!aborted) {
+          setData(res);
+          setWrittenReviewExists(false);
+          setReceivedReviewExists(false);
+
+          if (mode === "purchase") {
+            try {
+              const writtenReviews = await getMyWrittenReviews(0, 200);
+              const hasMatchingReview = writtenReviews.content.some(
+                (review) => {
+                  if (res.productType === "AUCTION") {
+                    return (
+                      review.auctionId != null &&
+                      res.auctionId != null &&
+                      review.auctionId === res.auctionId
+                    );
+                  }
+
+                  return review.productId === res.productId;
+                },
+              );
+
+              if (!aborted) {
+                setWrittenReviewExists(hasMatchingReview);
+              }
+            } catch {
+              if (!aborted) {
+                setWrittenReviewExists(false);
+              }
+            }
+          } else {
+            try {
+              const receivedReviews = await getMyReceivedReviews(0, 200);
+              const hasMatchingReview = receivedReviews.content.some(
+                (review) => {
+                  if (res.productType === "AUCTION") {
+                    return (
+                      review.auctionId != null &&
+                      res.auctionId != null &&
+                      review.auctionId === res.auctionId
+                    );
+                  }
+
+                  return review.productId === res.productId;
+                },
+              );
+
+              if (!aborted) {
+                setReceivedReviewExists(hasMatchingReview);
+              }
+            } catch {
+              if (!aborted) {
+                setReceivedReviewExists(false);
+              }
+            }
+          }
+        }
       } catch (e: any) {
         if (!aborted) setError(e);
       } finally {
@@ -189,6 +252,30 @@ export default function TransactionReceipt({
     }
   };
 
+  const isSellerShipped =
+    data.sellerShipped === true ||
+    data.status === "SHIPPED" ||
+    data.status === "COMPLETED";
+
+  const isBuyerConfirmed =
+    data.buyerConfirmed === true || data.status === "COMPLETED";
+
+  const isCompleted =
+    data.completed === true ||
+    data.status === "COMPLETED" ||
+    Boolean(data.completedAt);
+
+  const isReviewAvailable =
+    data.reviewAvailable === true ||
+    (data.reviewAvailable === undefined && isCompleted && !data.reviewWritten);
+
+  const hasWrittenReview =
+    data.reviewWritten === true || (mode === "purchase" && writtenReviewExists);
+  const canWriteReview =
+    mode === "purchase" && isReviewAvailable && !hasWrittenReview;
+  const hasReceivedReview =
+    data.reviewReceived === true || (mode === "sale" && receivedReviewExists);
+
   return (
     <div
       style={{
@@ -255,6 +342,24 @@ export default function TransactionReceipt({
                   </div>
                   <div style={{ color: "#6b7280", marginTop: 8, fontSize: 14 }}>
                     {getProductTypeLabel(data.productType)}
+                    {data.productType === "AUCTION" && data.auctionId ? (
+                      <button
+                        onClick={() =>
+                          router.push(`/auctions/${data.auctionId}`)
+                        }
+                        style={{
+                          marginLeft: 8,
+                          padding: "2px 6px",
+                          fontSize: 12,
+                          borderRadius: 6,
+                          border: "1px solid #e5e7eb",
+                          background: "#fff",
+                          cursor: "pointer",
+                        }}
+                      >
+                        경매 상세
+                      </button>
+                    ) : null}
                   </div>
                 </div>
                 <div style={{ fontWeight: 900, fontSize: 20 }}>
@@ -408,7 +513,72 @@ export default function TransactionReceipt({
                 거래 완료:
               </span>
               <span style={{ fontSize: 15, color: "#111", lineHeight: 1.6 }}>
-                {data.completedAt ? "완료" : "진행 중"}
+                {isCompleted ? "완료" : "진행 중"}
+              </span>
+            </div>
+            <div style={{ display: "block", width: "100%", padding: "12px 0" }}>
+              <span
+                style={{
+                  fontWeight: 600,
+                  display: "inline-block",
+                  minWidth: 140,
+                  marginRight: 12,
+                  fontSize: 15,
+                }}
+              >
+                리뷰:
+              </span>
+              <span style={{ fontSize: 15, color: "#111", lineHeight: 1.6 }}>
+                {mode === "purchase" ? (
+                  hasWrittenReview ? (
+                    <button
+                      type="button"
+                      disabled
+                      style={{
+                        padding: "6px 10px",
+                        borderRadius: 6,
+                        border: "1px solid #e5e7eb",
+                        background: "#f9fafb",
+                        color: "#9ca3af",
+                        cursor: "not-allowed",
+                        fontSize: 14,
+                      }}
+                    >
+                      리뷰를 작성했습니다
+                    </button>
+                  ) : canWriteReview ? (
+                    <button
+                      onClick={() => {
+                        const params = new URLSearchParams();
+                        params.set("productId", String(data.productId));
+                        if (data.productType === "AUCTION" && data.auctionId) {
+                          params.set("auctionId", String(data.auctionId));
+                        }
+                        router.push(
+                          `/mypage/review/write?${params.toString()}`,
+                        );
+                      }}
+                      style={{
+                        padding: "6px 10px",
+                        borderRadius: 6,
+                        border: "1px solid #e5e7eb",
+                        background: "#fff",
+                        cursor: "pointer",
+                        fontSize: 14,
+                      }}
+                    >
+                      리뷰 작성
+                    </button>
+                  ) : (
+                    "리뷰 작성 불가"
+                  )
+                ) : (
+                  <span>
+                    {hasReceivedReview
+                      ? "리뷰가 작성되었습니다"
+                      : "리뷰가 아직 달리지 않았습니다"}
+                  </span>
+                )}
               </span>
             </div>
           </div>

--- a/src/services/mypage/purchase-history/service.ts
+++ b/src/services/mypage/purchase-history/service.ts
@@ -39,6 +39,15 @@ function mapItem(item: PurchaseItemResponse): PurchaseItemViewModel {
     status: item.status,
     purchasedAtDisplay: formatPurchasedAt(item.purchasedAt),
     chatRoomId: item.chatRoomId ?? null,
+    productType: item.productType ?? null,
+    auctionId: item.auctionId ?? null,
+    sellerShipped: item.sellerShipped,
+    buyerConfirmed: item.buyerConfirmed,
+    completed: item.completed,
+    shippedAt: item.shippedAt ?? null,
+    completedAt: item.completedAt ?? null,
+    reviewWritten: item.reviewWritten,
+    reviewAvailable: item.reviewAvailable,
   };
 }
 
@@ -68,6 +77,15 @@ function mapDetailItem(item: PurchaseDetailResponse): PurchaseDetailViewModel {
     status: item.status,
     purchasedAtDisplay: formatPurchasedAt(item.purchasedAt),
     chatRoomId: item.chatRoomId ?? null,
+    productType: item.productType ?? null,
+    auctionId: item.auctionId ?? null,
+    sellerShipped: item.sellerShipped,
+    buyerConfirmed: item.buyerConfirmed,
+    completed: item.completed,
+    shippedAt: item.shippedAt ?? null,
+    completedAt: item.completedAt ?? null,
+    reviewWritten: item.reviewWritten,
+    reviewAvailable: item.reviewAvailable,
   };
 }
 

--- a/src/services/mypage/purchase-history/types.ts
+++ b/src/services/mypage/purchase-history/types.ts
@@ -12,6 +12,15 @@ export interface PurchaseItemResponse {
   status: PurchaseStatus;
   purchasedAt: string; // ISO timestamp
   chatRoomId: number | null;
+  productType?: string | null;
+  auctionId?: number | null;
+  sellerShipped?: boolean;
+  buyerConfirmed?: boolean;
+  completed?: boolean;
+  shippedAt?: string | null;
+  completedAt?: string | null;
+  reviewWritten?: boolean;
+  reviewAvailable?: boolean;
 }
 
 export type PurchasePageResponse = PageResponse<PurchaseItemResponse>;
@@ -27,6 +36,15 @@ export interface PurchaseItemViewModel {
   status: PurchaseStatus;
   purchasedAtDisplay: string; // 예: "2026.05.06 21:30"
   chatRoomId: number | null;
+  productType?: string | null;
+  auctionId?: number | null;
+  sellerShipped?: boolean;
+  buyerConfirmed?: boolean;
+  completed?: boolean;
+  shippedAt?: string | null;
+  completedAt?: string | null;
+  reviewWritten?: boolean;
+  reviewAvailable?: boolean;
 }
 
 // 상세 조회용 백엔드 응답
@@ -41,6 +59,15 @@ export interface PurchaseDetailResponse {
   status: PurchaseStatus;
   purchasedAt: string; // ISO timestamp
   chatRoomId: number | null;
+  productType?: string | null;
+  auctionId?: number | null;
+  sellerShipped?: boolean;
+  buyerConfirmed?: boolean;
+  completed?: boolean;
+  shippedAt?: string | null;
+  completedAt?: string | null;
+  reviewWritten?: boolean;
+  reviewAvailable?: boolean;
 }
 
 // 상세 화면용 뷰모델
@@ -52,4 +79,13 @@ export interface PurchaseDetailViewModel {
   status: PurchaseStatus;
   purchasedAtDisplay: string;
   chatRoomId: number | null;
+  productType?: string | null;
+  auctionId?: number | null;
+  sellerShipped?: boolean;
+  buyerConfirmed?: boolean;
+  completed?: boolean;
+  shippedAt?: string | null;
+  completedAt?: string | null;
+  reviewWritten?: boolean;
+  reviewAvailable?: boolean;
 }

--- a/src/services/mypage/sales-history/service.ts
+++ b/src/services/mypage/sales-history/service.ts
@@ -39,6 +39,16 @@ function mapItem(item: SaleItemResponse): SaleItemViewModel {
     status: item.status,
     purchasedAtDisplay: formatPurchasedAt(item.purchasedAt),
     chatRoomId: item.chatRoomId ?? null,
+    productType: item.productType ?? null,
+    auctionId: item.auctionId ?? null,
+    sellerShipped: item.sellerShipped,
+    buyerConfirmed: item.buyerConfirmed,
+    completed: item.completed,
+    shippedAt: item.shippedAt ?? null,
+    completedAt: item.completedAt ?? null,
+    reviewWritten: item.reviewWritten,
+    reviewAvailable: item.reviewAvailable,
+    reviewReceived: item.reviewReceived,
   };
 }
 
@@ -64,6 +74,16 @@ function mapDetailItem(item: SaleDetailResponse): SaleDetailViewModel {
     status: item.status,
     purchasedAtDisplay: formatPurchasedAt(item.purchasedAt),
     chatRoomId: item.chatRoomId ?? null,
+    productType: item.productType ?? null,
+    auctionId: item.auctionId ?? null,
+    sellerShipped: item.sellerShipped,
+    buyerConfirmed: item.buyerConfirmed,
+    completed: item.completed,
+    shippedAt: item.shippedAt ?? null,
+    completedAt: item.completedAt ?? null,
+    reviewWritten: item.reviewWritten,
+    reviewAvailable: item.reviewAvailable,
+    reviewReceived: item.reviewReceived,
   };
 }
 

--- a/src/services/mypage/sales-history/types.ts
+++ b/src/services/mypage/sales-history/types.ts
@@ -12,6 +12,16 @@ export interface SaleItemResponse {
   status: SaleStatus;
   purchasedAt: string; // ISO timestamp
   chatRoomId: number | null;
+  productType?: string | null;
+  auctionId?: number | null;
+  sellerShipped?: boolean;
+  buyerConfirmed?: boolean;
+  completed?: boolean;
+  shippedAt?: string | null;
+  completedAt?: string | null;
+  reviewWritten?: boolean;
+  reviewAvailable?: boolean;
+  reviewReceived?: boolean;
 }
 
 export type SalePageResponse = PageResponse<SaleItemResponse>;
@@ -27,6 +37,16 @@ export interface SaleItemViewModel {
   status: SaleStatus;
   purchasedAtDisplay: string;
   chatRoomId: number | null;
+  productType?: string | null;
+  auctionId?: number | null;
+  sellerShipped?: boolean;
+  buyerConfirmed?: boolean;
+  completed?: boolean;
+  shippedAt?: string | null;
+  completedAt?: string | null;
+  reviewWritten?: boolean;
+  reviewAvailable?: boolean;
+  reviewReceived?: boolean;
 }
 
 // 상세 조회용 백엔드 응답
@@ -41,6 +61,16 @@ export interface SaleDetailResponse {
   status: SaleStatus;
   purchasedAt: string; // ISO timestamp
   chatRoomId: number | null;
+  productType?: string | null;
+  auctionId?: number | null;
+  sellerShipped?: boolean;
+  buyerConfirmed?: boolean;
+  completed?: boolean;
+  shippedAt?: string | null;
+  completedAt?: string | null;
+  reviewWritten?: boolean;
+  reviewAvailable?: boolean;
+  reviewReceived?: boolean;
 }
 
 // 상세 화면용 뷰모델
@@ -52,4 +82,14 @@ export interface SaleDetailViewModel {
   status: SaleStatus;
   purchasedAtDisplay: string;
   chatRoomId: number | null;
+  productType?: string | null;
+  auctionId?: number | null;
+  sellerShipped?: boolean;
+  buyerConfirmed?: boolean;
+  completed?: boolean;
+  shippedAt?: string | null;
+  completedAt?: string | null;
+  reviewWritten?: boolean;
+  reviewAvailable?: boolean;
+  reviewReceived?: boolean;
 }

--- a/src/services/mypage/transaction-receipt/types.ts
+++ b/src/services/mypage/transaction-receipt/types.ts
@@ -34,6 +34,11 @@ export interface TransactionReceiptResponse {
   counterpartNickname: string | null; // 예: 판매자명(구매 영수증에서는 판매자)
   seller: Participant;
   buyer: Participant;
+  auctionId?: number | null;
+  completed?: boolean;
+  reviewWritten?: boolean;
+  reviewAvailable?: boolean;
+  reviewReceived?: boolean;
   // 추가 정보 (결제수단 등) - optional
   meta?: Record<string, unknown> | null;
 }


### PR DESCRIPTION
### 🚀 Summary

구매/판매내역과 영수증 화면을 경매 및 리뷰 상태에 맞게 리팩토링하고, 뒤로 가기와 하단 탭바, 리뷰 노출 조건을 정리했습니다.

---

### ✨ Description

#### 수정한 코드 경로
- [src/services/mypage/purchase-history/types.ts](src/services/mypage/purchase-history/types.ts)
- [src/services/mypage/purchase-history/service.ts](src/services/mypage/purchase-history/service.ts)
- [src/services/mypage/sales-history/types.ts](src/services/mypage/sales-history/types.ts)
- [src/services/mypage/sales-history/service.ts](src/services/mypage/sales-history/service.ts)
- [src/services/mypage/transaction-receipt/types.ts](src/services/mypage/transaction-receipt/types.ts)
- [src/components/transaction-receipt/TransactionReceipt.tsx](src/components/transaction-receipt/TransactionReceipt.tsx)
- [src/components/common/bottom-navigation/RouteTabShell.tsx](src/components/common/bottom-navigation/RouteTabShell.tsx)
- [src/app/(main)/mypage/purchase-history/page.tsx](src/app/(main)/mypage/purchase-history/page.tsx)
- [src/app/(main)/mypage/sales-history/page.tsx](src/app/(main)/mypage/sales-history/page.tsx)
- [src/app/(main)/mypage/purchase-history/[purchaseId]/receipt/page.tsx](src/app/(main)/mypage/purchase-history/[purchaseId]/receipt/page.tsx)
- [src/app/(main)/mypage/sales-history/[purchaseId]/receipt/page.tsx](src/app/(main)/mypage/sales-history/[purchaseId]/receipt/page.tsx)

#### 작업 내용
- 구매내역/판매내역 데이터 타입과 서비스 매핑에 경매 관련 필드(`productType`, `auctionId`, `sellerShipped`, `buyerConfirmed`, `completed`, `shippedAt`, `completedAt`, `reviewWritten`, `reviewAvailable`, `reviewReceived`)를 반영했습니다.
- 구매/판매 내역의 “자세히 보기” 흐름을 영수증 화면으로 연결하고, `returnUrl`을 통해 뒤로 가기 경로를 명확하게 분리했습니다.
- 구매내역/판매내역/영수증 화면에 전용 하단 탭바 쉘을 적용해, 해당 흐름에서는 네비게이션이 유지되도록 했습니다.
- 영수증 화면에서 리뷰 상태를 역할별로 구분해 표시하도록 정리했습니다.
- 구매자 영수증에서는 이미 리뷰를 작성한 경우 버튼을 비활성화하고 “리뷰를 작성했습니다”로 표시하도록 했습니다.
- 판매자 영수증에서는 “리뷰가 아직 달리지 않았습니다” / “리뷰가 작성되었습니다” 안내 문구를 표시하도록 했습니다.
- 리뷰 상태가 영수증 응답에 충분히 오지 않는 경우를 대비해, 구매자는 작성한 리뷰 목록, 판매자는 받은 리뷰 목록과 대조하는 fallback을 추가했습니다.
- 타입체크 기준으로 현재 변경 사항을 확인했습니다.

#### 확인 사항
- `npx tsc --noEmit` 통과
- 현재 변경은 구매/판매/영수증 흐름에 한정되어 있습니다.

<img width="1166" height="1022" alt="판매내역필터조정" src="https://github.com/user-attachments/assets/7a1daec9-0bc0-4da2-8fb0-e9a503168cf4" />

<img width="2559" height="543" alt="이제경매도받아옴" src="https://github.com/user-attachments/assets/f7dd572d-1835-412b-91d9-c6dc14260eb4" />

<img width="1009" height="739" alt="리뷰작성버튼생성구매자입장" src="https://github.com/user-attachments/assets/54ab00c0-9311-4493-bd06-378f97899b04" />

<img width="1093" height="880" alt="리뷰작성시판매자" src="https://github.com/user-attachments/assets/5eb7e886-2b5b-4f20-9f18-5b555a3224bf" />

<img width="1089" height="801" alt="리뷰작성시" src="https://github.com/user-attachments/assets/f12df2e0-fbcf-4442-8dae-e4366683d2cd" />

---

### 🎲 Issue Number

close #{Issue Number}