### PR TITLE
[fix] 판매내역 & 상세 페이지 수정

### DIFF
--- a/src/app/products/[productId]/index.tsx
+++ b/src/app/products/[productId]/index.tsx
@@ -225,7 +225,6 @@ export default function ProductDetailScreen({
     auctionDetail?.location ??
     productData?.seller?.location ??
     "지역 정보 없음";
-  const displayStatus = productData?.status ?? "정보 없음";
   const resolvedViewCount = productData
     ? productDetailService.getViewCount(productData)
     : 0;
@@ -399,7 +398,9 @@ export default function ProductDetailScreen({
       setCurrentPrice(latestAuctionEvent.currentPrice);
       setBidCount(latestAuctionEvent.bidCount);
       setInputBidAmount(latestAuctionEvent.minimumNextBidPrice);
-      setAuctionClockOffsetMs(getApiTime(latestAuctionEvent.serverTime) - Date.now());
+      setAuctionClockOffsetMs(
+        getApiTime(latestAuctionEvent.serverTime) - Date.now(),
+      );
       setAuctionDetail((previous) =>
         previous
           ? {
@@ -435,8 +436,10 @@ export default function ProductDetailScreen({
         previous
           ? {
               ...previous,
-              currentPrice: latestAuctionEvent.finalPrice ?? previous.currentPrice,
-              minimumNextBidPrice: latestAuctionEvent.finalPrice ?? previous.minimumNextBidPrice,
+              currentPrice:
+                latestAuctionEvent.finalPrice ?? previous.currentPrice,
+              minimumNextBidPrice:
+                latestAuctionEvent.finalPrice ?? previous.minimumNextBidPrice,
               serverTime: latestAuctionEvent.serverTime,
               status:
                 endedStatus === "SUCCESSFUL_BID" || endedStatus === "NO_BID"
@@ -474,7 +477,9 @@ export default function ProductDetailScreen({
       const nextAuctionDetail = await fetchAuctionDetail(productId);
 
       setAuctionDetail(nextAuctionDetail);
-      setAuctionClockOffsetMs(getApiTime(nextAuctionDetail.serverTime) - Date.now());
+      setAuctionClockOffsetMs(
+        getApiTime(nextAuctionDetail.serverTime) - Date.now(),
+      );
       setCurrentPrice(getAuctionDisplayCurrentPrice(nextAuctionDetail));
       setBidCount(nextAuctionDetail.bidCount);
       setInputBidAmount(nextAuctionDetail.minimumNextBidPrice);
@@ -762,16 +767,8 @@ export default function ProductDetailScreen({
             <h3 className="font-bold">상품 정보</h3>
             <div className="space-y-2 text-sm">
               <div className="flex justify-between">
-                <span className="text-gray-400">상태</span>
-                <span>{displayStatus}</span>
-              </div>
-              <div className="flex justify-between">
                 <span className="text-gray-400">거래지역</span>
                 <span>{displayLocation}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-gray-400">배송비</span>
-                <span>정보 없음</span>
               </div>
             </div>
             <p className="text-sm text-gray-600 leading-relaxed pt-2">
@@ -798,8 +795,11 @@ export default function ProductDetailScreen({
           </button>
         ) : (
           <button
-          onClick={() =>
-              !isAuctionScheduled && !isAuctionEnded && !isAuctionOwner && setShowBidSheet(true)
+            onClick={() =>
+              !isAuctionScheduled &&
+              !isAuctionEnded &&
+              !isAuctionOwner &&
+              setShowBidSheet(true)
             }
             disabled={isAuctionScheduled || isAuctionEnded || isAuctionOwner}
             className={`flex-1 h-14 font-bold rounded-xl transition-colors ${
@@ -819,7 +819,7 @@ export default function ProductDetailScreen({
                 ? "입찰은 시작 후 가능해요"
                 : isAuctionOwner
                   ? "내 경매입니다"
-                : "입찰하기"}
+                  : "입찰하기"}
           </button>
         )}
       </div>

--- a/src/components/transaction-receipt/TransactionReceipt.tsx
+++ b/src/components/transaction-receipt/TransactionReceipt.tsx
@@ -279,6 +279,11 @@ export default function TransactionReceipt({
     mode === "purchase" && isReviewAvailable && !hasWrittenReview;
   const hasReceivedReview =
     data.reviewReceived === true || (mode === "sale" && receivedReviewExists);
+  const counterpartLabel = mode === "purchase" ? "판매자" : "구매자";
+  const counterpartNickname =
+    mode === "purchase"
+      ? data.seller?.nickname ?? data.counterpartNickname ?? "-"
+      : data.buyer?.nickname ?? data.counterpartNickname ?? "-";
 
   return (
     <div
@@ -371,7 +376,7 @@ export default function TransactionReceipt({
                 </div>
               </div>
               <div style={{ marginTop: 10, fontSize: 15 }}>
-                판매자: {data.counterpartNickname ?? "-"}
+                {counterpartLabel}: {counterpartNickname}
               </div>
             </div>
           </div>


### PR DESCRIPTION
### 🚀 Summary

일반 상품 상세 페이지의 상품 정보 항목을 정리하고, 판매/구매내역 영수증에서 상대방 라벨이 올바르게 표시되도록 수정했습니다.

---

### ✨ Description

- 일반 상품 상세 페이지의 `상품 정보` 섹션에서 `상태` 항목을 제거했습니다.
- 일반 상품 상세 페이지의 `상품 정보` 섹션에서 `배송비` 항목을 제거했습니다.
- `상태` 항목 제거로 더 이상 사용하지 않는 `displayStatus` 변수를 정리했습니다.
- 거래 영수증 화면에서 상대방 라벨을 `mode` 기준으로 분기하도록 수정했습니다.
  - 구매내역 영수증: `판매자`
  - 판매내역 영수증: `구매자`
- 상대방 닉네임은 `seller.nickname` 또는 `buyer.nickname`을 우선 사용하고, 없을 경우 기존 `counterpartNickname`을 fallback으로 사용하도록 했습니다.

---

### 🎲 Issue Number

close #{Issue Number}