### PR TITLE
[fix] 상품 상세 판매자 프로필 정보 표시 수정

### DIFF
--- a/src/app/products/[productId]/index.tsx
+++ b/src/app/products/[productId]/index.tsx
@@ -244,7 +244,9 @@ export default function ProductDetailScreen({
     showToastRef.current = showToast;
   }, [showToast]);
 
-  const displaySellerBio = productData?.seller?.bio ?? "정보없음";
+  const sellerBio = auctionDetail?.seller?.bio ?? productData?.seller?.bio;
+  const displaySellerBio =
+    sellerBio == null || sellerBio.trim() === "" ? "정보없음" : sellerBio;
   const sellerRating =
     auctionDetail?.seller?.rating ?? productData?.seller?.rating;
 

--- a/src/app/products/[productId]/index.tsx
+++ b/src/app/products/[productId]/index.tsx
@@ -255,15 +255,6 @@ export default function ProductDetailScreen({
       ? "정보없음"
       : `${productData.seller.warningCount}회`;
   const displaySellerAddress = displayLocation;
-  const sellerRecentSales = productData?.seller?.recentSales ?? [];
-
-  function formatSellerRecentSalePrice(price?: number | null) {
-    if (price == null) {
-      return "정보없음";
-    }
-
-    return `${price.toLocaleString()}원`;
-  }
 
   useEffect(() => {
     if (regularPrice != null) {
@@ -948,9 +939,6 @@ export default function ProductDetailScreen({
                 </div>
                 <div>
                   <h3 className="text-xl font-bold">{displaySellerName}</h3>
-                  <p className="text-sm text-gray-500 mt-1">
-                    {displaySellerBio}
-                  </p>
                 </div>
               </div>
 
@@ -979,34 +967,9 @@ export default function ProductDetailScreen({
               </div>
 
               <div className="space-y-3">
-                <h4 className="font-bold text-sm">상대 판매내역 (최근 3건)</h4>
-                <div className="space-y-2">
-                  {sellerRecentSales.length === 0 ? (
-                    <div className="p-3 bg-gray-50 rounded-xl text-sm text-gray-500">
-                      정보없음
-                    </div>
-                  ) : (
-                    sellerRecentSales.map((item, idx) => (
-                      <div
-                        key={idx}
-                        className="flex items-center justify-between p-3 bg-gray-50 rounded-xl"
-                      >
-                        <span className="text-sm font-medium text-gray-800">
-                          {item.title ?? "정보없음"}
-                        </span>
-                        <div className="text-right">
-                          <p className="text-xs font-bold">
-                            {formatSellerRecentSalePrice(item.price)}
-                          </p>
-                          <p
-                            className={`text-[10px] ${item.status === "판매완료" ? "text-gray-400" : "text-blue-500"}`}
-                          >
-                            {item.status ?? "정보없음"}
-                          </p>
-                        </div>
-                      </div>
-                    ))
-                  )}
+                <h4 className="font-bold text-sm">소개글</h4>
+                <div className="rounded-xl bg-gray-50 p-4 text-sm leading-relaxed text-gray-600">
+                  {displaySellerBio}
                 </div>
               </div>
 

--- a/src/app/products/[productId]/index.tsx
+++ b/src/app/products/[productId]/index.tsx
@@ -245,10 +245,11 @@ export default function ProductDetailScreen({
   }, [showToast]);
 
   const displaySellerBio = productData?.seller?.bio ?? "정보없음";
+  const sellerRating =
+    auctionDetail?.seller?.rating ?? productData?.seller?.rating;
+
   const displaySellerRating =
-    productData?.seller?.rating == null
-      ? "정보없음"
-      : productData.seller.rating.toFixed(1);
+    sellerRating == null ? "정보없음" : sellerRating.toFixed(1);
   const displaySellerWarning =
     productData?.seller?.warningCount == null
       ? "정보없음"
@@ -753,7 +754,7 @@ export default function ProductDetailScreen({
                   <span>
                     {displaySellerRating === "정보없음"
                       ? "정보없음"
-                      : `${displaySellerRating} (거래 ${sellerRecentSales.length}건)`}
+                      : displaySellerRating}
                   </span>
                 </div>
               </div>

--- a/src/services/auction/detail/types.ts
+++ b/src/services/auction/detail/types.ts
@@ -18,6 +18,7 @@ export interface AuctionDetailSeller {
   nickname: string;
   profileImageUrl: string | null;
   rating?: number | null;
+  bio?: string | null;
 }
 
 export interface AuctionDetailResponse {

--- a/src/services/auction/detail/types.ts
+++ b/src/services/auction/detail/types.ts
@@ -17,6 +17,7 @@ export interface AuctionDetailSeller {
   memberId: number;
   nickname: string;
   profileImageUrl: string | null;
+  rating?: number | null;
 }
 
 export interface AuctionDetailResponse {


### PR DESCRIPTION
### 📌 Summary

상품 상세 화면의 판매자 프로필 정보 표시를 수정했습니다.

---

### 📝Description

- 경매 상세 응답의 판매자 타입에 `rating`, `bio` 필드를 추가했습니다.
- 일반 상품/경매 상품 상세 화면에서 판매자 평점을 공통으로 표시하도록 수정했습니다.
  - 경매 상세에서는 `auctionDetail.seller.rating`을 우선 사용합니다.
  - 일반 상품 상세에서는 기존처럼 `productData.seller.rating`을 사용합니다.
- 평점 옆에 표시되던 `(거래 N건)` 문구를 제거했습니다.
- 판매자 프로필 모달에서 `상대 판매내역 (최근 3건)` 섹션을 제거했습니다.
- 제거된 판매내역 영역에 `소개글` 섹션을 추가했습니다.
- 소개글은 `auctionDetail.seller.bio ?? productData.seller.bio` 기준으로 표시하며, 값이 없거나 공백이면 `정보없음`을 표시합니다.

검증:
- `npx tsc --noEmit` 통과

---

### 🔗 Issue Number

close #123